### PR TITLE
Don't allocate empty memory when none is defined or imported

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -241,7 +241,7 @@ std::tuple<bytes_ptr, size_t> allocate_memory(const std::vector<Memory>& module_
     }
     else
     {
-        bytes_ptr memory{new bytes{}, bytes_delete};
+        bytes_ptr memory{nullptr, null_delete};
         return {std::move(memory), MemoryPagesLimit};
     }
 }

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -335,8 +335,7 @@ TEST(instantiate, memory_default)
 
     auto instance = instantiate(module);
 
-    ASSERT_EQ(instance.memory->size(), 0);
-    EXPECT_EQ(instance.memory_max_pages * PageSize, 256 * 1024 * 1024);
+    EXPECT_FALSE(instance.memory);
 }
 
 TEST(instantiate, memory_single)

--- a/test/utils/fizzy_engine.cpp
+++ b/test/utils/fizzy_engine.cpp
@@ -51,11 +51,18 @@ bool FizzyEngine::instantiate()
 
 bytes_view FizzyEngine::get_memory() const
 {
+    if (!m_instance.memory)
+        return {};
+
     return {m_instance.memory->data(), m_instance.memory->size()};
 }
 
 void FizzyEngine::set_memory(bytes_view memory)
 {
+    if (memory.empty())
+        return;
+
+    assert(m_instance.memory != nullptr);
     *m_instance.memory = memory;
 }
 

--- a/test/utils/wabt_engine.cpp
+++ b/test/utils/wabt_engine.cpp
@@ -53,6 +53,8 @@ void WabtEngine::set_memory(bytes_view memory)
     if (memory.empty())
         return;
 
+    assert(m_env.GetMemoryCount() != 0);
+
     auto& dst = *m_env.GetMemory(0);
     const auto begin = reinterpret_cast<const char*>(memory.data());
     dst.data.assign(begin, begin + memory.size());

--- a/test/utils/wasm3_engine.cpp
+++ b/test/utils/wasm3_engine.cpp
@@ -81,6 +81,7 @@ void Wasm3Engine::set_memory(fizzy::bytes_view memory)
 
     uint32_t size;
     const auto data = m3_GetMemory(m_runtime, &size, 0);
+    assert(data != nullptr);
     std::memcpy(data, memory.data(), size);
 }
 


### PR DESCRIPTION
Module is allowed to not have any memory (then all memory instructions are invalid)
https://github.com/WebAssembly/spec/blob/3b2489d7e570ca0f8d32e9d0b1a1e8255c4212b7/test/core/memory.wast#L22-L25
