### PR TITLE
cmake: Prefer CONFIG mode for find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 
 cmake_policy(SET CMP0077 NEW)
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
 
 include(cmake/cable.cmake)
 include(CableBuildType)

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 include(GoogleTest)
 
-find_package(GTest CONFIG REQUIRED)
+find_package(GTest REQUIRED)
 
 add_executable(fizzy-unittests)
 target_link_libraries(fizzy-unittests PRIVATE fizzy::fizzy fizzy::test-utils GTest::gtest_main)


### PR DESCRIPTION
Docs: https://cmake.org/cmake/help/v3.16/variable/CMAKE_FIND_PACKAGE_PREFER_CONFIG.html

This makes the CONFIG mode of `find_package()` being the first to try if not explicitly specified. Without setting the variable, the MODULE mode is the first to try.

The CONFIG mode should be always preferable in "modern" CMake.