### PR TITLE
Add spectest runner tool

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,6 @@
+set(fizzy_include_dir ${PROJECT_SOURCE_DIR}/lib/fizzy)
+
 add_subdirectory(utils)
 add_subdirectory(bench)
+add_subdirectory(spectests)
 add_subdirectory(unittests)

--- a/test/bench/CMakeLists.txt
+++ b/test/bench/CMakeLists.txt
@@ -3,8 +3,6 @@ if(HUNTER_ENABLED)
 endif()
 find_package(benchmark REQUIRED)
 
-set(fizzy_include_dir ${PROJECT_SOURCE_DIR}/lib/fizzy)
-
 add_executable(fizzy-bench bench.cpp)
 target_compile_features(fizzy-bench PRIVATE cxx_std_17)
 target_link_libraries(fizzy-bench PRIVATE fizzy::fizzy fizzy::test-utils benchmark::benchmark)

--- a/test/spectests/CMakeLists.txt
+++ b/test/spectests/CMakeLists.txt
@@ -1,0 +1,17 @@
+if(HUNTER_ENABLED)
+    hunter_add_package(nlohmann_json)
+endif()
+find_package(nlohmann_json REQUIRED)
+
+add_executable(fizzy-spectests spectests.cpp)
+target_compile_features(fizzy-spectests PRIVATE cxx_std_17)
+target_link_libraries(fizzy-spectests PRIVATE fizzy::fizzy fizzy::test-utils nlohmann_json::nlohmann_json)
+target_include_directories(fizzy-spectests PRIVATE ${fizzy_include_dir})
+
+if(UNIX AND NOT APPLE)
+    # For libstdc++ up to version 8 (included) this is needed for proper <filesystem> support.
+    # Otherwise, the result program will crash on first use (no linker errors).
+    # For libstdc++ 9, this is not needed, but cause no harm.
+    # Clang compiler on linux may select libstdc++8 in some configurations.
+    target_link_libraries(fizzy-spectests PRIVATE stdc++fs)
+endif()

--- a/test/spectests/spectests.cpp
+++ b/test/spectests/spectests.cpp
@@ -18,134 +18,168 @@ uint64_t json_to_value(const json& v)
     return static_cast<uint64_t>(static_cast<T>(std::stoull(v.get<std::string>())));
 }
 
