### PR TITLE
Clarify execution unit tests

### DIFF
--- a/test/unittests/execute_test.cpp
+++ b/test/unittests/execute_test.cpp
@@ -1,10 +1,10 @@
 #include "execute.hpp"
 #include <gtest/gtest.h>
 
-TEST(execute, smoke)
+TEST(execute, end)
 {
     fizzy::module module;
-    module.codesec.emplace_back(fizzy::code{1, {fizzy::instr::nop, fizzy::instr::end}, {}});
+    module.codesec.emplace_back(fizzy::code{0, {fizzy::instr::end}, {}});
 
     const auto [trap, ret] = fizzy::execute(module, 0, {});
 
@@ -15,11 +15,64 @@ TEST(execute, smoke)
 TEST(execute, unreachable)
 {
     fizzy::module module;
-    module.codesec.emplace_back(fizzy::code{1, {fizzy::instr::unreachable, fizzy::instr::end}, {}});
+    module.codesec.emplace_back(fizzy::code{0, {fizzy::instr::unreachable, fizzy::instr::end}, {}});
 
     const auto [trap, ret] = fizzy::execute(module, 0, {});
 
     ASSERT_EQ(trap, true);
+}
+
+TEST(execute, nop)
+{
+    fizzy::module module;
+    module.codesec.emplace_back(fizzy::code{0, {fizzy::instr::nop, fizzy::instr::end}, {}});
+
+    const auto [trap, ret] = fizzy::execute(module, 0, {});
+
+    ASSERT_EQ(trap, false);
+    EXPECT_EQ(ret.size(), 0);
+}
+
+TEST(execute, local_get)
+{
+    fizzy::module module;
+    module.codesec.emplace_back(
+        fizzy::code{0, {fizzy::instr::local_get, fizzy::instr::end}, {0, 0, 0, 0}});
+
+    const auto [trap, ret] = fizzy::execute(module, 0, {42});
+
+    ASSERT_EQ(trap, false);
+    ASSERT_EQ(ret.size(), 1);
+    EXPECT_EQ(ret[0], 42);
+}
+
+TEST(execute, local_set)
+{
+    fizzy::module module;
+    module.codesec.emplace_back(fizzy::code{1,
+        {fizzy::instr::local_get, fizzy::instr::local_set, fizzy::instr::local_get,
+            fizzy::instr::end},
+        {0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0}});
+
+    const auto [trap, ret] = fizzy::execute(module, 0, {42});
+
+    ASSERT_EQ(trap, false);
+    ASSERT_EQ(ret.size(), 1);
+    EXPECT_EQ(ret[0], 42);
+}
+
+TEST(execute, local_tee)
+{
+    fizzy::module module;
+    module.codesec.emplace_back(
+        fizzy::code{1, {fizzy::instr::local_get, fizzy::instr::local_tee, fizzy::instr::end},
+            {0, 0, 0, 0, 1, 0, 0, 0}});
+
+    const auto [trap, ret] = fizzy::execute(module, 0, {42});
+
+    ASSERT_EQ(trap, false);
+    ASSERT_EQ(ret.size(), 1);
+    EXPECT_EQ(ret[0], 42);
 }
 
 TEST(execute, basic_add)
@@ -44,36 +97,6 @@ TEST(execute, basic_add_with_inputs)
         {fizzy::instr::local_get, fizzy::instr::local_get, fizzy::instr::i32_add,
             fizzy::instr::end},
         {0, 0, 0, 0, 1, 0, 0, 0}});
-
-    const auto [trap, ret] = fizzy::execute(module, 0, {20, 22});
-
-    ASSERT_EQ(trap, false);
-    ASSERT_EQ(ret.size(), 1);
-    EXPECT_EQ(ret[0], 42);
-}
-
-TEST(execute, local_set)
-{
-    fizzy::module module;
-    module.codesec.emplace_back(fizzy::code{0,
-        {fizzy::instr::local_get, fizzy::instr::local_get, fizzy::instr::i32_add,
-            fizzy::instr::local_set, fizzy::instr::local_get, fizzy::instr::end},
-        {0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}});
-
-    const auto [trap, ret] = fizzy::execute(module, 0, {20, 22});
-
-    ASSERT_EQ(trap, false);
-    ASSERT_EQ(ret.size(), 1);
-    EXPECT_EQ(ret[0], 42);
-}
-
-TEST(execute, local_tee)
-{
-    fizzy::module module;
-    module.codesec.emplace_back(fizzy::code{0,
-        {fizzy::instr::local_get, fizzy::instr::local_get, fizzy::instr::i32_add,
-            fizzy::instr::local_tee, fizzy::instr::end},
-        {0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0}});
 
     const auto [trap, ret] = fizzy::execute(module, 0, {20, 22});
 


### PR DESCRIPTION
Add case for single end opcode, simplify the local.get/set/tee cases
and reorder tests to match the opcode position.