### PR TITLE
Stack type improvements

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -36,7 +36,7 @@ inline T read(const uint8_t*& input) noexcept
 }
 
 template <typename Op>
-inline void unary_op(stack<uint64_t>& stack, Op op) noexcept
+inline void unary_op(Stack<uint64_t>& stack, Op op) noexcept
 {
     using T = decltype(op(stack.pop()));
     const auto a = static_cast<T>(stack.pop());
@@ -44,7 +44,7 @@ inline void unary_op(stack<uint64_t>& stack, Op op) noexcept
 }
 
 template <typename Op>
-inline void binary_op(stack<uint64_t>& stack, Op op) noexcept
+inline void binary_op(Stack<uint64_t>& stack, Op op) noexcept
 {
     using T = decltype(op(stack.pop(), stack.pop()));
     const auto val2 = static_cast<T>(stack.pop());
@@ -53,7 +53,7 @@ inline void binary_op(stack<uint64_t>& stack, Op op) noexcept
 }
 
 template <typename T, template <typename> class Op>
-inline void comparison_op(stack<uint64_t>& stack, Op<T> op) noexcept
+inline void comparison_op(Stack<uint64_t>& stack, Op<T> op) noexcept
 {
     const auto val2 = static_cast<T>(stack.pop());
     const auto val1 = static_cast<T>(stack.pop());
@@ -196,7 +196,7 @@ execution_result execute(Instance& instance, FuncIdx function, std::vector<uint6
     locals.resize(locals.size() + code.local_count);
 
     // TODO: preallocate fixed stack depth properly
-    stack<uint64_t> stack;
+    Stack<uint64_t> stack;
 
     bool trap = false;
 
@@ -760,7 +760,7 @@ execution_result execute(Instance& instance, FuncIdx function, std::vector<uint6
     }
 
 end:
-    // move allows to return derived stack<uint64_t> instance into base vector<uint64_t> value
+    // move allows to return derived Stack<uint64_t> instance into base vector<uint64_t> value
     return {trap, std::move(stack)};
 }
 

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -280,7 +280,7 @@ execution_result execute(Instance& instance, FuncIdx function, std::vector<uint6
         {
             const auto idx = read<uint32_t>(immediates);
             assert(idx <= locals.size());
-            locals[idx] = stack.back();
+            locals[idx] = stack.peek();
             break;
         }
         case Instr::global_get:
@@ -539,8 +539,8 @@ execution_result execute(Instance& instance, FuncIdx function, std::vector<uint6
         }
         case Instr::i32_div_s:
         {
-            auto const rhs = static_cast<int32_t>(stack.peek(1));
-            auto const lhs = static_cast<int32_t>(stack.peek(2));
+            auto const rhs = static_cast<int32_t>(stack.peek(0));
+            auto const lhs = static_cast<int32_t>(stack.peek(1));
             if (rhs == 0 || (lhs == std::numeric_limits<int32_t>::min() && rhs == -1))
             {
                 trap = true;
@@ -551,7 +551,7 @@ execution_result execute(Instance& instance, FuncIdx function, std::vector<uint6
         }
         case Instr::i32_div_u:
         {
-            auto const rhs = static_cast<uint32_t>(stack.peek(1));
+            auto const rhs = static_cast<uint32_t>(stack.peek());
             if (rhs == 0)
             {
                 trap = true;
@@ -562,7 +562,7 @@ execution_result execute(Instance& instance, FuncIdx function, std::vector<uint6
         }
         case Instr::i32_rem_s:
         {
-            auto const rhs = static_cast<int32_t>(stack.peek(1));
+            auto const rhs = static_cast<int32_t>(stack.peek());
             if (rhs == 0)
             {
                 trap = true;
@@ -573,7 +573,7 @@ execution_result execute(Instance& instance, FuncIdx function, std::vector<uint6
         }
         case Instr::i32_rem_u:
         {
-            auto const rhs = static_cast<uint32_t>(stack.peek(1));
+            auto const rhs = static_cast<uint32_t>(stack.peek());
             if (rhs == 0)
             {
                 trap = true;
@@ -654,8 +654,8 @@ execution_result execute(Instance& instance, FuncIdx function, std::vector<uint6
         }
         case Instr::i64_div_s:
         {
-            auto const rhs = static_cast<int64_t>(stack.peek(1));
-            auto const lhs = static_cast<int64_t>(stack.peek(2));
+            auto const rhs = static_cast<int64_t>(stack.peek(0));
+            auto const lhs = static_cast<int64_t>(stack.peek(1));
             if (rhs == 0 || (lhs == std::numeric_limits<int64_t>::min() && rhs == -1))
             {
                 trap = true;
@@ -666,7 +666,7 @@ execution_result execute(Instance& instance, FuncIdx function, std::vector<uint6
         }
         case Instr::i64_div_u:
         {
-            auto const rhs = static_cast<uint64_t>(stack.peek(1));
+            auto const rhs = static_cast<uint64_t>(stack.peek());
             if (rhs == 0)
             {
                 trap = true;
@@ -677,7 +677,7 @@ execution_result execute(Instance& instance, FuncIdx function, std::vector<uint6
         }
         case Instr::i64_rem_s:
         {
-            auto const rhs = static_cast<int64_t>(stack.peek(1));
+            auto const rhs = static_cast<int64_t>(stack.peek());
             if (rhs == 0)
             {
                 trap = true;
@@ -688,7 +688,7 @@ execution_result execute(Instance& instance, FuncIdx function, std::vector<uint6
         }
         case Instr::i64_rem_u:
         {
-            auto const rhs = static_cast<uint64_t>(stack.peek(1));
+            auto const rhs = static_cast<uint64_t>(stack.peek());
             if (rhs == 0)
             {
                 trap = true;

--- a/lib/fizzy/parser_expr.cpp
+++ b/lib/fizzy/parser_expr.cpp
@@ -32,7 +32,7 @@ parser_result<Code> parse_expr(const uint8_t* pos)
 
     // The stack of labels allowing to distinguish between block and label instructions.
     // For a block instruction the value is the block's immediate offset.
-    stack<LabelPosition> label_positions;
+    Stack<LabelPosition> label_positions;
 
     bool continue_parsing = true;
     while (continue_parsing)

--- a/lib/fizzy/stack.hpp
+++ b/lib/fizzy/stack.hpp
@@ -5,7 +5,7 @@
 namespace fizzy
 {
 template <typename T>
-class stack : public std::vector<T>
+class Stack : public std::vector<T>
 {
 public:
     using difference_type = typename std::vector<T>::difference_type;

--- a/lib/fizzy/stack.hpp
+++ b/lib/fizzy/stack.hpp
@@ -14,8 +14,8 @@ public:
 
     using std::vector<T>::back;
     using std::vector<T>::emplace_back;
-    using std::vector<T>::end;
     using std::vector<T>::pop_back;
+    using std::vector<T>::size;
 
     void push(T val) { emplace_back(val); }
 
@@ -26,6 +26,6 @@ public:
         return res;
     }
 
-    T peek(difference_type depth = 1) const noexcept { return *(end() - depth); }
+    T peek(size_t depth = 0) const noexcept { return (*this)[size() - depth - 1]; }
 };
 }  // namespace fizzy

--- a/lib/fizzy/stack.hpp
+++ b/lib/fizzy/stack.hpp
@@ -15,6 +15,7 @@ public:
     using std::vector<T>::back;
     using std::vector<T>::emplace_back;
     using std::vector<T>::pop_back;
+    using std::vector<T>::resize;
     using std::vector<T>::size;
 
     void push(T val) { emplace_back(val); }
@@ -27,5 +28,8 @@ public:
     }
 
     T peek(size_t depth = 0) const noexcept { return (*this)[size() - depth - 1]; }
+
+    /// Drops @a num_elements elements from the top of the stack.
+    void drop(size_t num_elements = 1) noexcept { resize(size() - num_elements); }
 };
 }  // namespace fizzy

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(
     instantiate_test.cpp
     leb128_test.cpp
     parser_test.cpp
+    stack_test.cpp
     utils.cpp
     utils.hpp
 )

--- a/test/unittests/stack_test.cpp
+++ b/test/unittests/stack_test.cpp
@@ -1,0 +1,50 @@
+#include "stack.hpp"
+#include <gtest/gtest.h>
+
+using namespace fizzy;
+
+TEST(stack, push_and_pop)
+{
+    Stack<char> stack;
+
+    EXPECT_EQ(stack.size(), 0);
+    EXPECT_TRUE(stack.empty());
+
+    stack.push('a');
+    stack.push('b');
+    stack.push('c');
+
+    EXPECT_EQ(stack.size(), 3);
+
+    EXPECT_EQ(stack.pop(), 'c');
+    EXPECT_EQ(stack.pop(), 'b');
+    EXPECT_EQ(stack.pop(), 'a');
+
+    EXPECT_EQ(stack.size(), 0);
+    EXPECT_TRUE(stack.empty());
+}
+
+TEST(stack, drop_and_peek)
+{
+    Stack<char> stack{'w', 'x', 'y', 'z'};
+
+    EXPECT_FALSE(stack.empty());
+    EXPECT_EQ(stack.size(), 4);
+    EXPECT_EQ(stack.peek(), 'z');
+    EXPECT_EQ(stack.peek(1), 'y');
+    EXPECT_EQ(stack.peek(2), 'x');
+    EXPECT_EQ(stack.peek(3), 'w');
+    EXPECT_EQ(stack.size(), 4);
+
+    stack.drop();
+    EXPECT_EQ(stack.size(), 3);
+    EXPECT_EQ(stack.peek(), 'y');
+
+    stack.drop(2);
+    EXPECT_EQ(stack.size(), 1);
+    EXPECT_EQ(stack.peek(), 'w');
+
+    stack.drop();
+    EXPECT_EQ(stack.size(), 0);
+    EXPECT_TRUE(stack.empty());
+}


### PR DESCRIPTION
- Rename `stack` to `Stack` to avoid conflict with `stack` variable defined in `execute()`.
- Change `peek()` argument semantic.
- Add `drop()` method to be used in #25. 