### PR TITLE
Add function's implict block

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -257,7 +257,17 @@ execution_result execute(Instance& instance, FuncIdx function, std::vector<uint6
             if (instruction == Instr::br_if && static_cast<uint32_t>(stack.pop()) == 0)
                 break;
 
-            assert(labels.size() > label_idx);
+            assert(label_idx <= labels.size());
+
+            if (label_idx == labels.size())
+            {
+                // This targets the function's implict block.
+                // In the implementation we don't actually add this label, because it is difficult
+                // to get the function's output type. Here the execution is just terminated
+                // without stack unwinding, but the result value is still on the top of the stack.
+                goto end;
+            }
+
             labels.drop(label_idx);  // Drop skipped labels (does nothing for labelidx == 0).
             const auto label = labels.pop();
 

--- a/test/unittests/execute_control_test.cpp
+++ b/test/unittests/execute_control_test.cpp
@@ -423,3 +423,32 @@ TEST(execute_control, br_if_with_result)
         EXPECT_EQ(ret[0], expected_results[param]);
     }
 }
+
+TEST(execute_control, br_if_out_of_function)
+{
+    /*
+    (func (param i32) (result i32)
+      i32.const 1
+      i32.const 2
+      get_local 0
+      br_if 0
+      drop
+    )
+    */
+    const auto bin = from_hex(
+        "0061736d0100000001060160017f017f030201000a0d010b004101410220000d001a0b000c046e616d65020501"
+        "00010000");
+
+    for (const auto param : {0u, 1u})
+    {
+        constexpr uint64_t expected_results[]{
+            1,  // br_if not taken.
+            2,  // br_if taken.
+        };
+
+        const auto [trap, ret] = execute(parse(bin), 0, {param});
+        ASSERT_FALSE(trap);
+        ASSERT_EQ(ret.size(), 1);
+        EXPECT_EQ(ret[0], expected_results[param]);
+    }
+}

--- a/test/unittests/execute_control_test.cpp
+++ b/test/unittests/execute_control_test.cpp
@@ -448,7 +448,7 @@ TEST(execute_control, br_if_out_of_function)
 
         const auto [trap, ret] = execute(parse(bin), 0, {param});
         ASSERT_FALSE(trap);
-        ASSERT_EQ(ret.size(), 1);
-        EXPECT_EQ(ret[0], expected_results[param]);
+        ASSERT_GE(ret.size(), 1);
+        EXPECT_EQ(ret.back(), expected_results[param]);
     }
 }


### PR DESCRIPTION
There is implicit `block` instruction at the beginning of every function. This label can be targeted with `return` instruction or simply `br` with correct `labelidx`.

There are at least 2 ways how to implement this:

### Hacky

As this example - handle case where `labelidx` is out of the label stack range. The hacky part is to skip the stack unwinding. Therefore, information about function's output type is not needed (if the function has a result or not).

### Clean

Just insert the label at the start of `execute()` as shown in #70. But to make it work properly we need the function type information (i.e. label's arity). This is theoretically available in `funcsec` / `typesec`, but in most execution tests now provided.