### PR TITLE
Implement imported memory

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -486,6 +486,9 @@ Instance instantiate(Module module, std::vector<ImportedFunction> imported_funct
         std::memcpy(memory->data() + offset, data.init.data(), data.init.size());
     }
 
+    // FIXME: clang-tidy warns about potential memory leak for moving memory (which is in fact
+    // safe), but also erroneously points this warning to std::move(table)
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     Instance instance = {std::move(module), std::move(memory), memory_max, std::move(table),
         std::move(globals), std::move(imported_functions), std::move(imported_function_types),
         std::move(imported_globals)};

--- a/test/unittests/end_to_end_test.cpp
+++ b/test/unittests/end_to_end_test.cpp
@@ -71,19 +71,20 @@ TEST(end_to_end, milestone2)
 
     auto instance = instantiate(module);
 
+    auto& memory = *instance.memory;
     // This performs uint256 x uint256 -> uint512 multiplication.
     // Arg1: 2^255 + 1
-    instance.memory[0] = 1;
-    instance.memory[31] = 0x80;
+    memory[0] = 1;
+    memory[31] = 0x80;
     // Arg2: 2^255 + 2^254 + 0xff
-    instance.memory[32] = 0xff;
-    instance.memory[63] = 0xc0;
+    memory[32] = 0xff;
+    memory[63] = 0xc0;
     // TODO: use find_exported_function
     const auto [trap, ret] = execute(instance, 0, {64, 0, 32});
 
     ASSERT_FALSE(trap);
     ASSERT_EQ(ret.size(), 0);
-    EXPECT_EQ(hex(instance.memory.substr(64, 64)),
+    EXPECT_EQ(hex(memory.substr(64, 64)),
         "ff00000000000000000000000000000000000000000000000000000000000040"
         "8000000000000000000000000000000000000000000000000000000000000060");
 }
@@ -185,5 +186,5 @@ TEST(end_to_end, memset)
 
     ASSERT_FALSE(trap);
     ASSERT_EQ(ret.size(), 0);
-    EXPECT_EQ(hex(instance.memory.substr(0, 2 * sizeof(int))), "d2040000d2040000");
+    EXPECT_EQ(hex(instance.memory->substr(0, 2 * sizeof(int))), "d2040000d2040000");
 }

