### PR TITLE
Pass module to instance by pointer

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -276,9 +276,9 @@ Instance instantiate(std::shared_ptr<const Module> module,
         std::move(imported_globals)};
 
     // Run start function if present
-    if (instance.module->startfunc)
+    if (instance.module.startfunc)
     {
-        if (execute(instance, *instance.module->startfunc, {}).trapped)
+        if (execute(instance, *instance.module.startfunc, {}).trapped)
             throw std::runtime_error("Start function failed to execute");
     }
 
@@ -335,9 +335,9 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         return instance.imported_functions[func_idx](instance, std::move(args));
 
     const auto code_idx = func_idx - instance.imported_functions.size();
-    assert(code_idx < instance.module->codesec.size());
+    assert(code_idx < instance.module.codesec.size());
 
-    const auto& code = instance.module->codesec[code_idx];
+    const auto& code = instance.module.codesec[code_idx];
 
     std::vector<uint64_t> locals = std::move(args);
     locals.resize(locals.size() + code.local_count);
@@ -422,14 +422,14 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         {
             const auto called_func_idx = read<uint32_t>(immediates);
             assert(called_func_idx <
-                   instance.imported_functions.size() + instance.module->funcsec.size());
+                   instance.imported_functions.size() + instance.module.funcsec.size());
             const auto type_idx =
                 called_func_idx < instance.imported_functions.size() ?
                     instance.imported_function_types[called_func_idx] :
-                    instance.module->funcsec[called_func_idx - instance.imported_functions.size()];
-            assert(type_idx < instance.module->typesec.size());
+                    instance.module.funcsec[called_func_idx - instance.imported_functions.size()];
+            assert(type_idx < instance.module.typesec.size());
 
-            const auto num_inputs = instance.module->typesec[type_idx].inputs.size();
+            const auto num_inputs = instance.module.typesec[type_idx].inputs.size();
             assert(stack.size() >= num_inputs);
             std::vector<uint64_t> call_args(
                 stack.rbegin(), stack.rbegin() + static_cast<ptrdiff_t>(num_inputs));
@@ -443,7 +443,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
                 goto end;
             }
 
-            const auto num_outputs = instance.module->typesec[type_idx].outputs.size();
+            const auto num_outputs = instance.module.typesec[type_idx].outputs.size();
             // NOTE: we can assume these two from validation
             assert(ret.stack.size() == num_outputs);
             assert(num_outputs <= 1);
@@ -458,10 +458,10 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
             // TODO: Not needed, but satisfies the assert in the end of the main loop.
             labels.clear();
 
-            assert(code_idx < instance.module->funcsec.size());
-            const auto type_idx = instance.module->funcsec[code_idx];
-            assert(type_idx < instance.module->typesec.size());
-            const bool have_result = !instance.module->typesec[type_idx].outputs.empty();
+            assert(code_idx < instance.module.funcsec.size());
+            const auto type_idx = instance.module.funcsec[code_idx];
+            assert(type_idx < instance.module.typesec.size());
+            const bool have_result = !instance.module.typesec[type_idx].outputs.empty();
 
             if (have_result)
             {
@@ -523,7 +523,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
             else
             {
                 const auto module_global_idx = idx - instance.imported_globals.size();
-                assert(module_global_idx < instance.module->globalsec.size());
+                assert(module_global_idx < instance.module.globalsec.size());
                 stack.push(instance.globals[module_global_idx]);
             }
             break;
@@ -539,8 +539,8 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
             else
             {
                 const auto module_global_idx = idx - instance.imported_globals.size();
-                assert(module_global_idx < instance.module->globalsec.size());
-                assert(instance.module->globalsec[module_global_idx].is_mutable);
+                assert(module_global_idx < instance.module.globalsec.size());
+                assert(instance.module.globalsec[module_global_idx].is_mutable);
                 instance.globals[module_global_idx] = stack.pop();
             }
             break;

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -2,6 +2,7 @@
 
 #include "types.hpp"
 #include <cstdint>
+#include <memory>
 
 namespace fizzy
 {
@@ -28,7 +29,7 @@ struct ImportedGlobal
 // The module instance.
 struct Instance
 {
-    const Module* module = nullptr;
+    std::shared_ptr<const Module> module;
     bytes memory;
     size_t memory_max_pages = 0;
     std::vector<uint64_t> globals;
@@ -38,14 +39,16 @@ struct Instance
 };
 
 // Instantiate a module.
-Instance instantiate(const Module* module, std::vector<ImportedFunction> imported_functions = {},
+Instance instantiate(std::shared_ptr<const Module> module,
+    std::vector<ImportedFunction> imported_functions = {},
     std::vector<ImportedGlobal> imported_globals = {});
 
 // Execute a function on an instance.
 execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint64_t> args);
 
 // TODO: remove this helper
-execution_result execute(const Module& module, FuncIdx func_idx, std::vector<uint64_t> args);
+execution_result execute(
+    std::shared_ptr<const Module> module, FuncIdx func_idx, std::vector<uint64_t> args);
 
 // Find exported function index by name.
 std::optional<FuncIdx> find_exported_function(const Module& module, std::string_view name);

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -28,7 +28,7 @@ struct ImportedGlobal
 // The module instance.
 struct Instance
 {
-    const Module& module;
+    const Module* module = nullptr;
     bytes memory;
     size_t memory_max_pages = 0;
     std::vector<uint64_t> globals;
@@ -38,7 +38,7 @@ struct Instance
 };
 
 // Instantiate a module.
-Instance instantiate(const Module& module, std::vector<ImportedFunction> imported_functions = {},
+Instance instantiate(const Module* module, std::vector<ImportedFunction> imported_functions = {},
     std::vector<ImportedGlobal> imported_globals = {});
 
 // Execute a function on an instance.

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -29,13 +29,30 @@ struct ImportedGlobal
 // The module instance.
 struct Instance
 {
-    std::shared_ptr<const Module> module;
+    const Module& module;
     bytes memory;
     size_t memory_max_pages = 0;
     std::vector<uint64_t> globals;
     std::vector<ImportedFunction> imported_functions;
     std::vector<TypeIdx> imported_function_types;
     std::vector<ImportedGlobal> imported_globals;
+
+    Instance(std::shared_ptr<const Module> module_ptr, bytes _memory, size_t _memory_max_pages,
+        std::vector<uint64_t> _globals, std::vector<ImportedFunction> _imported_functions,
+        std::vector<TypeIdx> _imported_function_types,
+        std::vector<ImportedGlobal> _imported_globals)
+      : module{*module_ptr},
+        memory{std::move(_memory)},
+        memory_max_pages{_memory_max_pages},
+        globals{std::move(_globals)},
+        imported_functions{std::move(_imported_functions)},
+        imported_function_types{std::move(_imported_function_types)},
+        imported_globals{std::move(_imported_globals)},
+        m_module_ptr{std::move(module_ptr)}
+    {}
+
+private:
+    std::shared_ptr<const Module> m_module_ptr;
 };
 
 // Instantiate a module.

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -218,14 +218,15 @@ struct parser<Data>
     }
 };
 
-Module parse(bytes_view input)
+std::shared_ptr<Module> parse(bytes_view input)
 {
     if (input.substr(0, wasm_prefix.size()) != wasm_prefix)
         throw parser_error{"invalid wasm module prefix"};
 
     input.remove_prefix(wasm_prefix.size());
 
-    Module module;
+    auto module_ptr = std::make_shared<Module>();
+    auto& module = *module_ptr;
     for (auto it = input.begin(); it != input.end();)
     {
         const auto id = static_cast<SectionId>(*it++);
@@ -285,6 +286,6 @@ Module parse(bytes_view input)
             throw parser_error{"too many memory sections (at most one is allowed)"};
     }
 
-    return module;
+    return module_ptr;
 }
 }  // namespace fizzy

--- a/lib/fizzy/parser.hpp
+++ b/lib/fizzy/parser.hpp
@@ -2,6 +2,7 @@
 
 #include "leb128.hpp"
 #include "types.hpp"
+#include <memory>
 #include <stdexcept>
 #include <tuple>
 
@@ -18,7 +19,7 @@ struct parser_error : public std::runtime_error
 template <typename T>
 using parser_result = std::tuple<T, const uint8_t*>;
 
-Module parse(bytes_view input);
+std::shared_ptr<Module> parse(bytes_view input);
 parser_result<Code> parse_expr(const uint8_t* input);
 
 template <typename T>

--- a/test/bench/bench.cpp
+++ b/test/bench/bench.cpp
@@ -44,7 +44,7 @@ void benchmark_instantiate(benchmark::State& state, const fizzy::bytes& wasm_bin
     const auto module = fizzy::parse(wasm_binary);
     for (auto _ : state)  // NOLINT(clang-analyzer-deadcode.DeadStores)
     {
-        auto instance = fizzy::instantiate(&module);
+        auto instance = fizzy::instantiate(module);
         benchmark::DoNotOptimize(instance);
     }
 }
@@ -61,15 +61,15 @@ struct ExecutionBenchmarkCase
 
 void benchmark_execute(benchmark::State& state, const ExecutionBenchmarkCase& benchmark_case)
 {
-    const auto module = fizzy::parse(*benchmark_case.wasm_binary);
-    const auto func_idx = fizzy::find_exported_function(module, benchmark_case.func_name);
+    auto module = fizzy::parse(*benchmark_case.wasm_binary);
+    const auto func_idx = fizzy::find_exported_function(*module, benchmark_case.func_name);
     if (!func_idx)
     {
         return state.SkipWithError(
             ("Function \"" + benchmark_case.func_name + "\" not found").c_str());
     }
 
-    auto instance = fizzy::instantiate(&module, {});
+    auto instance = fizzy::instantiate(std::move(module), {});
 
     // TODO: Check if memory is exported or imported.
     if (benchmark_case.memory.size() > instance.memory.size())

--- a/test/bench/bench.cpp
+++ b/test/bench/bench.cpp
@@ -44,7 +44,7 @@ void benchmark_instantiate(benchmark::State& state, const fizzy::bytes& wasm_bin
     const auto module = fizzy::parse(wasm_binary);
     for (auto _ : state)  // NOLINT(clang-analyzer-deadcode.DeadStores)
     {
-        auto instance = fizzy::instantiate(module);
+        auto instance = fizzy::instantiate(&module);
         benchmark::DoNotOptimize(instance);
     }
 }
@@ -69,7 +69,7 @@ void benchmark_execute(benchmark::State& state, const ExecutionBenchmarkCase& be
             ("Function \"" + benchmark_case.func_name + "\" not found").c_str());
     }
 
