### PR TITLE
Check fizzy-bench with ASan

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -58,6 +58,14 @@ commands:
         working_directory: ~/build
         command: ctest -R ${TESTS_FILTER:-'.*'} -j4 --schedule-random --output-on-failure
 
+  benchmark:
+    description: "Run benchmarks"
+    steps:
+      - run:
+          name: "Run benchmarks"
+          working_directory: ~/build
+          command: bin/fizzy-bench ~/project/test/benchmarks
+
 jobs:
 
   lint:
@@ -136,11 +144,12 @@ jobs:
   clang-latest-asan:
     executor: linux-clang-9
     environment:
-      BUILD_TYPE: Release
+      BUILD_TYPE: RelWithDebInfo
       CMAKE_OPTIONS: -DSANITIZE=address
     steps:
       - build
       - test
+      - benchmark
 
   clang-latest-ubsan:
     executor: linux-clang-9

--- a/test/bench/CMakeLists.txt
+++ b/test/bench/CMakeLists.txt
@@ -6,3 +6,11 @@ add_executable(fizzy-bench bench.cpp)
 target_compile_features(fizzy-bench PRIVATE cxx_std_17)
 target_link_libraries(fizzy-bench PRIVATE fizzy::fizzy fizzy::test-utils benchmark::benchmark)
 target_include_directories(fizzy-bench PRIVATE ${fizzy_include_dir})
+
+if(UNIX AND NOT APPLE)
+    # For libstdc++ up to version 8 (included) this is needed for proper <filesystem> support.
+    # Otherwise, the result program will crash on first use (no linker errors).
+    # For libstdc++ 9, this is not needed, but cause no harm.
+    # Clang compiler on linux may select libstdc++8 in some configurations.
+    target_link_libraries(fizzy-bench PRIVATE stdc++fs)
+endif()


### PR DESCRIPTION
- Fix fizzy-bench linking with stdc++fs — details explained in comments.
- Run all benchmarks with ASan to detect issues with the tool.