--- a/test/unittests/execute_test.cpp
+++ b/test/unittests/execute_test.cpp
@@ -350,7 +350,7 @@ TEST(execute, i32_load)
         Code{0, {Instr::local_get, Instr::i32_load, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
     auto instance = instantiate(module);
-    instance.memory[0] = 42;
+    (*instance.memory)[0] = 42;
     const auto [trap, ret] = execute(instance, 0, {0});
 
     ASSERT_FALSE(trap);
@@ -368,8 +368,8 @@ TEST(execute, i64_load)
         Code{0, {Instr::local_get, Instr::i64_load, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
     auto instance = instantiate(module);
-    instance.memory[0] = 0x2a;
-    instance.memory[4] = 0x2a;
+    (*instance.memory)[0] = 0x2a;
+    (*instance.memory)[4] = 0x2a;
     const auto [trap, ret] = execute(instance, 0, {0});
 
     ASSERT_FALSE(trap);
@@ -387,8 +387,8 @@ TEST(execute, i32_load8_s)
         Code{0, {Instr::local_get, Instr::i32_load8_s, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
     auto instance = instantiate(module);
-    instance.memory[0] = 0x80;
-    instance.memory[1] = 0xf1;
+    (*instance.memory)[0] = 0x80;
+    (*instance.memory)[1] = 0xf1;
     const auto [trap, ret] = execute(instance, 0, {0});
 
     ASSERT_FALSE(trap);
@@ -406,8 +406,8 @@ TEST(execute, i32_load8_u)
         Code{0, {Instr::local_get, Instr::i32_load8_u, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
     auto instance = instantiate(module);
-    instance.memory[0] = 0x81;
-    instance.memory[1] = 0xf1;
+    (*instance.memory)[0] = 0x81;
+    (*instance.memory)[1] = 0xf1;
     const auto [trap, ret] = execute(instance, 0, {0});
 
     ASSERT_FALSE(trap);
@@ -425,9 +425,9 @@ TEST(execute, i32_load16_s)
         Code{0, {Instr::local_get, Instr::i32_load16_s, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
     auto instance = instantiate(module);
-    instance.memory[0] = 0x00;
-    instance.memory[1] = 0x80;
-    instance.memory[3] = 0xf1;
+    (*instance.memory)[0] = 0x00;
+    (*instance.memory)[1] = 0x80;
+    (*instance.memory)[3] = 0xf1;
     const auto [trap, ret] = execute(instance, 0, {0});
 
     ASSERT_FALSE(trap);
@@ -445,9 +445,9 @@ TEST(execute, i32_load16_u)
         Code{0, {Instr::local_get, Instr::i32_load16_u, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
     auto instance = instantiate(module);
-    instance.memory[0] = 0x01;
-    instance.memory[1] = 0x80;
-    instance.memory[3] = 0xf1;
+    (*instance.memory)[0] = 0x01;
+    (*instance.memory)[1] = 0x80;
+    (*instance.memory)[3] = 0xf1;
     const auto [trap, ret] = execute(instance, 0, {0});
 
     ASSERT_FALSE(trap);
@@ -465,8 +465,8 @@ TEST(execute, i64_load8_s)
         Code{0, {Instr::local_get, Instr::i64_load8_s, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
     auto instance = instantiate(module);
-    instance.memory[0] = 0x80;
-    instance.memory[1] = 0xf1;
+    (*instance.memory)[0] = 0x80;
+    (*instance.memory)[1] = 0xf1;
     const auto [trap, ret] = execute(instance, 0, {0});
 
     ASSERT_FALSE(trap);
@@ -484,8 +484,8 @@ TEST(execute, i64_load8_u)
         Code{0, {Instr::local_get, Instr::i64_load8_u, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
     auto instance = instantiate(module);
-    instance.memory[0] = 0x81;
-    instance.memory[1] = 0xf1;
+    (*instance.memory)[0] = 0x81;
+    (*instance.memory)[1] = 0xf1;
     const auto [trap, ret] = execute(instance, 0, {0});
 
     ASSERT_FALSE(trap);
@@ -503,9 +503,9 @@ TEST(execute, i64_load16_s)
         Code{0, {Instr::local_get, Instr::i64_load16_s, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
     auto instance = instantiate(module);
-    instance.memory[0] = 0x00;
-    instance.memory[1] = 0x80;
-    instance.memory[2] = 0xf1;
+    (*instance.memory)[0] = 0x00;
+    (*instance.memory)[1] = 0x80;
+    (*instance.memory)[2] = 0xf1;
     const auto [trap, ret] = execute(instance, 0, {0});
 
     ASSERT_FALSE(trap);
@@ -523,9 +523,9 @@ TEST(execute, i64_load16_u)
         Code{0, {Instr::local_get, Instr::i64_load16_u, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
     auto instance = instantiate(module);
-    instance.memory[0] = 0x01;
-    instance.memory[1] = 0x80;
-    instance.memory[2] = 0xf1;
+    (*instance.memory)[0] = 0x01;
+    (*instance.memory)[1] = 0x80;
+    (*instance.memory)[2] = 0xf1;
     const auto [trap, ret] = execute(instance, 0, {0});
 
     ASSERT_FALSE(trap);
@@ -543,11 +543,12 @@ TEST(execute, i64_load32_s)
         Code{0, {Instr::local_get, Instr::i64_load32_s, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
     auto instance = instantiate(module);
-    instance.memory[0] = 0x00;
-    instance.memory[1] = 0x00;
-    instance.memory[2] = 0x00;
-    instance.memory[3] = 0x80;
-    instance.memory[4] = 0xf1;
+    auto& memory = *instance.memory;
+    memory[0] = 0x00;
+    memory[1] = 0x00;
+    memory[2] = 0x00;
+    memory[3] = 0x80;
+    memory[4] = 0xf1;
     const auto [trap, ret] = execute(instance, 0, {0});
 
     ASSERT_FALSE(trap);
@@ -565,11 +566,12 @@ TEST(execute, i64_load32_u)
         Code{0, {Instr::local_get, Instr::i64_load32_u, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
     auto instance = instantiate(module);
-    instance.memory[0] = 0x01;
-    instance.memory[1] = 0x00;
-    instance.memory[2] = 0x00;
-    instance.memory[3] = 0x80;
-    instance.memory[4] = 0xf1;
+    auto& memory = *instance.memory;
+    memory[0] = 0x01;
+    memory[1] = 0x00;
+    memory[2] = 0x00;
+    memory[3] = 0x80;
+    memory[4] = 0xf1;
     const auto [trap, ret] = execute(instance, 0, {0});
 
     ASSERT_FALSE(trap);
@@ -592,7 +594,7 @@ TEST(execute, i32_store)
 
     ASSERT_FALSE(trap);
     ASSERT_EQ(ret.size(), 0);
-    ASSERT_EQ(instance.memory.substr(0, 4), from_hex("2a000000"));
+    ASSERT_EQ(instance.memory->substr(0, 4), from_hex("2a000000"));
 
     ASSERT_TRUE(execute(instance, 0, {42, 65537}).trapped);
 }
@@ -610,7 +612,7 @@ TEST(execute, i64_store)
 
     ASSERT_FALSE(trap);
     ASSERT_EQ(ret.size(), 0);
-    ASSERT_EQ(instance.memory.substr(0, 8), from_hex("2a0000002a000000"));
+    ASSERT_EQ(instance.memory->substr(0, 8), from_hex("2a0000002a000000"));
 
     ASSERT_TRUE(execute(instance, 0, {0x2a0000002a, 65537}).trapped);
 }
@@ -628,7 +630,7 @@ TEST(execute, i32_store8)
 
     ASSERT_FALSE(trap);
     ASSERT_EQ(ret.size(), 0);
-    ASSERT_EQ(instance.memory.substr(0, 4), from_hex("80000000"));
+    ASSERT_EQ(instance.memory->substr(0, 4), from_hex("80000000"));
 
     ASSERT_TRUE(execute(instance, 0, {0xf1f2f380, 65537}).trapped);
 }
@@ -660,7 +662,7 @@ TEST(execute, i32_store16)
 
     ASSERT_FALSE(trap);
     ASSERT_EQ(ret.size(), 0);
-    ASSERT_EQ(instance.memory.substr(0, 4), from_hex("00800000"));
+    ASSERT_EQ(instance.memory->substr(0, 4), from_hex("00800000"));
 
     ASSERT_TRUE(execute(instance, 0, {0xf1f28000, 65537}).trapped);
 }
@@ -678,7 +680,7 @@ TEST(execute, i64_store8)
 
     ASSERT_FALSE(trap);
     ASSERT_EQ(ret.size(), 0);
-    ASSERT_EQ(instance.memory.substr(0, 8), from_hex("8000000000000000"));
+    ASSERT_EQ(instance.memory->substr(0, 8), from_hex("8000000000000000"));
 
     ASSERT_TRUE(execute(instance, 0, {0xf1f2f4f5f6f7f880, 65537}).trapped);
 }
@@ -696,7 +698,7 @@ TEST(execute, i64_store16)
 
     ASSERT_FALSE(trap);
     ASSERT_EQ(ret.size(), 0);
-    ASSERT_EQ(instance.memory.substr(0, 8), from_hex("0080000000000000"));
+    ASSERT_EQ(instance.memory->substr(0, 8), from_hex("0080000000000000"));
 
     ASSERT_TRUE(execute(instance, 0, {0xf1f2f4f5f6f78000, 65537}).trapped);
 }
@@ -714,7 +716,7 @@ TEST(execute, i64_store32)
 
     ASSERT_FALSE(trap);
     ASSERT_EQ(ret.size(), 0);
-    ASSERT_EQ(instance.memory.substr(0, 8), from_hex("0000008000000000"));
+    ASSERT_EQ(instance.memory->substr(0, 8), from_hex("0000008000000000"));
 
     ASSERT_TRUE(execute(instance, 0, {0xf1f2f4f580000000, 65537}).trapped);
 }
@@ -790,14 +792,14 @@ TEST(execute, start_section)
 
     auto instance = instantiate(module);
     // Start function sets this
-    ASSERT_EQ(instance.memory.substr(0, 4), from_hex("2a000000"));
+    ASSERT_EQ(instance.memory->substr(0, 4), from_hex("2a000000"));
 
     const auto [trap, ret] = execute(instance, 0, {});
 
     ASSERT_FALSE(trap);
     ASSERT_EQ(ret.size(), 1);
     EXPECT_EQ(ret[0], 42);
-    EXPECT_EQ(instance.memory.substr(0, 4), from_hex("2a000000"));
+    EXPECT_EQ(instance.memory->substr(0, 4), from_hex("2a000000"));
 }
 
 TEST(execute, imported_function)
@@ -1024,15 +1026,15 @@ TEST(execute, memory_copy_32bytes)
 
     const auto module = parse(bin);
     auto instance = instantiate(module);
-    ASSERT_EQ(instance.memory.size(), 65536);
+    ASSERT_EQ(instance.memory->size(), 65536);
     const auto input = from_hex("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
     ASSERT_EQ(input.size(), 32);
-    std::copy(input.begin(), input.end(), instance.memory.begin());
+    std::copy(input.begin(), input.end(), instance.memory->begin());
     const auto [trap, ret] = execute(instance, 0, {33, 0});
     ASSERT_FALSE(trap);
     EXPECT_EQ(ret.size(), 0);
-    ASSERT_EQ(instance.memory.size(), 65536);
+    ASSERT_EQ(instance.memory->size(), 65536);
     bytes output;
-    std::copy_n(&instance.memory[33], input.size(), std::back_inserter(output));
+    std::copy_n(&(*instance.memory)[33], input.size(), std::back_inserter(output));
     EXPECT_EQ(output, input);
 }

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -137,7 +137,7 @@ TEST(instantiate, memory_default)
 
     auto instance = instantiate(module);
 
-    ASSERT_EQ(instance.memory.size(), 0);
+    ASSERT_EQ(instance.memory->size(), 0);
     EXPECT_EQ(instance.memory_max_pages * page_size, 256 * 1024 * 1024);
 }
 
@@ -148,7 +148,7 @@ TEST(instantiate, memory_single)
 
     auto instance = instantiate(module);
 
-    ASSERT_EQ(instance.memory.size(), page_size);
+    ASSERT_EQ(instance.memory->size(), page_size);
     EXPECT_EQ(instance.memory_max_pages, 1);
 }
 
@@ -159,7 +159,7 @@ TEST(instantiate, memory_single_unspecified_maximum)
 
     auto instance = instantiate(module);
 
-    ASSERT_EQ(instance.memory.size(), page_size);
+    ASSERT_EQ(instance.memory->size(), page_size);
     EXPECT_EQ(instance.memory_max_pages * page_size, 256 * 1024 * 1024);
 }
 
@@ -169,7 +169,7 @@ TEST(instantiate, memory_single_large_minimum)
     module.memorysec.emplace_back(Memory{{(1024 * 1024 * 1024) / page_size, std::nullopt}});
 
     EXPECT_THROW_MESSAGE(instantiate(module), instantiate_error,
-        "Cannot exceed hard memory limit of 268435456 bytes");
+        "Cannot exceed hard memory limit of 268435456 bytes.");
 }
 
 TEST(instantiate, memory_single_large_maximum)
@@ -178,7 +178,7 @@ TEST(instantiate, memory_single_large_maximum)
     module.memorysec.emplace_back(Memory{{1, (1024 * 1024 * 1024) / page_size}});
 
     EXPECT_THROW_MESSAGE(instantiate(module), instantiate_error,
-        "Cannot exceed hard memory limit of 268435456 bytes");
+        "Cannot exceed hard memory limit of 268435456 bytes.");
 }
 
 TEST(instantiate, memory_multiple)
@@ -287,7 +287,7 @@ TEST(instantiate, data_section)
 
     auto instance = instantiate(module);
 
-    EXPECT_EQ(instance.memory.substr(0, 6), from_hex("00aa55550000"));
+    EXPECT_EQ(instance.memory->substr(0, 6), from_hex("00aa55550000"));
 }
 
 TEST(instantiate, data_section_offset_from_global)
@@ -300,7 +300,7 @@ TEST(instantiate, data_section_offset_from_global)
 
     auto instance = instantiate(module);
 
-    EXPECT_EQ(instance.memory.substr(42, 2), "aaff"_bytes);
+    EXPECT_EQ(instance.memory->substr(42, 2), "aaff"_bytes);
 }
 
 TEST(instantiate, data_section_offset_from_imported_global)
@@ -316,7 +316,7 @@ TEST(instantiate, data_section_offset_from_imported_global)
 
     auto instance = instantiate(module, {}, {g});
 
-    EXPECT_EQ(instance.memory.substr(42, 2), "aaff"_bytes);
+    EXPECT_EQ(instance.memory->substr(42, 2), "aaff"_bytes);
 }
 
 TEST(instantiate, data_section_offset_from_mutable_global)

--- a/test/utils/fizzy_engine.cpp
+++ b/test/utils/fizzy_engine.cpp
@@ -51,12 +51,12 @@ bool FizzyEngine::instantiate()
 
 bytes_view FizzyEngine::get_memory() const
 {
-    return {m_instance.memory.data(), m_instance.memory.size()};
+    return {m_instance.memory->data(), m_instance.memory->size()};
 }
 
 void FizzyEngine::set_memory(bytes_view memory)
 {
-    m_instance.memory = memory;
+    *m_instance.memory = memory;
 }
 
 std::optional<WasmEngine::FuncRef> FizzyEngine::find_function(std::string_view name) const


### PR DESCRIPTION
Some relevant links
- Matching memory imports described in spec https://webassembly.github.io/spec/core/exec/modules.html#memories
https://webassembly.github.io/spec/core/exec/modules.html#limits
-  how memory importing looks from the JS side https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory#Examples
- more about memories from JS point of view (note the last paragraph about imported memory usage) https://webassembly.org/getting-started/js-api/#memory