### PR TITLE
Fix UB in leb128s_decode

### DIFF
--- a/lib/fizzy/leb128.hpp
+++ b/lib/fizzy/leb128.hpp
@@ -43,7 +43,8 @@ std::pair<T, const uint8_t*> leb128s_decode(const uint8_t* input)
             // sign extend
             if ((*input & 0x40) != 0)
             {
-                auto const mask = static_cast<T_unsigned>(~T_unsigned{0} << (result_shift + 7));
+                constexpr auto all_ones = std::numeric_limits<T_unsigned>::max();
+                const auto mask = static_cast<T_unsigned>(all_ones << (result_shift + 7));
                 result |= mask;
             }
             return {static_cast<T>(result), input + 1};

--- a/test/unittests/leb128_test.cpp
+++ b/test/unittests/leb128_test.cpp
@@ -163,6 +163,7 @@ TEST(leb128, decode_s8)
             {{0x81, 0x00}, 1}, // 1 with leading zero
             {{0xff, 0x01}, -1},
             {{0xfe, 0x01}, -2},
+            {{0x40}, -64},
     };
     // clang-format on
 


### PR DESCRIPTION
For types smaller than `int`, there is a promotion to `int` for `~T_unsigned{0}` and the end result is `-1`. It is undefined behavior to shift left a negative value.