### PR TITLE
Script wat2wasm4cpp

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -82,6 +82,17 @@ jobs:
         name: "Run codespell"
         command: |
           codespell --quiet-level=4
+    - run:
+        name: "Install wabt"
+        working_directory: ~/bin
+        command: curl -L https://github.com/WebAssembly/wabt/releases/download/1.0.13/wabt-1.0.13-linux.tar.gz | tar xz --strip=1
+    - run:
+        name: "Check wat2wasm4cpp"
+        command: |
+          export PATH=$PATH:~/bin
+          ./wat2wasm4cpp.py test/unittests/execute_control_test.cpp
+          git diff --color --exit-code
+
 
   release-linux:
     executor: linux-gcc-9

--- a/wat2wasm4cpp.py
+++ b/wat2wasm4cpp.py
@@ -1,0 +1,133 @@
+#!/usr/bin/python3
+
+"""wat2wasm4cpp
+
+This script converts C++ comments containing WebAssembly text format (WAT)
+into WebAssembly binary format.
+
+It uses wat2wasm tool from WABT (https://github.com/WebAssembly/wabt)
+and expect the tool be available in PATH.
+- On Linux/Debian wabt package is avialble.
+- On macos wabt can be installed via homebrew.
+
+It searches for the C++ block comments starting with `wat2wasm [options]`.
+Optional options are going to be passed to the wat2wasm tool.
+Example:
+
+    /* wat2wasm --no-check
+    (module
+      (func ...)
+    )
+    */
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+DEBUG = False
+
+WAT2WASM_TOOL = 'wat2wasm'
+FORMAT_TOOL = 'clang-format'
+
+WAT_RE = re.compile(r'/\* wat2wasm(.*)\n([^*]*)\*/', re.MULTILINE)
+WASM_RE = re.compile(r'\s*(?:const )?auto \w+ =\s*from_hex\(\s*"([^;]*)"\);',
+                     re.MULTILINE)
+
+TMP_WAT_FILE = sys.argv[0] + '.wat'
+TMP_WASM_FILE = sys.argv[0] + '.wasm'
+
+
+def debug(*args, **kwargs):
+    if DEBUG:
+        print(*args, **kwargs)
+
+
+def report_wat_errors(errmsg, source, source_path, wat_pos):
+    wat_line = source.count('\n', 0, wat_pos)
+    line_re = re.compile(TMP_WAT_FILE.replace('.', '\\.') + r':(\d+):')
+
+    p = 0
+    while True:
+        line_match = line_re.search(errmsg, p)
+        if not line_match:
+            break
+        n = int(line_match.group(1))
+        s = line_match.span(1)
+        errmsg = "".join((errmsg[:s[0]], str(wat_line + n), errmsg[s[1]:]))
+        p = line_match.span()[1]
+
+    errmsg = errmsg.replace(TMP_WAT_FILE, source_path)
+    print(errmsg, file=sys.stderr)
+
+
+try:
+    if len(sys.argv) < 2:
+        raise Exception("Missing FILE argument")
+
+    source_path = sys.argv[1]
+    with open(source_path, 'r') as f:
+        source = f.read()
+
+    modified = False
+    pos = 0
+
+    while True:
+        wat_match = WAT_RE.search(source, pos)
+        if not wat_match:
+            break
+
+        wat = wat_match.group(2)
+        options = wat_match.group(1)
+        options = options.split() if options else []
+        pos = wat_match.span()[1]
+
+        debug(f"wat2wasm: {options}\n{wat}")
+
+        with open(TMP_WAT_FILE, 'w') as f:
+            f.write(wat)
+
+        r = subprocess.run([WAT2WASM_TOOL, TMP_WAT_FILE] + options,
+                           capture_output=True, text=True)
+        if r.returncode != 0:
+            report_wat_errors(r.stderr, source, source_path,
+                              wat_match.span(2)[0])
+            continue
+
+        with open(TMP_WASM_FILE, 'rb') as f:
+            new_wasm = f.read().hex()
+
+        wasm_match = WASM_RE.match(source, pos)
+        if wasm_match:
+            cur_wasm = wasm_match.group(1)
+            cur_wasm = cur_wasm.translate({ord(c): '' for c in ' \r\n"'})
+            if new_wasm != cur_wasm:
+                modified = True
+                begin, end = wasm_match.span(1)
+                source = "".join((source[:begin], new_wasm, source[end:]))
+        else:
+            modified = True
+            source = "".join((source[:pos], 'const auto wasm = from_hex("',
+                              new_wasm, '");', source[pos:]))
+
+    if modified:
+        with open(source_path, 'w') as f:
+            f.write(source)
+
+        # Format the modified file with clang-format, but ignore all the related
+        # errors, including clang-format not found.
+        try:
+            subprocess.run([FORMAT_TOOL, '-i', source_path],
+                           capture_output=True)
+        except:
+            pass
+
+
+except Exception as ex:
+    print(f"{ex}", file=sys.stderr)
+
+if os.path.exists(TMP_WAT_FILE):
+    os.remove(TMP_WAT_FILE)
+if os.path.exists(TMP_WASM_FILE):
+    os.remove(TMP_WASM_FILE)


### PR DESCRIPTION
1. Script is written in Python. Can be done in CMake someday, but this requires substantially  more work.
2. It takes a C++ source file as an argument.
3. It searches for `/* wasm ... */` comments containing WAT code. I think a match like `/*\n(... */` would also work. We can discuss if there should be a common name for this variable, e.g. `bin`, `wasm`, `wasm_binary`.
4. The result wasm binary is used to update the `const auto <any_name> = from_hex("...");`. This was used as a start because it was like that in the file already. There is some issue with formatting `""_bytes"` automatically. If this pattern is not found, the result wasm is ignored.
5. It expects `wat2wasm` (wabt) in the PATH.
6. The modified source file could be additionally formatted with clang-format, but this is not implemented.
7. There is a way to report WAT errors with line numbers matching the source file. But not implemented yet.
8. Fun fact: if you omit `(module)` in WAT, wat2wasm skips at least some custom sections. That's why the updated wasm binaries are smaller.