### PR TITLE
cmake: Add Cable modules, configure build type and compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.13)
 
+include(cmake/cable.cmake)
+include(CableBuildType)
+include(CableCompilerSettings)
 include(CMakeDependentOption)
 
 option(FIZZY_TESTING "Enable Fizzy internal tests" OFF)
@@ -10,7 +13,11 @@ if(HUNTER_ENABLED)
     include(cmake/Hunter/init.cmake)
 endif()
 
+cable_set_build_type(DEFAULT Release CONFIGURATION_TYPES Debug;Release;Coverage)
+
 project(fizzy LANGUAGES CXX)
+
+cable_configure_compiler()
 
 set(include_dir ${PROJECT_SOURCE_DIR}/include)  # Public include directory.
 

--- a/circle.yml
+++ b/circle.yml
@@ -92,6 +92,51 @@ jobs:
       - build
       - test
 
+  clang-latest-coverage:
+    executor: linux-clang-9
+    environment:
+      BUILD_TYPE: Coverage
+      TESTS_FILTER: unittests
+    steps:
+      - run:
+          name: "Install lcov"
+          working_directory: /tmp
+          command: |
+            curl -sL http://downloads.sourceforge.net/ltp/lcov-1.14.tar.gz | tar xz --strip=1
+            sudo make install
+      - build
+      - test
+      - run:
+          name: "Collect coverage data"
+          working_directory: ~/build
+          command: |
+            mkdir coverage
+            find -name '*.profraw'
+            llvm-profdata merge *.profraw -o fizzy.profdata
+
+            llvm-cov report -instr-profile fizzy.profdata -Xdemangler llvm-cxxfilt \
+              -object bin/fizzy-unittests -use-color
+            llvm-cov report -instr-profile fizzy.profdata -Xdemangler llvm-cxxfilt > coverage/report.txt \
+              -object bin/fizzy-unittests
+
+            llvm-cov show -format=html -instr-profile fizzy.profdata -Xdemangler llvm-cxxfilt -region-coverage-lt=100 > coverage/missing.html \
+              -object bin/fizzy-unittests
+            llvm-cov show -format=html -instr-profile fizzy.profdata -Xdemangler llvm-cxxfilt > coverage/full.html \
+             -object bin/fizzy-unittests
+
+            llvm-cov export -instr-profile fizzy.profdata -format=lcov > fizzy.lcov \
+              -object bin/fizzy-unittests
+            genhtml fizzy.lcov -o coverage -t Fizzy
+      - store_artifacts:
+          path: ~/build/coverage
+          destination: coverage
+      - run:
+          name: "Upload to Codecov"
+          command: |
+            # Convert to relative paths
+            sed -i 's|$(pwd)/||' ~/build/fizzy.lcov
+            codecov --file ~/build/fizzy.lcov -X gcov
+
 
 workflows:
   version: 2
@@ -100,3 +145,4 @@ workflows:
       - lint
       - release-linux
       - release-macos
+      - clang-latest-coverage

--- a/cmake/CableBuildType.cmake
+++ b/cmake/CableBuildType.cmake
@@ -1,0 +1,48 @@
+# Cable: CMake Bootstrap Library <https://github.com/ethereum/cable>
+# Copyright 2018-2019 Pawel Bylica.
+# Licensed under the Apache License, Version 2.0.
+
+# Cable Build Type, version 1.0.0
+#
+# This CMake module helps with setting default build type
+# and build configurations for multi-configuration generators.
+# Use cable_set_build_type().
+
+
+if(cable_build_type_included)
+    return()
+endif()
+set(cable_build_type_included TRUE)
+
+macro(cable_set_build_type)
+    if(NOT PROJECT_SOURCE_DIR)  # Before the main project().
+        cmake_parse_arguments(build_type "" DEFAULT CONFIGURATION_TYPES ${ARGN})
+
+        if(CMAKE_CONFIGURATION_TYPES)
+            if(build_type_CONFIGURATION_TYPES)
+                set(
+                    CMAKE_CONFIGURATION_TYPES
+                    ${build_type_CONFIGURATION_TYPES}
+                    CACHE
+                    STRING
+                    "Available configurations for multi-configuration generators"
+                    FORCE
+                )
+            endif()
+            message(STATUS "Configurations: ${CMAKE_CONFIGURATION_TYPES}")
+        else()
+            if(build_type_DEFAULT AND NOT CMAKE_BUILD_TYPE)
+                set(
+                    CMAKE_BUILD_TYPE
+                    ${build_type_DEFAULT}
+                    CACHE STRING
+                    "Build type for single-configuration generators"
+                    FORCE
+                )
+            endif()
+            message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+        endif()
+    elseif(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)  # After the main project().
+        message(FATAL_ERROR "cable_set_build_type() must be used before project()")
+    endif()  # Sub-project - silently ignore.
+endmacro()

