### PR TITLE
Load CMake 3.15.6 on lgtm

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,8 @@
+extraction:
+  cpp:
+    after_prepare:
+      - mkdir custom_cmake
+      - wget --quiet -O - "https://cmake.org/files/v3.15/cmake-3.15.6-Linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C custom_cmake
+      - export PATH=$(pwd)/custom_cmake/bin:${PATH}
+      - mkdir $LGTM_SRC/_lgtm_build_dir
+      - cd $LGTM_SRC/_lgtm_build_dir


### PR DESCRIPTION
Based on https://discuss.lgtm.com/t/update-cmake-to-3-14-to-allow-fetch-content/2048/16

Apparently this works: https://lgtm.com/logs/0940aadb80a435c4499775daaa8a39b7fe87d60e/lang:cpp