### PR TITLE
Add macro to test the thrown exception message

### DIFF
--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -1,5 +1,6 @@
 #include "execute.hpp"
 #include <gtest/gtest.h>
+#include <test/utils/asserts.hpp>
 #include <test/utils/hex.hpp>
 
 using namespace fizzy;
@@ -54,7 +55,8 @@ TEST(instantiate, imported_functions_not_enough)
     module.typesec.emplace_back(FuncType{{ValType::i32}, {ValType::i32}});
     module.importsec.emplace_back(Import{"mod", "foo", ExternalKind::Function, {0}});
 
-    EXPECT_THROW(instantiate(module, {}), std::runtime_error);
+    EXPECT_THROW_MESSAGE(instantiate(module, {}), std::runtime_error,
+        "Module requires 1 imported functions, 0 provided");
 }
 
 TEST(instantiate, memory_default)

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(fizzy::test-utils ALIAS test-utils)
 
 target_sources(
     test-utils PRIVATE
+    asserts.hpp
     hex.cpp
     hex.hpp
 )

--- a/test/utils/asserts.hpp
+++ b/test/utils/asserts.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#define EXPECT_THROW_MESSAGE(stmt, ex_type, expected)                                        \
+    try                                                                                      \
+    {                                                                                        \
+        stmt;                                                                                \
+        ADD_FAILURE() << "Exception of type " #ex_type " is expected, but none was thrown."; \
+    }                                                                                        \
+    catch (const ex_type& exception)                                                         \
+    {                                                                                        \
+        EXPECT_STREQ(exception.what(), expected);                                            \
+    }                                                                                        \
+    catch (...)                                                                              \
+    {                                                                                        \
+        ADD_FAILURE() << "Unexpected exception type thrown.";                                \
+    }


### PR DESCRIPTION
Failure messages look like this:

- Exception thrown, but wrong type
```
[ RUN      ] instantiate.imported_functions_not_enough
/home/andrei/dev/fizzy/test/unittests/instantiate_test.cpp:64: Failure
        Failed
Unexpected exception type thrown.
```
- Correct type, wrong message
```
[ RUN      ] instantiate.imported_functions_not_enough
/home/andrei/dev/fizzy/test/unittests/instantiate_test.cpp:64: Failure
        Expected equality of these values:
exception.what()
Which is: "Module requires 1 imported functions, 0 provided"
"incorrect message"
```
- Exception not thrown
```
[ RUN      ] instantiate.imported_functions_not_enough
/home/andrei/dev/fizzy/test/unittests/instantiate_test.cpp:68: Failure
        Failed
Exception of type std::runtime_error is expected, but none was thrown.
```