### PR TITLE
 Setup CMake project with unit tests 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,42 @@
+---
+Language:        Cpp
+BasedOnStyle:  Chromium
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  SplitEmptyFunction: false
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: false
+ColumnLimit:     100
+ConstructorInitializerIndentWidth: 2
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex:           '^".*'
+    Priority:        1
+  - Regex:           '^<boost.*'
+    Priority:        98
+  - Regex:           '^<.*\.(h|hpp)>'
+    Priority:        2
+  - Regex:           '^<.*'
+    Priority:        99
+  - Regex:           '.*'
+    Priority:        4
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentWidth:     4
+MaxEmptyLinesToKeep: 2
+PenaltyBreakAssignment: 1
+PenaltyBreakComment: 50
+TabWidth:        4
+...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/build
+/cmake-build-*
+/.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 3.13)
 
+include(CMakeDependentOption)
+
 option(FIZZY_TESTING "Enable Fizzy internal tests" OFF)
+cmake_dependent_option(HUNTER_ENABLED "Enable Hunter package manager" ON
+    "FIZZY_TESTING" OFF)
+
+if(HUNTER_ENABLED)
+    include(cmake/Hunter/init.cmake)
+endif()
 
 project(fizzy LANGUAGES CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.13)
+
+option(FIZZY_TESTING "Enable Fizzy internal tests" OFF)
+
+project(fizzy LANGUAGES CXX)
+
+set(include_dir ${PROJECT_SOURCE_DIR}/include)  # Public include directory.
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+
+add_subdirectory(lib)
+
+if(FIZZY_TESTING)
+    enable_testing()  # Enable CTest. Must be done in main CMakeLists.txt.
+    add_subdirectory(test)
+endif()

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,94 @@
+version: 2.1
+
+executors:
+  linux-gcc-9:
+    docker:
+      - image: ethereum/cpp-build-env:12-gcc-9
+  linux-clang-9:
+    docker:
+      - image: ethereum/cpp-build-env:12-clang-9
+  macos:
+    macos:
+      xcode: 11.3.0
+
+commands:
+  build:
+    description: "Build"
+    steps:
+      - checkout
+      - run:
+          name: "Environment"
+          command: |
+            CC=${CC:-cc}
+            CXX=${CXX:-cpp}
+            echo CC: $CC
+            echo CXX: $CXX
+            $CC --version
+            $CXX --version
+            cmake --version
+
+            # Create the toolchain.info file for cache key.
+            echo $TOOLCHAIN >> toolchain.info
+            $CXX --version >> toolchain.info
+      - run:
+          name: "Configure"
+          working_directory: ~/build
+          command: |
+            cmake ../project -G Ninja -DCMAKE_INSTALL_PREFIX=~/install -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DFIZZY_TESTING=ON $CMAKE_OPTIONS
+      - run:
+          name: "Build"
+          command: cmake --build ~/build
+
+  test:
+    description: "Test"
+    steps:
+    - run:
+        name: "Test"
+        working_directory: ~/build
+        command: ctest -R ${TESTS_FILTER:-'.*'} -j4 --schedule-random --output-on-failure
+
+jobs:
+
+  lint:
+    docker:
+    - image: ethereum/cpp-build-env:12-lint
+    steps:
+    - checkout
+    - run:
+        name: "Check code format"
+        command: |
+          clang-format --version
+          find . -name '*.hpp' -o -name '*.cpp' -o -name '*.h' -o -name '*.c' | xargs clang-format -i
+          git diff --color --exit-code
+    - run:
+        name: "Run codespell"
+        command: |
+          codespell --quiet-level=4
+
+  release-linux:
+    executor: linux-gcc-9
+    environment:
+      BUILD_TYPE: Release
+    steps:
+      - build
+      - test
+
+  release-macos:
+    executor: macos
+    environment:
+      BUILD_TYPE: Release
+    steps:
+      - run:
+          name: "Install System Dependencies"
+          command: HOMEBREW_NO_AUTO_UPDATE=1 brew install cmake ninja
+      - build
+      - test
+
+
+workflows:
+  version: 2
+  fizzy:
+    jobs:
+      - lint
+      - release-linux
+      - release-macos

--- a/circle.yml
+++ b/circle.yml
@@ -30,11 +30,19 @@ commands:
             # Create the toolchain.info file for cache key.
             echo $TOOLCHAIN >> toolchain.info
             $CXX --version >> toolchain.info