-    auto instance = fizzy::instantiate(module, {});
+    auto instance = fizzy::instantiate(&module, {});
 
     // TODO: Check if memory is exported or imported.
     if (benchmark_case.memory.size() > instance.memory.size())

--- a/test/unittests/end_to_end_test.cpp
+++ b/test/unittests/end_to_end_test.cpp
@@ -69,7 +69,7 @@ TEST(end_to_end, milestone2)
 
     const auto module = parse(bin);
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
 
     // This performs uint256 x uint256 -> uint512 multiplication.
     // Arg1: 2^255 + 1
@@ -173,7 +173,7 @@ TEST(end_to_end, memset)
 
     const auto module = parse(bin);
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     const auto [trap, ret] = execute(instance, 1, {0, 2});
 
     ASSERT_FALSE(trap);

--- a/test/unittests/end_to_end_test.cpp
+++ b/test/unittests/end_to_end_test.cpp
@@ -22,12 +22,10 @@ TEST(end_to_end, milestone1)
       )
     )
     */
-
     const auto bin = from_hex(
         "0061736d0100000001070160027f7f017f030201000a13011101017f200020016a20026a220220006a0b");
-    const auto module = parse(bin);
 
-    const auto [trap, ret] = execute(module, 0, {20, 22});
+    const auto [trap, ret] = execute(parse(bin), 0, {20, 22});
 
     ASSERT_FALSE(trap);
     ASSERT_EQ(ret.size(), 1);
@@ -67,9 +65,7 @@ TEST(end_to_end, milestone2)
         "2053742154204f20546a21552055204e3602002005280228215641012157"
         "205620576a2158200520583602280c00000b000b0b");
 
-    const auto module = parse(bin);
-
-    auto instance = instantiate(&module);
+    auto instance = instantiate(parse(bin));
 
     // This performs uint256 x uint256 -> uint512 multiplication.
     // Arg1: 2^255 + 1
@@ -123,10 +119,8 @@ TEST(end_to_end, nested_loops_in_c)
         "20056a21050b200441016a22042000480d000b20050f0b41040f0b41000f"
         "0b20000b");
 
-    const auto module = parse(bin);
-
     // Ignore the results for now
-    const auto [trap, ret] = execute(module, 0, {10, 2, 5});
+    const auto [trap, ret] = execute(parse(bin), 0, {10, 2, 5});
 
     ASSERT_FALSE(trap);
     ASSERT_EQ(ret.size(), 1);
@@ -171,9 +165,7 @@ TEST(end_to_end, memset)
         "0a2c"
         "0202000b2700024020014101480d000340200041d209360200200041046a21002001417f6a22010d000b0b0b");
 
-    const auto module = parse(bin);
-
-    auto instance = instantiate(&module);
+    auto instance = instantiate(parse(bin));
     const auto [trap, ret] = execute(instance, 1, {0, 2});
 
     ASSERT_FALSE(trap);

--- a/test/unittests/execute_control_test.cpp
+++ b/test/unittests/execute_control_test.cpp
@@ -473,7 +473,7 @@ TEST(execute_control, br_1_out_of_function_and_imported_function)
         [](Instance&, std::vector<uint64_t>) noexcept -> execution_result { return {}; };
 
     const auto module = parse(bin);
-    auto instance = instantiate(module, {fake_imported_function});
+    auto instance = instantiate(&module, {fake_imported_function});
     const auto [trap, ret] = execute(instance, 1, {});
     ASSERT_FALSE(trap);
     ASSERT_EQ(ret.size(), 1);