-void run_tests_from_file(const fs::path& path)
+class test_runner
 {
-    std::cout << "Running tests from " << path << "\n";
-
-    std::ifstream test_file{path};
-    const json j = json::parse(test_file);
-
-    fizzy::Instance instance;
-    for (const auto& cmd : j.at("commands"))
+public:
+    void run_from_file(const fs::path& path)
     {
-        const auto type = cmd.at("type").get<std::string>();
+        std::cout << "Running tests from " << path << "\n";
 
-        std::cout << "Line " << cmd.at("line").get<int>() << ": " << type << " " << std::flush;
+        std::ifstream test_file{path};
+        const json j = json::parse(test_file);
 
-        if (type == "module")
+        for (const auto& cmd : j.at("commands"))
         {
-            const auto filename = cmd.at("filename").get<std::string>();
-            std::cout << "Instantiating " << filename << "\n";
+            const auto type = cmd.at("type").get<std::string>();
 
-            std::ifstream wasm_file{fs::path{path}.replace_filename(filename)};
+            std::cout << "Line " << cmd.at("line").get<int>() << ": " << type << " " << std::flush;
 
-            const auto wasm_binary = fizzy::bytes(
-                std::istreambuf_iterator<char>{wasm_file}, std::istreambuf_iterator<char>{});
+            if (type == "module")
+            {
+                const auto filename = cmd.at("filename").get<std::string>();
+                std::cout << "Instantiating " << filename << "\n";
 
-            try
-            {
-                instance = fizzy::instantiate(fizzy::parse(wasm_binary));
-            }
-            catch (const fizzy::parser_error& ex)
-            {
-                std::cout << "FAILED Parsing failed with error: " << ex.what() << "\n";
-                continue;
-            }
-            catch (const fizzy::instantiate_error& ex)
-            {
-                std::cout << "FAILED Instantiation failed with error: " << ex.what() << "\n";
-                continue;
-            }
-        }
-        else if (type == "assert_return")
-        {
-            const auto& action = cmd.at("action");
-            const auto action_type = action.at("type").get<std::string>();
-            if (action_type == "invoke")
-            {
-                const auto func_name = action.at("field").get<std::string>();
-                const auto func_idx = fizzy::find_exported_function(instance.module, func_name);
-                if (!func_idx.has_value())
+                std::ifstream wasm_file{fs::path{path}.replace_filename(filename)};
+
+                const auto wasm_binary = fizzy::bytes(
+                    std::istreambuf_iterator<char>{wasm_file}, std::istreambuf_iterator<char>{});
+
+                try
                 {
-                    std::cout << "SKIPPED Function '" << func_name << "' not found.\n";
+                    instance = fizzy::instantiate(fizzy::parse(wasm_binary));
+                }
+                catch (const fizzy::parser_error& ex)
+                {
+                    std::cout << "FAILED Parsing failed with error: " << ex.what() << "\n";
                     continue;
                 }
-
-                std::vector<uint64_t> args;
-                for (const auto& arg : action.at("args"))
+                catch (const fizzy::instantiate_error& ex)
                 {
-                    const auto arg_type = arg.at("type").get<std::string>();
-                    uint64_t arg_value;
-                    if (arg_type == "i32")
-                        arg_value = json_to_value<int32_t>(arg.at("value"));
-                    else if (arg_type == "i64")
-                        arg_value = json_to_value<int64_t>(arg.at("value"));
-                    else
+                    std::cout << "FAILED Instantiation failed with error: " << ex.what() << "\n";
+                    continue;
+                }
+            }
+            else if (type == "assert_return")
+            {
+                const auto& action = cmd.at("action");
+                const auto action_type = action.at("type").get<std::string>();
+                if (action_type == "invoke")
+                {
+                    auto result = invoke(action);
+                    if (!result.has_value())
+                        continue;
+
+                    if (result->trapped)
                     {
-                        std::cout << "SKIPPED Unsupported argument type '" << arg_type << "'.\n";
+                        std::cout << "FAILED Function trapped.\n";
                         continue;
                     }
-                    args.push_back(arg_value);
-                }
 
-                const auto result = fizzy::execute(instance, *func_idx, std::move(args));
+                    const auto& expected = cmd.at("expected");
+                    if (expected.empty() && !result->stack.empty())
+                    {
+                        std::cout << "FAILED Unexpected returned value.\n";
+                        continue;
+                    }
 
-                if (result.trapped)
-                {
-                    std::cout << "FAILED Function trapped.\n";
-                    continue;
-                }
+                    if (result->stack.size() != 1)
+                    {
+                        std::cout << "FAILED More than 1 value returned.\n";
+                        continue;
+                    }
 
-                const auto& expected = cmd.at("expected");
-                if (expected.empty() && !result.stack.empty())
-                {
-                    std::cout << "FAILED Unexpected returned value.\n";
-                    continue;
-                }
+                    const auto expected_type = expected.at(0).at("type").get<std::string>();
+                    uint64_t expected_value;
+                    uint64_t actual_value;
+                    if (expected_type == "i32")
+                    {
+                        expected_value = json_to_value<int32_t>(expected.at(0).at("value"));
+                        actual_value =
+                            static_cast<uint64_t>(static_cast<int32_t>(result->stack[0]));
+                    }
+                    else if (expected_type == "i64")
+                    {
+                        expected_value = json_to_value<int64_t>(expected.at(0).at("value"));
+                        actual_value = result->stack[0];
+                    }
+                    else
+                    {
+                        std::cout << "SKIPPED Unsupported expected type '" << expected_type
+                                  << "'.\n";
+                        continue;
+                    }
 
-                if (result.stack.size() != 1)
-                {
-                    std::cout << "FAILED More than 1 value returned.\n";
-                    continue;
-                }
+                    if (expected_value != actual_value)
+                    {
+                        std::cout << "FAILED Incorrect returned value. Expected: " << expected_value
+                                  << " (0x" << std::hex << expected_value
+                                  << ") Actual: " << std::dec << actual_value << " (0x" << std::hex
+                                  << actual_value << std::dec << ")\n";
+                        continue;
+                    }
 
-                const auto expected_type = expected.at(0).at("type").get<std::string>();
-                uint64_t expected_value;
-                uint64_t actual_value;
-                if (expected_type == "i32")
-                {
-                    expected_value = json_to_value<int32_t>(expected.at(0).at("value"));
-                    actual_value = static_cast<uint64_t>(static_cast<int32_t>(result.stack[0]));
-                }
-                else if (expected_type == "i64")
-                {
-                    expected_value = json_to_value<int64_t>(expected.at(0).at("value"));
-                    actual_value = result.stack[0];
+                    std::cout << "PASSED\n";
                 }
                 else
-                {
-                    std::cout << "SKIPPED Unsupported expected type '" << expected_type << "'.\n";
-                    continue;
-                }
+                    std::cout << "SKIPPED Unsupported action type '" << action_type << "'\n";
+            }
+            else if (type == "assert_trap")
+            {
+                const auto& action = cmd.at("action");
+                const auto action_type = action.at("type").get<std::string>();
+                if (action_type != "invoke")
+                    std::cout << "SKIPPED Unsupported action type '" << action_type << "'\n";
 
-                if (expected_value != actual_value)
+                auto result = invoke(action);
+                if (!result.has_value())
+                    continue;
+
+                if (!result->trapped)
                 {
-                    std::cout << "FAILED Incorrect returned value. Expected: " << expected_value
-                              << " (0x" << std::hex << expected_value << ") Actual: " << std::dec
-                              << actual_value << " (0x" << std::hex << actual_value << std::dec
-                              << ")\n";
+                    std::cout << "FAILED Function expected to trap, but it didn't.\n";
                     continue;
                 }
 
                 std::cout << "PASSED\n";
             }
             else
-                std::cout << "SKIPPED Unsupported action type '" << action_type << "'\n";
+                std::cout << "SKIPPED Unsupported command type\n";
         }
-        else
-            std::cout << "SKIPPED Unsupported command type\n";
     }
-}
+
+private:
+    std::optional<fizzy::execution_result> invoke(const json& action)
+    {
+        const auto func_name = action.at("field").get<std::string>();
+        const auto func_idx = fizzy::find_exported_function(instance.module, func_name);
+        if (!func_idx.has_value())
+        {
+            std::cout << "SKIPPED Function '" << func_name << "' not found.\n";
+            return std::nullopt;
+        }
+
+        std::vector<uint64_t> args;
+        for (const auto& arg : action.at("args"))
+        {
+            const auto arg_type = arg.at("type").get<std::string>();
+            uint64_t arg_value;
+            if (arg_type == "i32")
+                arg_value = json_to_value<int32_t>(arg.at("value"));
+            else if (arg_type == "i64")
+                arg_value = json_to_value<int64_t>(arg.at("value"));
+            else
+            {
+                std::cout << "SKIPPED Unsupported argument type '" << arg_type << "'.\n";
+                return std::nullopt;
+            }
+            args.push_back(arg_value);
+        }
+
+        return fizzy::execute(instance, *func_idx, std::move(args));
+    }
+
+    fizzy::Instance instance;
+};
 
 void run_tests_from_dir(const fs::path& path)
 {
@@ -162,7 +196,7 @@ void run_tests_from_dir(const fs::path& path)
     {
         try
         {
-            run_tests_from_file(f);
+            test_runner{}.run_from_file(f);
         }
         catch (const std::exception& ex)
         {

--- a/test/spectests/spectests.cpp
+++ b/test/spectests/spectests.cpp
@@ -36,7 +36,20 @@ void run_tests_from_file(const fs::path& path)
             const auto wasm_binary = fizzy::bytes(
                 std::istreambuf_iterator<char>{wasm_file}, std::istreambuf_iterator<char>{});
 
-            instance = fizzy::instantiate(fizzy::parse(wasm_binary));
+            try
+            {
+                instance = fizzy::instantiate(fizzy::parse(wasm_binary));
+            }
+            catch (const fizzy::parser_error& ex)
+            {
+                std::cout << "FAILED Parsing failed with error: " << ex.what() << "\n";
+                continue;
+            }
+            catch (const fizzy::instantiate_error& ex)
+            {
+                std::cout << "FAILED Instantiation failed with error: " << ex.what() << "\n";
+                continue;
+            }
         }
         else if (type == "assert_return")
         {

--- a/test/spectests/spectests.cpp
+++ b/test/spectests/spectests.cpp
@@ -1,0 +1,170 @@
+#include "execute.hpp"
+#include "parser.hpp"
+#include <nlohmann/json.hpp>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+
+namespace fs = std::filesystem;
+using json = nlohmann::json;
+
+namespace
+{
+constexpr auto JsonExtension = ".json";
+
+void run_tests_from_file(const fs::path& path)
+{
+    std::cout << "Running tests from " << path << "\n";
+
+    std::ifstream test_file{path};
+    const json j = json::parse(test_file);
+
+    fizzy::Instance instance;
+    for (const auto& cmd : j.at("commands"))
+    {
+        const auto type = cmd.at("type").get<std::string>();
+
+        std::cout << "Line " << cmd.at("line").get<int>() << ": " << type << " " << std::flush;
+
+        if (type == "module")
+        {
+            const auto filename = cmd.at("filename").get<std::string>();
+            std::cout << "Instantiating " << filename << "\n";
+
+            std::ifstream wasm_file{fs::path{path}.replace_filename(filename)};
+
+            const auto wasm_binary = fizzy::bytes(
+                std::istreambuf_iterator<char>{wasm_file}, std::istreambuf_iterator<char>{});
+
+            instance = fizzy::instantiate(fizzy::parse(wasm_binary));
+        }
+        else if (type == "assert_return")
+        {
+            const auto& action = cmd.at("action");
+            const auto action_type = action.at("type").get<std::string>();
+            if (action_type == "invoke")
+            {
+                const auto func_name = action.at("field").get<std::string>();
+                const auto func_idx = fizzy::find_exported_function(instance.module, func_name);
+                if (!func_idx.has_value())
+                {
+                    std::cout << "SKIPPED Function '" << func_name << "' not found.\n";
+                    continue;
+                }
+
+                std::vector<uint64_t> args;
+                for (const auto& arg : action.at("args"))
+                {
+                    const auto arg_type = arg.at("type").get<std::string>();
+                    uint64_t arg_value;
+                    if (arg_type == "i32")
+                        arg_value = static_cast<uint64_t>(
+                            static_cast<int32_t>(std::stoll(arg.at("value").get<std::string>())));
+                    args.push_back(arg_value);
+                }
+
+                const auto result = fizzy::execute(instance, *func_idx, std::move(args));
+
+                if (result.trapped)
+                {
+                    std::cout << "FAILED Function trapped.\n";
+                    continue;
+                }
+
+                const auto& expected = cmd.at("expected");
+                if (expected.empty() && !result.stack.empty())
+                {
+                    std::cout << "FAILED Unexpected returned value.\n";
+                    continue;
+                }
+
+                if (result.stack.size() != 1)
+                {
+                    std::cout << "FAILED More than 1 value returned.\n";
+                    continue;
+                }
+
+                const auto expected_type = expected.at(0).at("type").get<std::string>();
+                uint64_t expected_value;
+                uint64_t actual_value;
+                if (expected_type == "i32")
+                {
+                    expected_value = static_cast<uint64_t>(static_cast<int32_t>(
+                        std::stoll(expected.at(0).at("value").get<std::string>())));
+                    actual_value = static_cast<uint64_t>(static_cast<int32_t>(result.stack[0]));
+                }
+                else
+                {
+                    std::cout << "SKIPPED Unsupported expected type.\n";
+                    continue;
+                }
+
+                if (expected_value != actual_value)
+                {
+                    std::cout << "FAILED Incorrect returned value. Expected: " << expected_value
+                              << " (0x" << std::hex << expected_value << ") Actual: " << std::dec
+                              << actual_value << " (0x" << std::hex << actual_value << std::dec
+                              << ")\n";
+                    continue;
+                }
+
+                std::cout << "PASSED\n";
+            }
+            else
+                std::cout << "SKIPPED Unsupported action type '" << action_type << "'\n";
+        }
+        else
+            std::cout << "SKIPPED Unsupported command type\n";
+    }
+}
+
+void run_tests_from_dir(const fs::path& path)
+{
+    std::vector<fs::path> files;
+    for (const auto& e : fs::recursive_directory_iterator{path})
+    {
+        if (e.is_regular_file() && e.path().extension() == JsonExtension)
+            files.emplace_back(e);
+    }
+
+    std::sort(std::begin(files), std::end(files));
+
+    for (const auto& f : files)
+    {
+        try
+        {
+            run_tests_from_file(f);
+        }
+        catch (const std::exception& ex)
+        {
+            std::cerr << "Exception: " << ex.what() << "\n\n";
+        }
+    }
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    try
+    {
+        if (argc < 2)
+        {
+            std::cerr << "Missing DIR argument\n";
+            return -1;
+        }
+        else if (argc > 2)
+        {
+            std::cerr << "Too many arguments\n";
+            return -1;
+        }
+
+        run_tests_from_dir(argv[1]);
+        return 0;
+    }
+    catch (const std::exception& ex)
+    {
+        std::cerr << "Exception: " << ex.what() << "\n";
+        return -2;
+    }
+}

--- a/test/spectests/spectests.cpp
+++ b/test/spectests/spectests.cpp
@@ -19,6 +19,14 @@ uint64_t json_to_value(const json& v)
     return static_cast<uint64_t>(static_cast<T>(std::stoull(v.get<std::string>())));
 }
 
+fizzy::bytes load_wasm_file(const fs::path& json_file_path, std::string_view filename)
+{
+    std::ifstream wasm_file{fs::path{json_file_path}.replace_filename(filename)};
+
+    return fizzy::bytes(
+        std::istreambuf_iterator<char>{wasm_file}, std::istreambuf_iterator<char>{});
+}
+
 class test_runner
 {
 public:
@@ -40,11 +48,7 @@ public:
                 const auto filename = cmd.at("filename").get<std::string>();
                 log_no_newline("Instantiating " + filename + " ");
 
-                std::ifstream wasm_file{fs::path{path}.replace_filename(filename)};
-
-                const auto wasm_binary = fizzy::bytes(
-                    std::istreambuf_iterator<char>{wasm_file}, std::istreambuf_iterator<char>{});
-
+                const auto wasm_binary = load_wasm_file(path, filename);
                 try
                 {
                     // TODO provide dummy imports if needed
@@ -149,11 +153,7 @@ public:
             else if (type == "assert_invalid")
             {
                 const auto filename = cmd.at("filename").get<std::string>();
-                std::ifstream wasm_file{fs::path{path}.replace_filename(filename)};
-
-                const auto wasm_binary = fizzy::bytes(
-                    std::istreambuf_iterator<char>{wasm_file}, std::istreambuf_iterator<char>{});
-
+                const auto wasm_binary = load_wasm_file(path, filename);
                 try
                 {
                     fizzy::parse(wasm_binary);

--- a/test/spectests/spectests.cpp
+++ b/test/spectests/spectests.cpp
@@ -24,7 +24,7 @@ class test_runner
 public:
     void run_from_file(const fs::path& path)
     {
-        std::cout << "Running tests from " << path << "\n";
+        log("Running tests from " + path.string());
 
         std::ifstream test_file{path};
         const json j = json::parse(test_file);
@@ -33,12 +33,12 @@ public:
         {
             const auto type = cmd.at("type").get<std::string>();
 
-            std::cout << "Line " << cmd.at("line").get<int>() << ": " << type << " " << std::flush;
+            log_no_newline("Line " + std::to_string(cmd.at("line").get<int>()) + ": " + type + " ");
 
             if (type == "module")
             {
                 const auto filename = cmd.at("filename").get<std::string>();
-                std::cout << "Instantiating " << filename << " ";
+                log_no_newline("Instantiating " + filename + " ");
 
                 std::ifstream wasm_file{fs::path{path}.replace_filename(filename)};
 
@@ -171,9 +171,9 @@ public:
                 skip("Unsupported command type");
         }
 
-        std::cout << (passed + failed + skipped) << " tests ran from " << path.filename().string()
-                  << ".\n  PASSED " << passed << ", FAILED " << failed << ", SKIPPED " << skipped
-                  << ".\n\n";
+        log(std::to_string(passed + failed + skipped) + " tests ran from " +
+            path.filename().string() + ".\n  PASSED " + std::to_string(passed) + ", FAILED " +
+            std::to_string(failed) + ", SKIPPED " + std::to_string(skipped) + ".\n");
     }
 
 private:
@@ -224,6 +224,10 @@ private:
         ++skipped;
         std::cout << "SKIPPED " << message << "\n";
     }
+
+    void log(std::string_view message) const { std::cout << message << "\n"; }
+
+    void log_no_newline(std::string_view message) const { std::cout << message << std::flush; }
 
     fizzy::Instance instance;
     int passed = 0;

--- a/test/spectests/spectests.cpp
+++ b/test/spectests/spectests.cpp
@@ -142,6 +142,27 @@ public:
 
                 std::cout << "PASSED\n";
             }
+            else if (type == "assert_invalid")
+            {
+                const auto filename = cmd.at("filename").get<std::string>();
+                std::ifstream wasm_file{fs::path{path}.replace_filename(filename)};
+
+                const auto wasm_binary = fizzy::bytes(
+                    std::istreambuf_iterator<char>{wasm_file}, std::istreambuf_iterator<char>{});
+
+                try
+                {
+                    fizzy::parse(wasm_binary);
+                }
+                catch (fizzy::parser_error const&)
+                {
+                    std::cout << "PASSED\n";
+                    continue;
+                }
+
+                std::cout << "FAILED Invalid module parsed successfully. Expected error: "
+                          << cmd.at("text").get<std::string>() << "\n";
+            }
             else
                 std::cout << "SKIPPED Unsupported command type\n";
         }

--- a/test/spectests/spectests.cpp
+++ b/test/spectests/spectests.cpp
@@ -12,6 +12,12 @@ namespace
 {
 constexpr auto JsonExtension = ".json";
 
+template <typename T>
+uint64_t json_to_value(const json& v)
+{
+    return static_cast<uint64_t>(static_cast<T>(std::stoull(v.get<std::string>())));
+}
+
 void run_tests_from_file(const fs::path& path)
 {
     std::cout << "Running tests from " << path << "\n";
@@ -71,8 +77,14 @@ void run_tests_from_file(const fs::path& path)
                     const auto arg_type = arg.at("type").get<std::string>();
                     uint64_t arg_value;
                     if (arg_type == "i32")
-                        arg_value = static_cast<uint64_t>(
-                            static_cast<int32_t>(std::stoll(arg.at("value").get<std::string>())));
+                        arg_value = json_to_value<int32_t>(arg.at("value"));
+                    else if (arg_type == "i64")
+                        arg_value = json_to_value<int64_t>(arg.at("value"));
+                    else
+                    {
+                        std::cout << "SKIPPED Unsupported argument type '" << arg_type << "'.\n";
+                        continue;
+                    }
                     args.push_back(arg_value);
                 }
 
@@ -102,13 +114,17 @@ void run_tests_from_file(const fs::path& path)
                 uint64_t actual_value;
                 if (expected_type == "i32")
                 {
-                    expected_value = static_cast<uint64_t>(static_cast<int32_t>(
-                        std::stoll(expected.at(0).at("value").get<std::string>())));
+                    expected_value = json_to_value<int32_t>(expected.at(0).at("value"));
                     actual_value = static_cast<uint64_t>(static_cast<int32_t>(result.stack[0]));
+                }
+                else if (expected_type == "i64")
+                {
+                    expected_value = json_to_value<int64_t>(expected.at(0).at("value"));
+                    actual_value = result.stack[0];
                 }
                 else
                 {
-                    std::cout << "SKIPPED Unsupported expected type.\n";
+                    std::cout << "SKIPPED Unsupported expected type '" << expected_type << "'.\n";
                     continue;
                 }
 


### PR DESCRIPTION
Part of #110

Commands that can be used to convert all *.wast files in current dir to json/wasm files in separate subdirs:
```
mkdir json
for f in *.wast; do mkdir json/${f%.*}; wast2json $f -o json/${f%.*}/${f%.*}.json; done
```