+      - restore_cache:
+          name: "Restore Hunter cache"
+          key: &hunter-cache-key hunter-{{arch}}-{{checksum "toolchain.info"}}-{{checksum "cmake/Hunter/init.cmake"}}
       - run:
           name: "Configure"
           working_directory: ~/build
           command: |
             cmake ../project -G Ninja -DCMAKE_INSTALL_PREFIX=~/install -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DFIZZY_TESTING=ON $CMAKE_OPTIONS
+      - save_cache:
+          name: "Save Hunter cache"
+          key: *hunter-cache-key
+          paths:
+            - ~/.hunter/_Base/Cache
       - run:
           name: "Build"
           command: cmake --build ~/build

--- a/cmake/Hunter/init.cmake
+++ b/cmake/Hunter/init.cmake
@@ -1,0 +1,19 @@
+# This file setups Hunter package manager.
+
+set(HUNTER_URL https://github.com/cpp-pm/hunter/archive/v0.23.239.tar.gz)
+set(HUNTER_SHA1 135567a8493ab3499187bce1f2a8df9b449febf3)
+set(HUNTER_PACKAGES GTest)
+
+include(FetchContent)
+FetchContent_Declare(
+    SetupHunter
+    URL https://github.com/cpp-pm/gate/archive/v0.9.1.tar.gz
+    URL_HASH SHA256=33b6c9fdb47f364cd833baccc55100f9b8e9223387edcdfa616ed9661f897ec0
+)
+
+# The following is equivalent of FetchContent_MakeAvailable(SetupHunter) from CMake 3.14.
+FetchContent_GetProperties(SetupHunter)
+if(NOT setuphunter_POPULATED)
+    FetchContent_Populate(SetupHunter)
+    add_subdirectory(${setuphunter_SOURCE_DIR} ${setuphunter_BINARY_DIR})
+endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(fizzy)

--- a/lib/fizzy/CMakeLists.txt
+++ b/lib/fizzy/CMakeLists.txt
@@ -1,0 +1,10 @@
+
+add_library(fizzy)
+add_library(fizzy::fizzy ALIAS fizzy)
+
+target_sources(
+    fizzy PRIVATE
+    dummy.cpp
+    leb128.hpp
+)
+target_compile_features(fizzy PUBLIC cxx_std_14)

--- a/lib/fizzy/dummy.cpp
+++ b/lib/fizzy/dummy.cpp
@@ -1,0 +1,1 @@
+#include "leb128.hpp"

--- a/lib/fizzy/leb128.hpp
+++ b/lib/fizzy/leb128.hpp
@@ -1,0 +1,9 @@
+#include <cstdint>
+
+namespace fizzy
+{
+inline constexpr uint64_t leb128_decode(const uint8_t*) noexcept
+{
+    return 0;
+}
+}  // namespace fizzy

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(unittests)

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -1,0 +1,15 @@
+
+include(GoogleTest)
+
+find_package(GTest REQUIRED)
+
+add_executable(fizzy-unittests)
+target_link_libraries(fizzy-unittests PRIVATE fizzy::fizzy GTest::Main)
+target_include_directories(fizzy-unittests PRIVATE ${PROJECT_SOURCE_DIR}/lib/fizzy)
+
+target_sources(
+    fizzy-unittests PRIVATE
+    leb128_test.cpp
+)
+
+gtest_discover_tests(fizzy-unittests TEST_PREFIX ${PROJECT_NAME}/unittests/)

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -1,10 +1,10 @@
 
 include(GoogleTest)
 
-find_package(GTest REQUIRED)
+find_package(GTest CONFIG REQUIRED)
 
 add_executable(fizzy-unittests)
-target_link_libraries(fizzy-unittests PRIVATE fizzy::fizzy GTest::Main)
+target_link_libraries(fizzy-unittests PRIVATE fizzy::fizzy GTest::gtest_main)
 target_include_directories(fizzy-unittests PRIVATE ${PROJECT_SOURCE_DIR}/lib/fizzy)
 
 target_sources(

--- a/test/unittests/leb128_test.cpp
+++ b/test/unittests/leb128_test.cpp
@@ -1,0 +1,8 @@
+#include "leb128.hpp"
+#include <gtest/gtest.h>
+
+TEST(leb128, DISABLED_decode)
+{
+    uint8_t encoded_1 = 1;
+    EXPECT_EQ(fizzy::leb128_decode(&encoded_1), 1);
+}


### PR DESCRIPTION
- CMake project setup
- Unit tests based on GTest (using system installed gtest-dev and FindGTest CMake's standard module).
- Clang-format from evmone

All is up to discussion, but make it quick.

Closes #1.