--- a/test/unittests/execute_test.cpp
+++ b/test/unittests/execute_test.cpp
@@ -168,7 +168,7 @@ TEST(execute, global_get)
 
     module.codesec.emplace_back(Code{0, {Instr::global_get, Instr::end}, {0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
 
     const auto [trap, ret] = execute(instance, 0, {});
 
@@ -186,7 +186,7 @@ TEST(execute, global_get_two_globals)
     module.codesec.emplace_back(Code{0, {Instr::global_get, Instr::end}, {0, 0, 0, 0}});
     module.codesec.emplace_back(Code{0, {Instr::global_get, Instr::end}, {1, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
 
     auto [trap, ret] = execute(instance, 0, {});
 
@@ -208,7 +208,7 @@ TEST(execute, global_get_imported)
     module.codesec.emplace_back(Code{0, {Instr::global_get, Instr::end}, {0, 0, 0, 0}});
 
     uint64_t global_value = 42;
-    auto instance = instantiate(module, {}, {ImportedGlobal{&global_value, false}});
+    auto instance = instantiate(&module, {}, {ImportedGlobal{&global_value, false}});
 
     const auto [trap, ret] = execute(instance, 0, {});
 
@@ -233,7 +233,7 @@ TEST(execute, global_set)
     module.codesec.emplace_back(
         Code{0, {Instr::i32_const, Instr::global_set, Instr::end}, {42, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
 
     const auto [trap, ret] = execute(instance, 0, {});
 
@@ -251,7 +251,7 @@ TEST(execute, global_set_two_globals)
         {Instr::i32_const, Instr::global_set, Instr::i32_const, Instr::global_set, Instr::end},
         {44, 0, 0, 0, 0, 0, 0, 0, 45, 0, 0, 0, 1, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
 
     const auto [trap, ret] = execute(instance, 0, {});
 
@@ -268,7 +268,7 @@ TEST(execute, global_set_imported)
         Code{0, {Instr::i32_const, Instr::global_set, Instr::end}, {42, 0, 0, 0, 0, 0, 0, 0}});
 
     uint64_t global_value = 41;
-    auto instance = instantiate(module, {}, {ImportedGlobal{&global_value, true}});
+    auto instance = instantiate(&module, {}, {ImportedGlobal{&global_value, true}});
 
     const auto [trap, ret] = execute(instance, 0, {});
 
@@ -308,7 +308,7 @@ TEST(execute, i32_load)
     module.codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i32_load, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     instance.memory[0] = 42;
     const auto [trap, ret] = execute(instance, 0, {0});
 
@@ -326,7 +326,7 @@ TEST(execute, i64_load)
     module.codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i64_load, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     instance.memory[0] = 0x2a;
     instance.memory[4] = 0x2a;
     const auto [trap, ret] = execute(instance, 0, {0});
@@ -345,7 +345,7 @@ TEST(execute, i32_load8_s)
     module.codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i32_load8_s, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     instance.memory[0] = 0x80;
     instance.memory[1] = 0xf1;
     const auto [trap, ret] = execute(instance, 0, {0});
@@ -364,7 +364,7 @@ TEST(execute, i32_load8_u)
     module.codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i32_load8_u, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     instance.memory[0] = 0x81;
     instance.memory[1] = 0xf1;
     const auto [trap, ret] = execute(instance, 0, {0});
@@ -383,7 +383,7 @@ TEST(execute, i32_load16_s)
     module.codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i32_load16_s, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     instance.memory[0] = 0x00;
     instance.memory[1] = 0x80;
     instance.memory[3] = 0xf1;
@@ -403,7 +403,7 @@ TEST(execute, i32_load16_u)
     module.codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i32_load16_u, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     instance.memory[0] = 0x01;
     instance.memory[1] = 0x80;
     instance.memory[3] = 0xf1;
@@ -423,7 +423,7 @@ TEST(execute, i64_load8_s)
     module.codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i64_load8_s, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     instance.memory[0] = 0x80;
     instance.memory[1] = 0xf1;
     const auto [trap, ret] = execute(instance, 0, {0});
@@ -442,7 +442,7 @@ TEST(execute, i64_load8_u)
     module.codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i64_load8_u, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     instance.memory[0] = 0x81;
     instance.memory[1] = 0xf1;
     const auto [trap, ret] = execute(instance, 0, {0});
@@ -461,7 +461,7 @@ TEST(execute, i64_load16_s)
     module.codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i64_load16_s, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     instance.memory[0] = 0x00;
     instance.memory[1] = 0x80;
     instance.memory[2] = 0xf1;
@@ -481,7 +481,7 @@ TEST(execute, i64_load16_u)
     module.codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i64_load16_u, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     instance.memory[0] = 0x01;
     instance.memory[1] = 0x80;
     instance.memory[2] = 0xf1;
@@ -501,7 +501,7 @@ TEST(execute, i64_load32_s)
     module.codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i64_load32_s, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     instance.memory[0] = 0x00;
     instance.memory[1] = 0x00;
     instance.memory[2] = 0x00;
@@ -523,7 +523,7 @@ TEST(execute, i64_load32_u)
     module.codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i64_load32_u, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     instance.memory[0] = 0x01;
     instance.memory[1] = 0x00;
     instance.memory[2] = 0x00;
@@ -546,7 +546,7 @@ TEST(execute, i32_store)
         Code{0, {Instr::local_get, Instr::local_get, Instr::i32_store, Instr::end},
             {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     const auto [trap, ret] = execute(instance, 0, {42, 0});
 
     ASSERT_FALSE(trap);
@@ -564,7 +564,7 @@ TEST(execute, i64_store)
         Code{0, {Instr::local_get, Instr::local_get, Instr::i64_store, Instr::end},
             {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     const auto [trap, ret] = execute(instance, 0, {0x2a0000002a, 0});
 
     ASSERT_FALSE(trap);
@@ -582,7 +582,7 @@ TEST(execute, i32_store8)
         Code{0, {Instr::local_get, Instr::local_get, Instr::i32_store8, Instr::end},
             {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     const auto [trap, ret] = execute(instance, 0, {0xf1f2f380, 0});
 
     ASSERT_FALSE(trap);
@@ -600,7 +600,7 @@ TEST(execute, i32_store8_trap)
         Code{0, {Instr::local_get, Instr::local_get, Instr::i32_store8, Instr::end},
             {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     const auto [trap, ret] = execute(instance, 0, {0xf1f2f380, 65537});
 
     ASSERT_TRUE(trap);
@@ -614,7 +614,7 @@ TEST(execute, i32_store16)
         Code{0, {Instr::local_get, Instr::local_get, Instr::i32_store16, Instr::end},
             {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     const auto [trap, ret] = execute(instance, 0, {0xf1f28000, 0});
 
     ASSERT_FALSE(trap);
@@ -632,7 +632,7 @@ TEST(execute, i64_store8)
         Code{0, {Instr::local_get, Instr::local_get, Instr::i64_store8, Instr::end},
             {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     const auto [trap, ret] = execute(instance, 0, {0xf1f2f4f5f6f7f880, 0});
 
     ASSERT_FALSE(trap);
@@ -650,7 +650,7 @@ TEST(execute, i64_store16)
         Code{0, {Instr::local_get, Instr::local_get, Instr::i64_store16, Instr::end},
             {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     const auto [trap, ret] = execute(instance, 0, {0xf1f2f4f5f6f78000, 0});
 
     ASSERT_FALSE(trap);
@@ -668,7 +668,7 @@ TEST(execute, i64_store32)
         Code{0, {Instr::local_get, Instr::local_get, Instr::i64_store32, Instr::end},
             {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     const auto [trap, ret] = execute(instance, 0, {0xf1f2f4f580000000, 0});
 
     ASSERT_FALSE(trap);
@@ -1754,7 +1754,7 @@ TEST(execute, start_section)
         Code{0, {Instr::i32_const, Instr::i32_const, Instr::i32_store, Instr::end},
             {0, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     // Start function sets this
     ASSERT_EQ(instance.memory.substr(0, 4), from_hex("2a000000"));
 
@@ -1776,7 +1776,7 @@ TEST(execute, imported_function)
         return {false, {args[0] + args[1]}};
     };
 
-    auto instance = instantiate(module, {host_foo});
+    auto instance = instantiate(&module, {host_foo});
 
     const auto [trap, ret] = execute(instance, 0, {20, 22});
 
@@ -1799,7 +1799,7 @@ TEST(execute, imported_two_functions)
         return {false, {args[0] * args[1]}};
     };
 
-    auto instance = instantiate(module, {host_foo1, host_foo2});
+    auto instance = instantiate(&module, {host_foo1, host_foo2});
 
     const auto [trap1, ret1] = execute(instance, 0, {20, 22});
 
@@ -1830,7 +1830,7 @@ TEST(execute, imported_functions_and_regular_one)
         return {false, {args[0] * args[0]}};
     };
 
-    auto instance = instantiate(module, {host_foo1, host_foo2});
+    auto instance = instantiate(&module, {host_foo1, host_foo2});
 
     const auto [trap1, ret1] = execute(instance, 0, {20, 22});
 
@@ -1849,7 +1849,7 @@ TEST(execute, imported_functions_and_regular_one)
         return {false, {args.size()}};
     };
 
-    auto instance_couner = instantiate(module, {count_args, count_args});
+    auto instance_couner = instantiate(&module, {count_args, count_args});
 
     const auto [trap3, ret3] = execute(instance_couner, 0, {20, 22});
 
@@ -1880,7 +1880,7 @@ TEST(execute, imported_two_functions_different_type)
         return {false, {args[0] * args[0]}};
     };
 
-    auto instance = instantiate(module, {host_foo1, host_foo2});
+    auto instance = instantiate(&module, {host_foo1, host_foo2});
 
     const auto [trap1, ret1] = execute(instance, 0, {20, 22});
 
@@ -1909,7 +1909,7 @@ TEST(execute, imported_function_traps)
 
     auto host_foo = [](Instance&, std::vector<uint64_t>) -> execution_result { return {true, {}}; };
 
-    auto instance = instantiate(module, {host_foo});
+    auto instance = instantiate(&module, {host_foo});
 
     const auto [trap, ret] = execute(instance, 0, {20, 22});
 
@@ -1928,7 +1928,7 @@ TEST(execute, imported_function_call)
         return {false, {42}};
     };
 
-    auto instance = instantiate(module, {host_foo});
+    auto instance = instantiate(&module, {host_foo});
 
     const auto [trap, ret] = execute(instance, 1, {});
 
@@ -1951,7 +1951,7 @@ TEST(execute, imported_function_call_with_arguments)
         return {false, {args[0] * 2}};
     };
 
-    auto instance = instantiate(module, {host_foo});
+    auto instance = instantiate(&module, {host_foo});
 
     const auto [trap, ret] = execute(instance, 1, {20});
 
@@ -1989,7 +1989,7 @@ TEST(execute, memory_copy_32bytes)
         "030837030820002001290310370310200020012903183703180b000e046e616d65020701000200000100");
 
     const auto module = parse(bin);
-    auto instance = instantiate(module);
+    auto instance = instantiate(&module);
     ASSERT_EQ(instance.memory.size(), 65536);
     const auto input = from_hex("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
     ASSERT_EQ(input.size(), 32);

--- a/test/unittests/execute_test.cpp
+++ b/test/unittests/execute_test.cpp
@@ -9,16 +9,16 @@ namespace
 {
 execution_result execute_unary_operation(Instr instr, uint64_t arg)
 {
-    Module module;
-    module.codesec.emplace_back(Code{0, {Instr::local_get, instr, Instr::end}, {0, 0, 0, 0}});
+    auto module = std::make_shared<Module>();
+    module->codesec.emplace_back(Code{0, {Instr::local_get, instr, Instr::end}, {0, 0, 0, 0}});
 
     return execute(module, 0, {arg});
 }
 
 execution_result execute_binary_operation(Instr instr, uint64_t lhs, uint64_t rhs)
 {
-    Module module;
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::local_get, instr, Instr::end}, {0, 0, 0, 0, 1, 0, 0, 0}});
 
     return execute(module, 0, {lhs, rhs});
@@ -27,8 +27,8 @@ execution_result execute_binary_operation(Instr instr, uint64_t lhs, uint64_t rh
 
 TEST(execute, end)
 {
-    Module module;
-    module.codesec.emplace_back(Code{0, {Instr::end}, {}});
+    auto module = std::make_shared<Module>();
+    module->codesec.emplace_back(Code{0, {Instr::end}, {}});
 
     const auto [trap, ret] = execute(module, 0, {});
 
@@ -38,12 +38,12 @@ TEST(execute, end)
 
 TEST(execute, call)
 {
-    Module module;
-    module.typesec.emplace_back(FuncType{{}, {ValType::i32}});
-    module.funcsec.emplace_back(TypeIdx{0});
-    module.funcsec.emplace_back(TypeIdx{0});
-    module.codesec.emplace_back(Code{0, {Instr::i32_const, Instr::end}, {42, 0, 42, 0}});
-    module.codesec.emplace_back(Code{0, {Instr::call, Instr::end}, {0, 0, 0, 0}});
+    auto module = std::make_shared<Module>();
+    module->typesec.emplace_back(FuncType{{}, {ValType::i32}});
+    module->funcsec.emplace_back(TypeIdx{0});
+    module->funcsec.emplace_back(TypeIdx{0});
+    module->codesec.emplace_back(Code{0, {Instr::i32_const, Instr::end}, {42, 0, 42, 0}});
+    module->codesec.emplace_back(Code{0, {Instr::call, Instr::end}, {0, 0, 0, 0}});
 
     const auto [trap, ret] = execute(module, 1, {});
 
@@ -54,12 +54,12 @@ TEST(execute, call)
 
 TEST(execute, call_trap)
 {
-    Module module;
-    module.typesec.emplace_back(FuncType{{}, {ValType::i32}});
-    module.funcsec.emplace_back(TypeIdx{0});
-    module.funcsec.emplace_back(TypeIdx{0});
-    module.codesec.emplace_back(Code{0, {Instr::unreachable, Instr::end}, {}});
-    module.codesec.emplace_back(Code{0, {Instr::call, Instr::end}, {0, 0, 0, 0}});
+    auto module = std::make_shared<Module>();
+    module->typesec.emplace_back(FuncType{{}, {ValType::i32}});
+    module->funcsec.emplace_back(TypeIdx{0});
+    module->funcsec.emplace_back(TypeIdx{0});
+    module->codesec.emplace_back(Code{0, {Instr::unreachable, Instr::end}, {}});
+    module->codesec.emplace_back(Code{0, {Instr::call, Instr::end}, {0, 0, 0, 0}});
 
     const auto [trap, ret] = execute(module, 1, {});
 
@@ -68,13 +68,13 @@ TEST(execute, call_trap)
 
 TEST(execute, call_with_arguments)
 {
-    Module module;
-    module.typesec.emplace_back(FuncType{{ValType::i32, ValType::i32}, {ValType::i32}});
-    module.typesec.emplace_back(FuncType{{}, {ValType::i32}});
-    module.funcsec.emplace_back(TypeIdx{0});
-    module.funcsec.emplace_back(TypeIdx{1});
-    module.codesec.emplace_back(Code{2, {Instr::local_get, Instr::end}, {0, 0, 0, 0}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->typesec.emplace_back(FuncType{{ValType::i32, ValType::i32}, {ValType::i32}});
+    module->typesec.emplace_back(FuncType{{}, {ValType::i32}});
+    module->funcsec.emplace_back(TypeIdx{0});
+    module->funcsec.emplace_back(TypeIdx{1});
+    module->codesec.emplace_back(Code{2, {Instr::local_get, Instr::end}, {0, 0, 0, 0}});
+    module->codesec.emplace_back(
         Code{0, {Instr::i32_const, Instr::i32_const, Instr::call, Instr::end},
             {1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0}});
 
@@ -87,8 +87,9 @@ TEST(execute, call_with_arguments)
 
 TEST(execute, drop)
 {
-    Module module;
-    module.codesec.emplace_back(Code{1, {Instr::local_get, Instr::drop, Instr::end}, {0, 0, 0, 0}});
+    auto module = std::make_shared<Module>();
+    module->codesec.emplace_back(
+        Code{1, {Instr::local_get, Instr::drop, Instr::end}, {0, 0, 0, 0}});
 
     const auto [trap, ret] = execute(module, 0, {});
 
@@ -98,8 +99,8 @@ TEST(execute, drop)
 
 TEST(execute, select)
 {
-    Module module;
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::local_get, Instr::local_get, Instr::select, Instr::end},
             {0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0}});
 
@@ -124,8 +125,8 @@ TEST(execute, select)
 
 TEST(execute, local_get)
 {
-    Module module;
-    module.codesec.emplace_back(Code{0, {Instr::local_get, Instr::end}, {0, 0, 0, 0}});
+    auto module = std::make_shared<Module>();
+    module->codesec.emplace_back(Code{0, {Instr::local_get, Instr::end}, {0, 0, 0, 0}});
 
     const auto [trap, ret] = execute(module, 0, {42});
 
@@ -136,8 +137,8 @@ TEST(execute, local_get)
 
 TEST(execute, local_set)
 {
-    Module module;
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->codesec.emplace_back(
         Code{1, {Instr::local_get, Instr::local_set, Instr::local_get, Instr::end},
             {0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0}});
 
@@ -150,8 +151,8 @@ TEST(execute, local_set)
 
 TEST(execute, local_tee)
 {
-    Module module;
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->codesec.emplace_back(
         Code{1, {Instr::local_get, Instr::local_tee, Instr::end}, {0, 0, 0, 0, 1, 0, 0, 0}});
 
     const auto [trap, ret] = execute(module, 0, {42});
@@ -163,12 +164,12 @@ TEST(execute, local_tee)
 
 TEST(execute, global_get)
 {
-    Module module;
-    module.globalsec.emplace_back(Global{true, {ConstantExpression::Kind::Constant, {42}}});
+    auto module = std::make_shared<Module>();
+    module->globalsec.emplace_back(Global{true, {ConstantExpression::Kind::Constant, {42}}});
 
-    module.codesec.emplace_back(Code{0, {Instr::global_get, Instr::end}, {0, 0, 0, 0}});
+    module->codesec.emplace_back(Code{0, {Instr::global_get, Instr::end}, {0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
 
     const auto [trap, ret] = execute(instance, 0, {});
 
@@ -179,14 +180,14 @@ TEST(execute, global_get)
 
 TEST(execute, global_get_two_globals)
 {
-    Module module;
-    module.globalsec.emplace_back(Global{true, {ConstantExpression::Kind::Constant, {42}}});
-    module.globalsec.emplace_back(Global{true, {ConstantExpression::Kind::Constant, {43}}});
+    auto module = std::make_shared<Module>();
+    module->globalsec.emplace_back(Global{true, {ConstantExpression::Kind::Constant, {42}}});
+    module->globalsec.emplace_back(Global{true, {ConstantExpression::Kind::Constant, {43}}});
 
-    module.codesec.emplace_back(Code{0, {Instr::global_get, Instr::end}, {0, 0, 0, 0}});
-    module.codesec.emplace_back(Code{0, {Instr::global_get, Instr::end}, {1, 0, 0, 0}});
+    module->codesec.emplace_back(Code{0, {Instr::global_get, Instr::end}, {0, 0, 0, 0}});
+    module->codesec.emplace_back(Code{0, {Instr::global_get, Instr::end}, {1, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
 
     auto [trap, ret] = execute(instance, 0, {});
 
@@ -203,12 +204,12 @@ TEST(execute, global_get_two_globals)
 
 TEST(execute, global_get_imported)
 {
-    Module module;
-    module.importsec.emplace_back(Import{"mod", "glob", ExternalKind::Global, {false}});
-    module.codesec.emplace_back(Code{0, {Instr::global_get, Instr::end}, {0, 0, 0, 0}});
+    auto module = std::make_shared<Module>();
+    module->importsec.emplace_back(Import{"mod", "glob", ExternalKind::Global, {false}});
+    module->codesec.emplace_back(Code{0, {Instr::global_get, Instr::end}, {0, 0, 0, 0}});
 
     uint64_t global_value = 42;
-    auto instance = instantiate(&module, {}, {ImportedGlobal{&global_value, false}});
+    auto instance = instantiate(std::move(module), {}, {ImportedGlobal{&global_value, false}});
 
     const auto [trap, ret] = execute(instance, 0, {});
 
@@ -227,13 +228,13 @@ TEST(execute, global_get_imported)
 
 TEST(execute, global_set)
 {
-    Module module;
-    module.globalsec.emplace_back(Global{true, {ConstantExpression::Kind::Constant, {41}}});
+    auto module = std::make_shared<Module>();
+    module->globalsec.emplace_back(Global{true, {ConstantExpression::Kind::Constant, {41}}});
 
-    module.codesec.emplace_back(
+    module->codesec.emplace_back(
         Code{0, {Instr::i32_const, Instr::global_set, Instr::end}, {42, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
 
     const auto [trap, ret] = execute(instance, 0, {});
 
@@ -243,15 +244,15 @@ TEST(execute, global_set)
 
 TEST(execute, global_set_two_globals)
 {
-    Module module;
-    module.globalsec.emplace_back(Global{true, {ConstantExpression::Kind::Constant, {42}}});
-    module.globalsec.emplace_back(Global{true, {ConstantExpression::Kind::Constant, {43}}});
+    auto module = std::make_shared<Module>();
+    module->globalsec.emplace_back(Global{true, {ConstantExpression::Kind::Constant, {42}}});
+    module->globalsec.emplace_back(Global{true, {ConstantExpression::Kind::Constant, {43}}});
 
-    module.codesec.emplace_back(Code{0,
+    module->codesec.emplace_back(Code{0,
         {Instr::i32_const, Instr::global_set, Instr::i32_const, Instr::global_set, Instr::end},
         {44, 0, 0, 0, 0, 0, 0, 0, 45, 0, 0, 0, 1, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
 
     const auto [trap, ret] = execute(instance, 0, {});
 
@@ -262,13 +263,13 @@ TEST(execute, global_set_two_globals)
 
 TEST(execute, global_set_imported)
 {
-    Module module;
-    module.importsec.emplace_back(Import{"mod", "glob", ExternalKind::Global, {true}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->importsec.emplace_back(Import{"mod", "glob", ExternalKind::Global, {true}});
+    module->codesec.emplace_back(
         Code{0, {Instr::i32_const, Instr::global_set, Instr::end}, {42, 0, 0, 0, 0, 0, 0, 0}});
 
     uint64_t global_value = 41;
-    auto instance = instantiate(&module, {}, {ImportedGlobal{&global_value, true}});
+    auto instance = instantiate(std::move(module), {}, {ImportedGlobal{&global_value, true}});
 
     const auto [trap, ret] = execute(instance, 0, {});
 
@@ -278,8 +279,8 @@ TEST(execute, global_set_imported)
 
 TEST(execute, i32_const)
 {
-    Module module;
-    module.codesec.emplace_back(Code{0, {Instr::i32_const, Instr::end}, {0x42, 0, 0x42, 0}});
+    auto module = std::make_shared<Module>();
+    module->codesec.emplace_back(Code{0, {Instr::i32_const, Instr::end}, {0x42, 0, 0x42, 0}});
 
     const auto [trap, ret] = execute(module, 0, {});
 
@@ -290,8 +291,8 @@ TEST(execute, i32_const)
 
 TEST(execute, i64_const)
 {
-    Module module;
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->codesec.emplace_back(
         Code{0, {Instr::i64_const, Instr::end}, {0x42, 0, 0x42, 0, 0, 0, 0, 1}});
 
     const auto [trap, ret] = execute(module, 0, {});
@@ -303,12 +304,12 @@ TEST(execute, i64_const)
 
 TEST(execute, i32_load)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i32_load, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     instance.memory[0] = 42;
     const auto [trap, ret] = execute(instance, 0, {0});
 
@@ -321,12 +322,12 @@ TEST(execute, i32_load)
 
 TEST(execute, i64_load)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i64_load, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     instance.memory[0] = 0x2a;
     instance.memory[4] = 0x2a;
     const auto [trap, ret] = execute(instance, 0, {0});
@@ -340,12 +341,12 @@ TEST(execute, i64_load)
 
 TEST(execute, i32_load8_s)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i32_load8_s, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     instance.memory[0] = 0x80;
     instance.memory[1] = 0xf1;
     const auto [trap, ret] = execute(instance, 0, {0});
@@ -359,12 +360,12 @@ TEST(execute, i32_load8_s)
 
 TEST(execute, i32_load8_u)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i32_load8_u, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     instance.memory[0] = 0x81;
     instance.memory[1] = 0xf1;
     const auto [trap, ret] = execute(instance, 0, {0});
@@ -378,12 +379,12 @@ TEST(execute, i32_load8_u)
 
 TEST(execute, i32_load16_s)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i32_load16_s, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     instance.memory[0] = 0x00;
     instance.memory[1] = 0x80;
     instance.memory[3] = 0xf1;
@@ -398,12 +399,12 @@ TEST(execute, i32_load16_s)
 
 TEST(execute, i32_load16_u)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i32_load16_u, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     instance.memory[0] = 0x01;
     instance.memory[1] = 0x80;
     instance.memory[3] = 0xf1;
@@ -418,12 +419,12 @@ TEST(execute, i32_load16_u)
 
 TEST(execute, i64_load8_s)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i64_load8_s, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     instance.memory[0] = 0x80;
     instance.memory[1] = 0xf1;
     const auto [trap, ret] = execute(instance, 0, {0});
@@ -437,12 +438,12 @@ TEST(execute, i64_load8_s)
 
 TEST(execute, i64_load8_u)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i64_load8_u, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     instance.memory[0] = 0x81;
     instance.memory[1] = 0xf1;
     const auto [trap, ret] = execute(instance, 0, {0});
@@ -456,12 +457,12 @@ TEST(execute, i64_load8_u)
 
 TEST(execute, i64_load16_s)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i64_load16_s, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     instance.memory[0] = 0x00;
     instance.memory[1] = 0x80;
     instance.memory[2] = 0xf1;
@@ -476,12 +477,12 @@ TEST(execute, i64_load16_s)
 
 TEST(execute, i64_load16_u)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i64_load16_u, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     instance.memory[0] = 0x01;
     instance.memory[1] = 0x80;
     instance.memory[2] = 0xf1;
@@ -496,12 +497,12 @@ TEST(execute, i64_load16_u)
 
 TEST(execute, i64_load32_s)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i64_load32_s, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     instance.memory[0] = 0x00;
     instance.memory[1] = 0x00;
     instance.memory[2] = 0x00;
@@ -518,12 +519,12 @@ TEST(execute, i64_load32_s)
 
 TEST(execute, i64_load32_u)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::i64_load32_u, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     instance.memory[0] = 0x01;
     instance.memory[1] = 0x00;
     instance.memory[2] = 0x00;
@@ -540,13 +541,13 @@ TEST(execute, i64_load32_u)
 
 TEST(execute, i32_store)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::local_get, Instr::i32_store, Instr::end},
             {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     const auto [trap, ret] = execute(instance, 0, {42, 0});
 
     ASSERT_FALSE(trap);
@@ -558,13 +559,13 @@ TEST(execute, i32_store)
 
 TEST(execute, i64_store)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::local_get, Instr::i64_store, Instr::end},
             {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     const auto [trap, ret] = execute(instance, 0, {0x2a0000002a, 0});
 
     ASSERT_FALSE(trap);
@@ -576,13 +577,13 @@ TEST(execute, i64_store)
 
 TEST(execute, i32_store8)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::local_get, Instr::i32_store8, Instr::end},
             {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     const auto [trap, ret] = execute(instance, 0, {0xf1f2f380, 0});
 
     ASSERT_FALSE(trap);
@@ -594,13 +595,13 @@ TEST(execute, i32_store8)
 
 TEST(execute, i32_store8_trap)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::local_get, Instr::i32_store8, Instr::end},
             {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     const auto [trap, ret] = execute(instance, 0, {0xf1f2f380, 65537});
 
     ASSERT_TRUE(trap);
@@ -608,13 +609,13 @@ TEST(execute, i32_store8_trap)
 
 TEST(execute, i32_store16)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::local_get, Instr::i32_store16, Instr::end},
             {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     const auto [trap, ret] = execute(instance, 0, {0xf1f28000, 0});
 
     ASSERT_FALSE(trap);
@@ -626,13 +627,13 @@ TEST(execute, i32_store16)
 
 TEST(execute, i64_store8)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::local_get, Instr::i64_store8, Instr::end},
             {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     const auto [trap, ret] = execute(instance, 0, {0xf1f2f4f5f6f7f880, 0});
 
     ASSERT_FALSE(trap);
@@ -644,13 +645,13 @@ TEST(execute, i64_store8)
 
 TEST(execute, i64_store16)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::local_get, Instr::i64_store16, Instr::end},
             {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     const auto [trap, ret] = execute(instance, 0, {0xf1f2f4f5f6f78000, 0});
 
     ASSERT_FALSE(trap);
@@ -662,13 +663,13 @@ TEST(execute, i64_store16)
 
 TEST(execute, i64_store32)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::local_get, Instr::i64_store32, Instr::end},
             {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     const auto [trap, ret] = execute(instance, 0, {0xf1f2f4f580000000, 0});
 
     ASSERT_FALSE(trap);
@@ -680,9 +681,9 @@ TEST(execute, i64_store32)
 
 TEST(execute, memory_size)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(Code{0, {Instr::memory_size, Instr::end}, {}});
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(Code{0, {Instr::memory_size, Instr::end}, {}});
 
     const auto [trap, ret] = execute(module, 0, {});
 
@@ -692,9 +693,9 @@ TEST(execute, memory_size)
 
 TEST(execute, memory_grow)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 4096}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->memorysec.emplace_back(Memory{{1, 4096}});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::memory_grow, Instr::end}, {0, 0, 0, 0}});
 
     auto result = execute(module, 0, {0});
@@ -1745,16 +1746,16 @@ TEST(execute, start_section)
 {
     // In this test the start function (index 1) writes a i32 value to the memory
     // and the same is read back in the "main" function (index 0).
-    Module module;
-    module.startfunc = 1;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->startfunc = 1;
+    module->memorysec.emplace_back(Memory{{1, 1}});
+    module->codesec.emplace_back(
         Code{0, {Instr::i32_const, Instr::i32_load, Instr::end}, {0, 0, 0, 0, 0, 0, 0, 0}});
-    module.codesec.emplace_back(
+    module->codesec.emplace_back(
         Code{0, {Instr::i32_const, Instr::i32_const, Instr::i32_store, Instr::end},
             {0, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0}});
 
-    auto instance = instantiate(&module);
+    auto instance = instantiate(std::move(module));
     // Start function sets this
     ASSERT_EQ(instance.memory.substr(0, 4), from_hex("2a000000"));
 
@@ -1768,15 +1769,15 @@ TEST(execute, start_section)
 
 TEST(execute, imported_function)
 {
-    Module module;
-    module.typesec.emplace_back(FuncType{{ValType::i32, ValType::i32}, {ValType::i32}});
-    module.importsec.emplace_back(Import{"mod", "foo", ExternalKind::Function, {0}});
+    auto module = std::make_shared<Module>();
+    module->typesec.emplace_back(FuncType{{ValType::i32, ValType::i32}, {ValType::i32}});
+    module->importsec.emplace_back(Import{"mod", "foo", ExternalKind::Function, {0}});
 
     auto host_foo = [](Instance&, std::vector<uint64_t> args) -> execution_result {
         return {false, {args[0] + args[1]}};
     };
 
-    auto instance = instantiate(&module, {host_foo});
+    auto instance = instantiate(std::move(module), {host_foo});
 
     const auto [trap, ret] = execute(instance, 0, {20, 22});
 
@@ -1787,10 +1788,10 @@ TEST(execute, imported_function)
 
 TEST(execute, imported_two_functions)
 {
-    Module module;
-    module.typesec.emplace_back(FuncType{{ValType::i32, ValType::i32}, {ValType::i32}});
-    module.importsec.emplace_back(Import{"mod", "foo1", ExternalKind::Function, {0}});
-    module.importsec.emplace_back(Import{"mod", "foo2", ExternalKind::Function, {0}});
+    auto module = std::make_shared<Module>();
+    module->typesec.emplace_back(FuncType{{ValType::i32, ValType::i32}, {ValType::i32}});
+    module->importsec.emplace_back(Import{"mod", "foo1", ExternalKind::Function, {0}});
+    module->importsec.emplace_back(Import{"mod", "foo2", ExternalKind::Function, {0}});
 
     auto host_foo1 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
         return {false, {args[0] + args[1]}};
@@ -1799,7 +1800,7 @@ TEST(execute, imported_two_functions)
         return {false, {args[0] * args[1]}};
     };
 
-    auto instance = instantiate(&module, {host_foo1, host_foo2});
+    auto instance = instantiate(std::move(module), {host_foo1, host_foo2});
 
     const auto [trap1, ret1] = execute(instance, 0, {20, 22});
 
@@ -1816,12 +1817,12 @@ TEST(execute, imported_two_functions)
 
 TEST(execute, imported_functions_and_regular_one)
 {
-    Module module;
-    module.typesec.emplace_back(FuncType{{ValType::i32, ValType::i32}, {ValType::i32}});
-    module.typesec.emplace_back(FuncType{{ValType::i64}, {ValType::i64}});
-    module.importsec.emplace_back(Import{"mod", "foo1", ExternalKind::Function, {0}});
-    module.importsec.emplace_back(Import{"mod", "foo2", ExternalKind::Function, {0}});
-    module.codesec.emplace_back(Code{0, {Instr::i32_const, Instr::end}, {42, 0, 42, 0}});
+    const auto module = std::make_shared<Module>();
+    module->typesec.emplace_back(FuncType{{ValType::i32, ValType::i32}, {ValType::i32}});
+    module->typesec.emplace_back(FuncType{{ValType::i64}, {ValType::i64}});
+    module->importsec.emplace_back(Import{"mod", "foo1", ExternalKind::Function, {0}});
+    module->importsec.emplace_back(Import{"mod", "foo2", ExternalKind::Function, {0}});
+    module->codesec.emplace_back(Code{0, {Instr::i32_const, Instr::end}, {42, 0, 42, 0}});
 
     auto host_foo1 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
         return {false, {args[0] + args[1]}};
@@ -1830,7 +1831,7 @@ TEST(execute, imported_functions_and_regular_one)
         return {false, {args[0] * args[0]}};
     };
 
-    auto instance = instantiate(&module, {host_foo1, host_foo2});
+    auto instance = instantiate(module, {host_foo1, host_foo2});
 
     const auto [trap1, ret1] = execute(instance, 0, {20, 22});
 
@@ -1849,7 +1850,7 @@ TEST(execute, imported_functions_and_regular_one)
         return {false, {args.size()}};
     };
 
-    auto instance_couner = instantiate(&module, {count_args, count_args});
+    auto instance_couner = instantiate(module, {count_args, count_args});
 
     const auto [trap3, ret3] = execute(instance_couner, 0, {20, 22});
 
@@ -1866,12 +1867,12 @@ TEST(execute, imported_functions_and_regular_one)
 
 TEST(execute, imported_two_functions_different_type)
 {
-    Module module;
-    module.typesec.emplace_back(FuncType{{ValType::i32, ValType::i32}, {ValType::i32}});
-    module.typesec.emplace_back(FuncType{{ValType::i64}, {ValType::i64}});
-    module.importsec.emplace_back(Import{"mod", "foo1", ExternalKind::Function, {0}});
-    module.importsec.emplace_back(Import{"mod", "foo2", ExternalKind::Function, {0}});
-    module.codesec.emplace_back(Code{0, {Instr::i32_const, Instr::end}, {42, 0, 42, 0}});
+    auto module = std::make_shared<Module>();
+    module->typesec.emplace_back(FuncType{{ValType::i32, ValType::i32}, {ValType::i32}});
+    module->typesec.emplace_back(FuncType{{ValType::i64}, {ValType::i64}});
+    module->importsec.emplace_back(Import{"mod", "foo1", ExternalKind::Function, {0}});
+    module->importsec.emplace_back(Import{"mod", "foo2", ExternalKind::Function, {0}});
+    module->codesec.emplace_back(Code{0, {Instr::i32_const, Instr::end}, {42, 0, 42, 0}});
 
     auto host_foo1 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
         return {false, {args[0] + args[1]}};
@@ -1880,7 +1881,7 @@ TEST(execute, imported_two_functions_different_type)
         return {false, {args[0] * args[0]}};
     };
 
-    auto instance = instantiate(&module, {host_foo1, host_foo2});
+    auto instance = instantiate(std::move(module), {host_foo1, host_foo2});
 
     const auto [trap1, ret1] = execute(instance, 0, {20, 22});
 
@@ -1903,13 +1904,13 @@ TEST(execute, imported_two_functions_different_type)
 
 TEST(execute, imported_function_traps)
 {
-    Module module;
-    module.typesec.emplace_back(FuncType{{ValType::i32, ValType::i32}, {ValType::i32}});
-    module.importsec.emplace_back(Import{"mod", "foo", ExternalKind::Function, {0}});
+    auto module = std::make_shared<Module>();
+    module->typesec.emplace_back(FuncType{{ValType::i32, ValType::i32}, {ValType::i32}});
+    module->importsec.emplace_back(Import{"mod", "foo", ExternalKind::Function, {0}});
 
     auto host_foo = [](Instance&, std::vector<uint64_t>) -> execution_result { return {true, {}}; };
 
-    auto instance = instantiate(&module, {host_foo});
+    auto instance = instantiate(std::move(module), {host_foo});
 
     const auto [trap, ret] = execute(instance, 0, {20, 22});
 
@@ -1918,17 +1919,17 @@ TEST(execute, imported_function_traps)
 
 TEST(execute, imported_function_call)
 {
-    Module module;
-    module.typesec.emplace_back(FuncType{{}, {ValType::i32}});
-    module.importsec.emplace_back(Import{"mod", "foo", ExternalKind::Function, {0}});
-    module.funcsec.emplace_back(TypeIdx{0});
-    module.codesec.emplace_back(Code{0, {Instr::call, Instr::end}, {0, 0, 0, 0}});
+    auto module = std::make_shared<Module>();
+    module->typesec.emplace_back(FuncType{{}, {ValType::i32}});
+    module->importsec.emplace_back(Import{"mod", "foo", ExternalKind::Function, {0}});
+    module->funcsec.emplace_back(TypeIdx{0});
+    module->codesec.emplace_back(Code{0, {Instr::call, Instr::end}, {0, 0, 0, 0}});
 
     auto host_foo = [](Instance&, std::vector<uint64_t>) -> execution_result {
         return {false, {42}};
     };
 
-    auto instance = instantiate(&module, {host_foo});
+    auto instance = instantiate(std::move(module), {host_foo});
 
     const auto [trap, ret] = execute(instance, 1, {});
 
@@ -1939,11 +1940,11 @@ TEST(execute, imported_function_call)
 
 TEST(execute, imported_function_call_with_arguments)
 {
-    Module module;
-    module.typesec.emplace_back(FuncType{{ValType::i32}, {ValType::i32}});
-    module.importsec.emplace_back(Import{"mod", "foo", ExternalKind::Function, {0}});
-    module.funcsec.emplace_back(TypeIdx{0});
-    module.codesec.emplace_back(
+    auto module = std::make_shared<Module>();
+    module->typesec.emplace_back(FuncType{{ValType::i32}, {ValType::i32}});
+    module->importsec.emplace_back(Import{"mod", "foo", ExternalKind::Function, {0}});
+    module->funcsec.emplace_back(TypeIdx{0});
+    module->codesec.emplace_back(
         Code{0, {Instr::local_get, Instr::call, Instr::i32_const, Instr::i32_add, Instr::end},
             {0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0}});
 
@@ -1951,7 +1952,7 @@ TEST(execute, imported_function_call_with_arguments)
         return {false, {args[0] * 2}};
     };
 
-    auto instance = instantiate(&module, {host_foo});
+    auto instance = instantiate(std::move(module), {host_foo});
 
     const auto [trap, ret] = execute(instance, 1, {20});
 
@@ -1988,8 +1989,7 @@ TEST(execute, memory_copy_32bytes)
         "0061736d0100000001060160027f7f000302010005030100010a2c012a00200020012903003703002000200129"
         "030837030820002001290310370310200020012903183703180b000e046e616d65020701000200000100");
 
-    const auto module = parse(bin);
-    auto instance = instantiate(&module);
+    auto instance = instantiate(parse(bin));
     ASSERT_EQ(instance.memory.size(), 65536);
     const auto input = from_hex("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
     ASSERT_EQ(input.size(), 32);

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -1,5 +1,6 @@
 #include "parser.hpp"
 #include <gtest/gtest.h>
+#include <test/utils/asserts.hpp>
 #include <test/utils/hex.hpp>
 #include <types.hpp>
 
@@ -595,10 +596,8 @@ TEST(parser, milestone1)
 TEST(parser, instr_loop)
 {
     const auto loop_without_imm = "030b"_bytes;
-    EXPECT_THROW(parse_expr(loop_without_imm.data()), parser_error);
-
-    const auto loop_missing_end = "03400b"_bytes;
-    EXPECT_THROW(parse_expr(loop_missing_end.data()), parser_error);
+    EXPECT_THROW_MESSAGE(
+        parse_expr(loop_without_imm.data()), parser_error, "loop can only have type arity 0");
 
     const auto loop_void_empty = "03400b0b"_bytes;
     const auto [code1, pos1] = parse_expr(loop_void_empty.data());
@@ -606,16 +605,20 @@ TEST(parser, instr_loop)
     EXPECT_EQ(code1.immediates.size(), 0);
 
     const auto loop_i32_empty = "037f0b0b"_bytes;
-    EXPECT_THROW(parse_expr(loop_i32_empty.data()), parser_error);  // loop arity != 0.
+    EXPECT_THROW_MESSAGE(
+        parse_expr(loop_i32_empty.data()), parser_error, "loop can only have type arity 0");
+}
+
+TEST(parser, DISABLED_instr_loop_input_buffer_overflow)
+{
+    const auto loop_missing_end = "03400b"_bytes;
+    EXPECT_THROW_MESSAGE(parse_expr(loop_missing_end.data()), parser_error, "???");
 }
 
 TEST(parser, instr_block)
 {
     const auto wrong_type = "0200"_bytes;
-    EXPECT_THROW(parse_expr(wrong_type.data()), parser_error);
-
-    const auto block_missing_end = "02400b"_bytes;
-    EXPECT_THROW(parse_expr(block_missing_end.data()), parser_error);
+    EXPECT_THROW_MESSAGE(parse_expr(wrong_type.data()), parser_error, "invalid valtype 0");
 
     const auto empty = "010102400b0b"_bytes;
     const auto [code1, pos1] = parse_expr(empty.data());
@@ -633,6 +636,12 @@ TEST(parser, instr_block)
         "01"
         "02000000"
         "09000000"_bytes);
+}
+
+TEST(parser, DISABLED_instr_block_input_buffer_overflow)
+{
+    const auto block_missing_end = "02400b"_bytes;
+    EXPECT_THROW_MESSAGE(parse_expr(block_missing_end.data()), parser_error, "???");
 }
 
 TEST(parser, block_br)

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -107,9 +107,9 @@ TEST(parser, locals)
 TEST(parser, empty_module)
 {
     const auto module = parse(wasm_prefix);
-    EXPECT_EQ(module.typesec.size(), 0);
-    EXPECT_EQ(module.funcsec.size(), 0);
-    EXPECT_EQ(module.codesec.size(), 0);
+    EXPECT_EQ(module->typesec.size(), 0);
+    EXPECT_EQ(module->funcsec.size(), 0);
+    EXPECT_EQ(module->codesec.size(), 0);
 }
 
 TEST(parser, module_with_wrong_prefix)
@@ -124,18 +124,18 @@ TEST(parser, custom_section_empty)
 {
     const auto bin = bytes{wasm_prefix} + make_section(0, bytes{});
     const auto module = parse(bin);
-    EXPECT_EQ(module.typesec.size(), 0);
-    EXPECT_EQ(module.funcsec.size(), 0);
-    EXPECT_EQ(module.codesec.size(), 0);
+    EXPECT_EQ(module->typesec.size(), 0);
+    EXPECT_EQ(module->funcsec.size(), 0);
+    EXPECT_EQ(module->codesec.size(), 0);
 }
 
 TEST(parser, custom_section_nonempty)
 {
     const auto bin = bytes{wasm_prefix} + make_section(0, "ff"_bytes);
     const auto module = parse(bin);
-    EXPECT_EQ(module.typesec.size(), 0);
-    EXPECT_EQ(module.funcsec.size(), 0);
-    EXPECT_EQ(module.codesec.size(), 0);
+    EXPECT_EQ(module->typesec.size(), 0);
+    EXPECT_EQ(module->funcsec.size(), 0);
+    EXPECT_EQ(module->codesec.size(), 0);
 }
 
 TEST(parser, functype_wrong_prefix)
@@ -171,12 +171,12 @@ TEST(parser, type_section_with_single_functype)
     const auto section_contents = "01"_bytes + functype_void_to_void;
     const auto bin = bytes{wasm_prefix} + make_section(1, section_contents);
     const auto module = parse(bin);
-    ASSERT_EQ(module.typesec.size(), 1);
-    const auto functype = module.typesec[0];
+    ASSERT_EQ(module->typesec.size(), 1);
+    const auto functype = module->typesec[0];
     EXPECT_EQ(functype.inputs.size(), 0);
     EXPECT_EQ(functype.outputs.size(), 0);
-    EXPECT_EQ(module.funcsec.size(), 0);
-    EXPECT_EQ(module.codesec.size(), 0);
+    EXPECT_EQ(module->funcsec.size(), 0);
+    EXPECT_EQ(module->codesec.size(), 0);
 }
 
 TEST(parser, type_section_with_single_functype_params)
@@ -185,15 +185,15 @@ TEST(parser, type_section_with_single_functype_params)
     const auto section_contents = make_vec({functype_i32i64_to_i32});
     const auto bin = bytes{wasm_prefix} + make_section(1, section_contents);
     const auto module = parse(bin);
-    ASSERT_EQ(module.typesec.size(), 1);
-    const auto functype = module.typesec[0];
+    ASSERT_EQ(module->typesec.size(), 1);
+    const auto functype = module->typesec[0];
     ASSERT_EQ(functype.inputs.size(), 2);
     EXPECT_EQ(functype.inputs[0], ValType::i32);
     EXPECT_EQ(functype.inputs[1], ValType::i64);
     ASSERT_EQ(functype.outputs.size(), 1);
     EXPECT_EQ(functype.outputs[0], ValType::i32);
-    EXPECT_EQ(module.funcsec.size(), 0);
-    EXPECT_EQ(module.codesec.size(), 0);
+    EXPECT_EQ(module->funcsec.size(), 0);
+    EXPECT_EQ(module->codesec.size(), 0);
 }
 
 TEST(parser, type_section_with_multiple_functypes)
@@ -206,22 +206,22 @@ TEST(parser, type_section_with_multiple_functypes)
     const auto bin = bytes{wasm_prefix} + make_section(1, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.typesec.size(), 3);
-    const auto functype0 = module.typesec[0];
+    ASSERT_EQ(module->typesec.size(), 3);
+    const auto functype0 = module->typesec[0];
     EXPECT_EQ(functype0.inputs.size(), 0);
     EXPECT_EQ(functype0.outputs.size(), 0);
-    const auto functype1 = module.typesec[1];
+    const auto functype1 = module->typesec[1];
     EXPECT_EQ(functype1.inputs.size(), 2);
     EXPECT_EQ(functype1.inputs[0], ValType::i32);
     EXPECT_EQ(functype1.inputs[1], ValType::i64);
     EXPECT_EQ(functype1.outputs.size(), 1);
     EXPECT_EQ(functype1.outputs[0], ValType::i32);
-    const auto functype2 = module.typesec[2];
+    const auto functype2 = module->typesec[2];
     EXPECT_EQ(functype2.inputs.size(), 1);
     EXPECT_EQ(functype2.inputs[0], ValType::i32);
     EXPECT_EQ(functype2.outputs.size(), 0);
-    EXPECT_EQ(module.funcsec.size(), 0);
-    EXPECT_EQ(module.codesec.size(), 0);
+    EXPECT_EQ(module->funcsec.size(), 0);
+    EXPECT_EQ(module->codesec.size(), 0);
 }
 
 TEST(parser, import_single_function)
@@ -230,11 +230,11 @@ TEST(parser, import_single_function)
     const auto bin = bytes{wasm_prefix} + make_section(2, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.importsec.size(), 1);
-    EXPECT_EQ(module.importsec[0].module, "mod");
-    EXPECT_EQ(module.importsec[0].name, "foo");
-    EXPECT_EQ(module.importsec[0].kind, ExternalKind::Function);
-    EXPECT_EQ(module.importsec[0].desc.function_type_index, 0x42);
+    ASSERT_EQ(module->importsec.size(), 1);
+    EXPECT_EQ(module->importsec[0].module, "mod");
+    EXPECT_EQ(module->importsec[0].name, "foo");
+    EXPECT_EQ(module->importsec[0].kind, ExternalKind::Function);
+    EXPECT_EQ(module->importsec[0].desc.function_type_index, 0x42);
 }
 
 TEST(parser, import_multiple)
@@ -245,20 +245,20 @@ TEST(parser, import_multiple)
     const auto bin = bytes{wasm_prefix} + make_section(2, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.importsec.size(), 3);
-    EXPECT_EQ(module.importsec[0].module, "m1");
-    EXPECT_EQ(module.importsec[0].name, "abc");
-    EXPECT_EQ(module.importsec[0].kind, ExternalKind::Function);
-    EXPECT_EQ(module.importsec[0].desc.function_type_index, 0x42);
-    EXPECT_EQ(module.importsec[1].module, "m2");
-    EXPECT_EQ(module.importsec[1].name, "foo");
-    EXPECT_EQ(module.importsec[1].kind, ExternalKind::Memory);
-    EXPECT_EQ(module.importsec[1].desc.memory.limits.min, 0x7f);
-    EXPECT_FALSE(module.importsec[1].desc.memory.limits.max);
-    EXPECT_EQ(module.importsec[2].module, "m3");
-    EXPECT_EQ(module.importsec[2].name, "bar");
-    EXPECT_EQ(module.importsec[2].kind, ExternalKind::Global);
-    EXPECT_FALSE(module.importsec[2].desc.global_mutable);
+    ASSERT_EQ(module->importsec.size(), 3);
+    EXPECT_EQ(module->importsec[0].module, "m1");
+    EXPECT_EQ(module->importsec[0].name, "abc");
+    EXPECT_EQ(module->importsec[0].kind, ExternalKind::Function);
+    EXPECT_EQ(module->importsec[0].desc.function_type_index, 0x42);
+    EXPECT_EQ(module->importsec[1].module, "m2");
+    EXPECT_EQ(module->importsec[1].name, "foo");
+    EXPECT_EQ(module->importsec[1].kind, ExternalKind::Memory);
+    EXPECT_EQ(module->importsec[1].desc.memory.limits.min, 0x7f);
+    EXPECT_FALSE(module->importsec[1].desc.memory.limits.max);
+    EXPECT_EQ(module->importsec[2].module, "m3");
+    EXPECT_EQ(module->importsec[2].name, "bar");
+    EXPECT_EQ(module->importsec[2].kind, ExternalKind::Global);
+    EXPECT_FALSE(module->importsec[2].desc.global_mutable);
 }
 
 TEST(parser, function_section_with_single_function)
@@ -266,8 +266,8 @@ TEST(parser, function_section_with_single_function)
     const auto section_contents = "0100"_bytes;
     const auto bin = bytes{wasm_prefix} + make_section(3, section_contents);
     const auto module = parse(bin);
-    ASSERT_EQ(module.funcsec.size(), 1);
-    EXPECT_EQ(module.funcsec[0], 0);
+    ASSERT_EQ(module->funcsec.size(), 1);
+    EXPECT_EQ(module->funcsec[0], 0);
 }
 
 TEST(parser, function_section_with_multiple_functions)
@@ -275,11 +275,11 @@ TEST(parser, function_section_with_multiple_functions)
     const auto section_contents = "04000142ff01"_bytes;
     const auto bin = bytes{wasm_prefix} + make_section(3, section_contents);
     const auto module = parse(bin);
-    ASSERT_EQ(module.funcsec.size(), 4);
-    EXPECT_EQ(module.funcsec[0], 0);
-    EXPECT_EQ(module.funcsec[1], 1);
-    EXPECT_EQ(module.funcsec[2], 0x42);
-    EXPECT_EQ(module.funcsec[3], 0xff);
+    ASSERT_EQ(module->funcsec.size(), 4);
+    EXPECT_EQ(module->funcsec[0], 0);
+    EXPECT_EQ(module->funcsec[1], 1);
+    EXPECT_EQ(module->funcsec[2], 0x42);
+    EXPECT_EQ(module->funcsec[3], 0xff);
 }
 
 TEST(parser, table_single_min_limit)
@@ -288,8 +288,8 @@ TEST(parser, table_single_min_limit)
     const auto bin = bytes{wasm_prefix} + make_section(4, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.tablesec.size(), 1);
-    EXPECT_EQ(module.tablesec[0].limits.min, 0x7f);
+    ASSERT_EQ(module->tablesec.size(), 1);
+    EXPECT_EQ(module->tablesec[0].limits.min, 0x7f);
 }
 
 TEST(parser, table_single_minmax_limit)
@@ -298,9 +298,9 @@ TEST(parser, table_single_minmax_limit)
     const auto bin = bytes{wasm_prefix} + make_section(4, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.tablesec.size(), 1);
-    EXPECT_EQ(module.tablesec[0].limits.min, 0x12);
-    EXPECT_EQ(module.tablesec[0].limits.max, 0x7f);
+    ASSERT_EQ(module->tablesec.size(), 1);
+    EXPECT_EQ(module->tablesec[0].limits.min, 0x12);
+    EXPECT_EQ(module->tablesec[0].limits.max, 0x7f);
 }
 
 // Where minimum exceeds maximum
@@ -326,8 +326,8 @@ TEST(parser, memory_single_min_limit)
     const auto bin = bytes{wasm_prefix} + make_section(5, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.memorysec.size(), 1);
-    EXPECT_EQ(module.memorysec[0].limits.min, 0x7f);
+    ASSERT_EQ(module->memorysec.size(), 1);
+    EXPECT_EQ(module->memorysec[0].limits.min, 0x7f);
 }
 
 TEST(parser, memory_single_minmax_limit)
@@ -336,9 +336,9 @@ TEST(parser, memory_single_minmax_limit)
     const auto bin = bytes{wasm_prefix} + make_section(5, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.memorysec.size(), 1);
-    EXPECT_EQ(module.memorysec[0].limits.min, 0x12);
-    EXPECT_EQ(module.memorysec[0].limits.max, 0x7f);
+    ASSERT_EQ(module->memorysec.size(), 1);
+    EXPECT_EQ(module->memorysec[0].limits.min, 0x12);
+    EXPECT_EQ(module->memorysec[0].limits.max, 0x7f);
 }
 
 // Where minimum exceeds maximum
@@ -364,10 +364,10 @@ TEST(parser, global_single_mutable_const_inited)
     const auto bin = bytes{wasm_prefix} + make_section(6, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.globalsec.size(), 1);
-    EXPECT_TRUE(module.globalsec[0].is_mutable);
-    EXPECT_EQ(module.globalsec[0].expression.kind, ConstantExpression::Kind::Constant);
-    EXPECT_EQ(module.globalsec[0].expression.value.constant, 0x10);
+    ASSERT_EQ(module->globalsec.size(), 1);
+    EXPECT_TRUE(module->globalsec[0].is_mutable);
+    EXPECT_EQ(module->globalsec[0].expression.kind, ConstantExpression::Kind::Constant);
+    EXPECT_EQ(module->globalsec[0].expression.value.constant, 0x10);
 }
 
 TEST(parser, global_single_const_global_inited)
@@ -376,10 +376,10 @@ TEST(parser, global_single_const_global_inited)
     const auto bin = bytes{wasm_prefix} + make_section(6, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.globalsec.size(), 1);
-    EXPECT_FALSE(module.globalsec[0].is_mutable);
-    EXPECT_EQ(module.globalsec[0].expression.kind, ConstantExpression::Kind::GlobalGet);
-    EXPECT_EQ(module.globalsec[0].expression.value.global_index, 0x01);
+    ASSERT_EQ(module->globalsec.size(), 1);
+    EXPECT_FALSE(module->globalsec[0].is_mutable);
+    EXPECT_EQ(module->globalsec[0].expression.kind, ConstantExpression::Kind::GlobalGet);
+    EXPECT_EQ(module->globalsec[0].expression.value.global_index, 0x01);
 }
 
 TEST(parser, global_single_multi_instructions_inited)
@@ -389,10 +389,10 @@ TEST(parser, global_single_multi_instructions_inited)
     const auto bin = bytes{wasm_prefix} + make_section(6, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.globalsec.size(), 1);
-    EXPECT_TRUE(module.globalsec[0].is_mutable);
-    EXPECT_EQ(module.globalsec[0].expression.kind, ConstantExpression::Kind::Constant);
-    EXPECT_EQ(module.globalsec[0].expression.value.constant, uint64_t(-1));
+    ASSERT_EQ(module->globalsec.size(), 1);
+    EXPECT_TRUE(module->globalsec[0].is_mutable);
+    EXPECT_EQ(module->globalsec[0].expression.kind, ConstantExpression::Kind::Constant);
+    EXPECT_EQ(module->globalsec[0].expression.value.constant, uint64_t(-1));
 }
 
 TEST(parser, global_multi_const_inited)
@@ -403,13 +403,13 @@ TEST(parser, global_multi_const_inited)
     const auto bin = bytes{wasm_prefix} + make_section(6, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.globalsec.size(), 2);
-    EXPECT_FALSE(module.globalsec[0].is_mutable);
-    EXPECT_EQ(module.globalsec[0].expression.kind, ConstantExpression::Kind::Constant);
-    EXPECT_EQ(module.globalsec[0].expression.value.constant, 0x01);
-    EXPECT_TRUE(module.globalsec[1].is_mutable);
-    EXPECT_EQ(module.globalsec[1].expression.kind, ConstantExpression::Kind::Constant);
-    EXPECT_EQ(module.globalsec[1].expression.value.constant, uint32_t(-1));
+    ASSERT_EQ(module->globalsec.size(), 2);
+    EXPECT_FALSE(module->globalsec[0].is_mutable);
+    EXPECT_EQ(module->globalsec[0].expression.kind, ConstantExpression::Kind::Constant);
+    EXPECT_EQ(module->globalsec[0].expression.value.constant, 0x01);
+    EXPECT_TRUE(module->globalsec[1].is_mutable);
+    EXPECT_EQ(module->globalsec[1].expression.kind, ConstantExpression::Kind::Constant);
+    EXPECT_EQ(module->globalsec[1].expression.value.constant, uint32_t(-1));
 }
 
 TEST(parser, export_single_function)
@@ -418,10 +418,10 @@ TEST(parser, export_single_function)
     const auto bin = bytes{wasm_prefix} + make_section(7, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.exportsec.size(), 1);
-    EXPECT_EQ(module.exportsec[0].name, "abc");
-    EXPECT_EQ(module.exportsec[0].kind, ExternalKind::Function);
-    EXPECT_EQ(module.exportsec[0].index, 0x42);
+    ASSERT_EQ(module->exportsec.size(), 1);
+    EXPECT_EQ(module->exportsec[0].name, "abc");
+    EXPECT_EQ(module->exportsec[0].kind, ExternalKind::Function);
+    EXPECT_EQ(module->exportsec[0].index, 0x42);
 }
 
 TEST(parser, export_multiple)
@@ -432,19 +432,19 @@ TEST(parser, export_multiple)
     const auto bin = bytes{wasm_prefix} + make_section(7, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.exportsec.size(), 4);
-    EXPECT_EQ(module.exportsec[0].name, "abc");
-    EXPECT_EQ(module.exportsec[0].kind, ExternalKind::Function);
-    EXPECT_EQ(module.exportsec[0].index, 0x42);
-    EXPECT_EQ(module.exportsec[1].name, "foo");
-    EXPECT_EQ(module.exportsec[1].kind, ExternalKind::Table);
-    EXPECT_EQ(module.exportsec[1].index, 0x43);
-    EXPECT_EQ(module.exportsec[2].name, "bar");
-    EXPECT_EQ(module.exportsec[2].kind, ExternalKind::Memory);
-    EXPECT_EQ(module.exportsec[2].index, 0x44);
-    EXPECT_EQ(module.exportsec[3].name, "xyz");
-    EXPECT_EQ(module.exportsec[3].kind, ExternalKind::Global);
-    EXPECT_EQ(module.exportsec[3].index, 0x45);
+    ASSERT_EQ(module->exportsec.size(), 4);
+    EXPECT_EQ(module->exportsec[0].name, "abc");
+    EXPECT_EQ(module->exportsec[0].kind, ExternalKind::Function);
+    EXPECT_EQ(module->exportsec[0].index, 0x42);
+    EXPECT_EQ(module->exportsec[1].name, "foo");
+    EXPECT_EQ(module->exportsec[1].kind, ExternalKind::Table);
+    EXPECT_EQ(module->exportsec[1].index, 0x43);
+    EXPECT_EQ(module->exportsec[2].name, "bar");
+    EXPECT_EQ(module->exportsec[2].kind, ExternalKind::Memory);
+    EXPECT_EQ(module->exportsec[2].index, 0x44);
+    EXPECT_EQ(module->exportsec[3].name, "xyz");
+    EXPECT_EQ(module->exportsec[3].kind, ExternalKind::Global);
+    EXPECT_EQ(module->exportsec[3].index, 0x45);
 }
 
 TEST(parser, start)
@@ -453,8 +453,8 @@ TEST(parser, start)
     const auto bin = bytes{wasm_prefix} + make_section(8, section_contents);
 
     const auto module = parse(bin);
-    EXPECT_TRUE(module.startfunc);
-    EXPECT_EQ(*module.startfunc, 7);
+    EXPECT_TRUE(module->startfunc);
+    EXPECT_EQ(*module->startfunc, 7);
 }
 
 TEST(parser, code_with_empty_expr_2_locals)
@@ -491,14 +491,14 @@ TEST(parser, code_section_with_2_trivial_codes)
     const auto bin = bytes{wasm_prefix} + make_section(10, section_contents);
 
     const auto module = parse(bin);
-    EXPECT_EQ(module.typesec.size(), 0);
-    ASSERT_EQ(module.codesec.size(), 2);
-    EXPECT_EQ(module.codesec[0].local_count, 0);
-    ASSERT_EQ(module.codesec[0].instructions.size(), 1);
-    EXPECT_EQ(module.codesec[0].instructions[0], Instr::end);
-    EXPECT_EQ(module.codesec[1].local_count, 0);
-    ASSERT_EQ(module.codesec[1].instructions.size(), 1);
-    EXPECT_EQ(module.codesec[1].instructions[0], Instr::end);
+    EXPECT_EQ(module->typesec.size(), 0);
+    ASSERT_EQ(module->codesec.size(), 2);
+    EXPECT_EQ(module->codesec[0].local_count, 0);
+    ASSERT_EQ(module->codesec[0].instructions.size(), 1);
+    EXPECT_EQ(module->codesec[0].instructions[0], Instr::end);
+    EXPECT_EQ(module->codesec[1].local_count, 0);
+    ASSERT_EQ(module->codesec[1].instructions.size(), 1);
+    EXPECT_EQ(module->codesec[1].instructions[0], Instr::end);
 }
 
 TEST(parser, code_section_with_basic_instructions)
@@ -511,19 +511,19 @@ TEST(parser, code_section_with_basic_instructions)
     const auto bin = bytes{wasm_prefix} + make_section(10, section_contents);
 
     const auto module = parse(bin);
-    EXPECT_EQ(module.typesec.size(), 0);
-    ASSERT_EQ(module.codesec.size(), 1);
-    EXPECT_EQ(module.codesec[0].local_count, 0);
-    ASSERT_EQ(module.codesec[0].instructions.size(), 7);
-    EXPECT_EQ(module.codesec[0].instructions[0], Instr::local_get);
-    EXPECT_EQ(module.codesec[0].instructions[1], Instr::local_set);
-    EXPECT_EQ(module.codesec[0].instructions[2], Instr::local_tee);
-    EXPECT_EQ(module.codesec[0].instructions[3], Instr::i32_add);
-    EXPECT_EQ(module.codesec[0].instructions[4], Instr::nop);
-    EXPECT_EQ(module.codesec[0].instructions[5], Instr::unreachable);
-    EXPECT_EQ(module.codesec[0].instructions[6], Instr::end);
-    ASSERT_EQ(module.codesec[0].immediates.size(), 3 * 4);
-    EXPECT_EQ(module.codesec[0].immediates, "010000000200000003000000"_bytes);
+    EXPECT_EQ(module->typesec.size(), 0);
+    ASSERT_EQ(module->codesec.size(), 1);
+    EXPECT_EQ(module->codesec[0].local_count, 0);
+    ASSERT_EQ(module->codesec[0].instructions.size(), 7);
+    EXPECT_EQ(module->codesec[0].instructions[0], Instr::local_get);
+    EXPECT_EQ(module->codesec[0].instructions[1], Instr::local_set);
+    EXPECT_EQ(module->codesec[0].instructions[2], Instr::local_tee);
+    EXPECT_EQ(module->codesec[0].instructions[3], Instr::i32_add);
+    EXPECT_EQ(module->codesec[0].instructions[4], Instr::nop);
+    EXPECT_EQ(module->codesec[0].instructions[5], Instr::unreachable);
+    EXPECT_EQ(module->codesec[0].instructions[6], Instr::end);
+    ASSERT_EQ(module->codesec[0].immediates.size(), 3 * 4);
+    EXPECT_EQ(module->codesec[0].immediates, "010000000200000003000000"_bytes);
 }
 
 TEST(parser, data_section)
@@ -533,16 +533,16 @@ TEST(parser, data_section)
     const auto bin = bytes{wasm_prefix} + make_section(11, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.datasec.size(), 3);
-    EXPECT_EQ(module.datasec[0].offset.kind, ConstantExpression::Kind::Constant);
-    EXPECT_EQ(module.datasec[0].offset.value.constant, 1);
-    EXPECT_EQ(module.datasec[0].init, "aaff"_bytes);
-    EXPECT_EQ(module.datasec[1].offset.kind, ConstantExpression::Kind::Constant);
-    EXPECT_EQ(module.datasec[1].offset.value.constant, 2);
-    EXPECT_EQ(module.datasec[1].init, "5555"_bytes);
-    EXPECT_EQ(module.datasec[2].offset.kind, ConstantExpression::Kind::GlobalGet);
-    EXPECT_EQ(module.datasec[2].offset.value.global_index, 0);
-    EXPECT_EQ(module.datasec[2].init, "2424"_bytes);
+    ASSERT_EQ(module->datasec.size(), 3);
+    EXPECT_EQ(module->datasec[0].offset.kind, ConstantExpression::Kind::Constant);
+    EXPECT_EQ(module->datasec[0].offset.value.constant, 1);
+    EXPECT_EQ(module->datasec[0].init, "aaff"_bytes);
+    EXPECT_EQ(module->datasec[1].offset.kind, ConstantExpression::Kind::Constant);
+    EXPECT_EQ(module->datasec[1].offset.value.constant, 2);
+    EXPECT_EQ(module->datasec[1].init, "5555"_bytes);
+    EXPECT_EQ(module->datasec[2].offset.kind, ConstantExpression::Kind::GlobalGet);
+    EXPECT_EQ(module->datasec[2].offset.value.global_index, 0);
+    EXPECT_EQ(module->datasec[2].init, "2424"_bytes);
 }
 
 TEST(parser, data_section_memidx_nonzero)
@@ -575,12 +575,12 @@ TEST(parser, milestone1)
         "0061736d0100000001070160027f7f017f030201000a13011101017f200020016a20026a220220006a0b"_bytes;
     const auto m = parse(bin);
 
-    ASSERT_EQ(m.typesec.size(), 1);
-    EXPECT_EQ(m.typesec[0].inputs, (std::vector{ValType::i32, ValType::i32}));
-    EXPECT_EQ(m.typesec[0].outputs, (std::vector{ValType::i32}));
+    ASSERT_EQ(m->typesec.size(), 1);
+    EXPECT_EQ(m->typesec[0].inputs, (std::vector{ValType::i32, ValType::i32}));
+    EXPECT_EQ(m->typesec[0].outputs, (std::vector{ValType::i32}));
 
-    ASSERT_EQ(m.codesec.size(), 1);
-    const auto& c = m.codesec[0];
+    ASSERT_EQ(m->codesec.size(), 1);
+    const auto& c = m->codesec[0];
     EXPECT_EQ(c.local_count, 1);
     EXPECT_EQ(c.instructions,
         (std::vector{Instr::local_get, Instr::local_get, Instr::i32_add, Instr::local_get,

--- a/test/utils/asserts.hpp
+++ b/test/utils/asserts.hpp
@@ -15,4 +15,5 @@
     catch (...)                                                                              \
     {                                                                                        \
         ADD_FAILURE() << "Unexpected exception type thrown.";                                \
-    }
+    }                                                                                        \
+    (void)0


### PR DESCRIPTION
The instance object captures the reference to the module object. This is bad API design, because the owner of the module must remember to keep it alive as long as the instance object is used. Anyway, this change makes it only slightly better. Using temporary module objects is more difficult now, e.g. `instantiate(parse(wasm))` will not compile any more. Also, instance objects are now assignable. This is useful, because they are returned by value from instantiate().