--- a/cmake/CableCompilerSettings.cmake
+++ b/cmake/CableCompilerSettings.cmake
@@ -1,0 +1,166 @@
+# Cable: CMake Bootstrap Library <https://github.com/ethereum/cable>
+# Copyright 2018-2019 Pawel Bylica.
+# Licensed under the Apache License, Version 2.0.
+
+# Cable Compiler Settings, version 1.0.0
+#
+# This CMake module provides default configuration (with some options)
+# for C/C++ compilers. Use cable_configure_compiler().
+
+if(cable_compiler_settings_included)
+    return()
+endif()
+set(cable_compiler_settings_included TRUE)
+
+include(CheckCXXCompilerFlag)
+
+# Adds CXX compiler flag if the flag is supported by the compiler.
+#
+# This is effectively a combination of CMake's check_cxx_compiler_flag()
+# and add_compile_options():
+#
+#    if(check_cxx_compiler_flag(flag))
+#        add_compile_options(flag)
+#
+function(cable_add_cxx_compiler_flag_if_supported FLAG)
+    # Remove leading - or / from the flag name.
+    string(REGEX REPLACE "^-|/" "" name ${FLAG})
+    check_cxx_compiler_flag(${FLAG} ${name})
+    if(${name})
+        add_compile_options(${FLAG})
+    endif()
+
+    # If the optional argument passed, store the result there.
+    if(ARGV1)
+        set(${ARGV1} ${name} PARENT_SCOPE)
+    endif()
+endfunction()
+
+
+# Configures the compiler with default flags.
+macro(cable_configure_compiler)
+    if(NOT PROJECT_SOURCE_DIR)
+        message(FATAL_ERROR "cable_configure_compiler() must be used after project()")
+    endif()
+
+    # Determine if this is the main or a subproject. Leave this variable available for later use.
+    if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+        set(PROJECT_IS_MAIN TRUE)
+    else()
+        set(PROJECT_IS_MAIN FALSE)
+    endif()
+
+    if(PROJECT_IS_MAIN)
+        # Do this configuration only in the main project.
+
+        cmake_parse_arguments(cable "NO_CONVERSION_WARNINGS;NO_STACK_PROTECTION;NO_PEDANTIC" "" "" ${ARGN})
+
+        if(cable_UNPARSED_ARGUMENTS)
+            message(FATAL_ERROR "cable_configure_compiler: Unknown options: ${cable_UNPARSED_ARGUMENTS}")
+        endif()
+
+        # Set helper variables recognizing C++ compilers.
+        if(${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
+            set(CABLE_COMPILER_GNU TRUE)
+        elseif(${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
+            # This matches both clang and AppleClang.
+            set(CABLE_COMPILER_CLANG TRUE)
+        endif()
+
+        if(CABLE_COMPILER_GNU OR CABLE_COMPILER_CLANG)
+            set(CABLE_COMPILER_GNULIKE TRUE)
+        endif()
+
+        if(CABLE_COMPILER_GNULIKE)
+
+            if(NOT cable_NO_PEDANTIC)
+                add_compile_options(-Wpedantic)
+            endif()
+
+            # Enable basing warnings set and treat them as errors.
+            add_compile_options(-Werror -Wall -Wextra -Wshadow)
+
+            if(NOT cable_NO_CONVERSION_WARNINGS)
+                # Enable conversion warnings if not explicitly disabled.
+                add_compile_options(-Wconversion -Wsign-conversion)
+            endif()
+
+            # Allow unknown pragmas, we don't want to wrap them with #ifdefs.
+            add_compile_options(-Wno-unknown-pragmas)
+
+            # Stack protection.
+            check_cxx_compiler_flag(-fstack-protector fstack-protector)
+            if(fstack-protector)
+                # The compiler supports stack protection options.
+                if(cable_NO_STACK_PROTECTION)
+                    # Stack protection explicitly disabled.
+                    # Add "no" flag, because in some configuration the compiler has it enabled by default.
+                    add_compile_options(-fno-stack-protector)
+                else()
+                    # Try enabling the "strong" variant.
+                    cable_add_cxx_compiler_flag_if_supported(-fstack-protector-strong have_stack_protector_strong_support)
+                    if(NOT have_stack_protector_strong_support)
+                        # Fallback to standard variant if "strong" not available.
+                        add_compile_options(-fstack-protector)
+                    endif()
+                endif()
+            endif()
+
+            cable_add_cxx_compiler_flag_if_supported(-Wimplicit-fallthrough)
+
+        elseif(MSVC)
+
+            # Get rid of default warning level.
+            string(REPLACE " /W3" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+            string(REPLACE " /W3" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+
+            # Enable basing warnings set and treat them as errors.
+            add_compile_options(/W4 /WX)
+
+            # Allow unknown pragmas, we don't want to wrap them with #ifdefs.
+            add_compile_options(/wd4068)
+
+        endif()
+
+        # Option for arch=native.
+        option(NATIVE "Build for native CPU" OFF)
+        if(NATIVE)
+            if(MSVC)
+                add_compile_options(-arch:AVX)
+            else()
+                add_compile_options(-mtune=native -march=native)
+            endif()
+        elseif(NOT MSVC)
+            # Tune for currently most common CPUs.
+            cable_add_cxx_compiler_flag_if_supported(-mtune=generic)
+        endif()
+
+        # Sanitizers support.
+        set(SANITIZE OFF CACHE STRING "Build with the specified sanitizer")
+        if(SANITIZE)
+            # Set the linker flags first, they are required to properly test the compiler flag.
+            set(CMAKE_SHARED_LINKER_FLAGS "-fsanitize=${SANITIZE} ${CMAKE_SHARED_LINKER_FLAGS}")
+            set(CMAKE_EXE_LINKER_FLAGS "-fsanitize=${SANITIZE} ${CMAKE_EXE_LINKER_FLAGS}")
+
+            set(test_name have_fsanitize_${SANITIZE})
+            check_cxx_compiler_flag(-fsanitize=${SANITIZE} ${test_name})
+            if(NOT ${test_name})
+                message(FATAL_ERROR "Unsupported sanitizer: ${SANITIZE}")
+            endif()
+            add_compile_options(-fno-omit-frame-pointer -fsanitize=${SANITIZE})
+
+            set(blacklist_file ${PROJECT_SOURCE_DIR}/sanitizer-blacklist.txt)
+            if(EXISTS ${blacklist_file})
+                cable_add_cxx_compiler_flag_if_supported(-fsanitize-blacklist=${blacklist_file})
+            endif()
+            unset(blacklist_file)
+        endif()
+
+        # The "Coverage" build type.
+        if(CABLE_COMPILER_CLANG)
+            set(CMAKE_CXX_FLAGS_COVERAGE "-fprofile-instr-generate -fcoverage-mapping")
+        elseif(CABLE_COMPILER_GNU)
+            set(CMAKE_CXX_FLAGS_COVERAGE "--coverage")
+        endif()
+    endif()
+endmacro()

--- a/cmake/cable.cmake
+++ b/cmake/cable.cmake
@@ -1,0 +1,68 @@
+#!/usr/bin/cmake -P
+
+# Cable: CMake Bootstrap Library <https://github.com/ethereum/cable>
+# Copyright 2019 Pawel Bylica.
+# Licensed under the Apache License, Version 2.0.
+
+# The cable command-line tool, version 1.0.0
+#
+# This CMake script allows installing or updating Cable modules.
+# Commands:
+# - list
+# - install
+# - update
+#
+# You can also include it from CMakeLists.txt to add Cable modules to
+# CMAKE_MODULE_PATH.
+
+if(NOT CMAKE_SCRIPT_MODE_FILE)
+    # Setup Cable modules when included as include(cable.cmake).
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+    return()
+endif()
+
+set(repo_url https://github.com/ethereum/cable)
+set(download_url ${repo_url}/raw/master)
+set(cable_dir ${CMAKE_CURRENT_LIST_DIR})
+
+function(get_modules_list OUTPUT_LIST)
+    file(GLOB modules_files RELATIVE ${cable_dir} "${cable_dir}/Cable*.cmake")
+    string(REPLACE ".cmake" "" modules "${modules_files}")
+    set(${OUTPUT_LIST} "${modules}" PARENT_SCOPE)
+endfunction()
+
+function(download MODULE_NAME)
+    set(module_file ${MODULE_NAME}.cmake)
+    set(src "${download_url}/${module_file}")
+    set(dst "${cable_dir}/${module_file}")
+    file(DOWNLOAD "${src}" "${dst}" STATUS status)
+    list(GET status 0 status_code)
+    list(GET status 1 error_msg)
+    if(status EQUAL 0)
+        set(msg DONE)
+    else()
+        file(REMOVE "${dst}")
+        set(msg "${status_code} ${error_msg}\n  ${src}")
+    endif()
+    message("Downloading ${MODULE_NAME}: ${msg}")
+endfunction()
+
+set(cmd ${CMAKE_ARGV3})  # cmake -P cable.cmake ARGV3 ARGV4 ...
+if(NOT cmd)
+    set(cmd list)
+endif()
+
+if(cmd STREQUAL list)
+    get_modules_list(modules)
+    string(REPLACE ";" "\n  " modules "${modules}")
+    message("Installed modules:\n  ${modules}")
+elseif(cmd STREQUAL update)
+    get_modules_list(modules)
+    foreach(module ${modules})
+        download(${module})
+    endforeach()
+elseif(cmd STREQUAL install)
+    download(${CMAKE_ARGV4})
+else()
+    message(FATAL_ERROR "Unknown command '${cmd}'")
+endif()

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  status:
+    project: no
+    patch: no
+
+comment:
+  layout: "diff"

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -12,4 +12,8 @@ target_sources(
     leb128_test.cpp
 )
 
-gtest_discover_tests(fizzy-unittests TEST_PREFIX ${PROJECT_NAME}/unittests/)
+gtest_discover_tests(
+    fizzy-unittests
+    TEST_PREFIX ${PROJECT_NAME}/unittests/
+    PROPERTIES ENVIRONMENT LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/unittests-%p.profraw
+)

--- a/test/unittests/leb128_test.cpp
+++ b/test/unittests/leb128_test.cpp
@@ -6,3 +6,9 @@ TEST(leb128, DISABLED_decode)
     uint8_t encoded_1 = 1;
     EXPECT_EQ(fizzy::leb128_decode(&encoded_1), 1);
 }
+
+TEST(leb128, dummy)
+{
+    auto s = std::string{"hello"};
+    EXPECT_FALSE(s.empty());
+}


### PR DESCRIPTION
## Cable

This adds 2 Cable modules. They were converted to standalone CMake modules so no other Cable files are needed. The modules are also versioned independently. I also added the `cable.cmake` tool that helps with installing / updating Cable modules. E.g. `./cable.cmake install CableBuildType` or `./cable.cmake update`.

This is new way of consuming Cable. All 3 files to be uploaded to the Cable repo.

## Coverage

Code coverage setup is done. ~~Just an admin has to enable codecov.~~

LCOV: https://79-224892340-gh.circle-artifacts.com/0/coverage/index.html
Summary: https://79-224892340-gh.circle-artifacts.com/0/coverage/report.txt
Full: https://79-224892340-gh.circle-artifacts.com/0/coverage/full.html
Missing: https://79-224892340-gh.circle-artifacts.com/0/coverage/missing.html
