### PR TITLE
Implement stack cleanup in br/br_if instructions

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -271,8 +271,12 @@ execution_result execute(Instance& instance, FuncIdx function, std::vector<uint6
             pc = label.pc;
             immediates = label.immediate;
 
-            // FIXME: handle arity + stack_height ?
-            assert(stack.size() == label.stack_height);
+            // FIXME: handle arity
+            assert(label.arity == 0);
+
+            // When branch is taken, additional stack items must be dropped.
+            assert(stack.size() >= label.stack_height);
+            stack.resize(label.stack_height);
             break;
         }
         case Instr::call:


### PR DESCRIPTION
Requires #25.

When branch is taken, additional stack items must be dropped. I.e. when stack height at the label was `X` branch instruction must make it `X` again (`loop`, `block` with type `[]`) or `X+1` (`block` with type `[t]`).