### PR TITLE
Fix rem_s instructions causing SIGFPE

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -1068,7 +1068,14 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
                 trap = true;
                 goto end;
             }
-            binary_op(stack, std::modulus<int32_t>());
+            auto const lhs = static_cast<int32_t>(stack.peek(1));
+            if (lhs == std::numeric_limits<int32_t>::min() && rhs == -1)
+            {
+                stack.drop(2);
+                stack.push(0);
+            }
+            else
+                binary_op(stack, std::modulus<int32_t>());
             break;
         }
         case Instr::i32_rem_u:
@@ -1183,7 +1190,14 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
                 trap = true;
                 goto end;
             }
-            binary_op(stack, std::modulus<int64_t>());
+            auto const lhs = static_cast<int64_t>(stack.peek(1));
+            if (lhs == std::numeric_limits<int64_t>::min() && rhs == -1)
+            {
+                stack.drop(2);
+                stack.push(0);
+            }
+            else
+                binary_op(stack, std::modulus<int64_t>());
             break;
         }
         case Instr::i64_rem_u:

--- a/test/unittests/execute_numeric_test.cpp
+++ b/test/unittests/execute_numeric_test.cpp
@@ -689,11 +689,9 @@ TEST(execute_numeric, i32_div_u_by_zero)
 
 TEST(execute_numeric, i32_rem_s)
 {
-    const auto [trap, ret] = execute_binary_operation(Instr::i32_rem_s, uint64_t(-4242), 4200);
-
-    ASSERT_FALSE(trap);
-    ASSERT_EQ(ret.size(), 1);
-    EXPECT_EQ(ret[0], uint64_t(-42));
+    EXPECT_RESULT(execute_binary_operation(Instr::i32_rem_s, uint64_t(-4242), 4200), -42);
+    constexpr auto i32_min = std::numeric_limits<int32_t>::min();
+    EXPECT_RESULT(execute_binary_operation(Instr::i32_rem_s, uint64_t(i32_min), uint64_t(-1)), 0);
 }
 
 TEST(execute_numeric, i32_rem_s_by_zero)
@@ -975,11 +973,9 @@ TEST(execute_numeric, i64_div_u_by_zero)
 
 TEST(execute_numeric, i64_rem_s)
 {
-    const auto [trap, ret] = execute_binary_operation(Instr::i64_rem_s, uint64_t(-4242), 4200);
-
-    ASSERT_FALSE(trap);
-    ASSERT_EQ(ret.size(), 1);
-    EXPECT_EQ(ret[0], uint64_t(-42));
+    EXPECT_RESULT(execute_binary_operation(Instr::i64_rem_s, uint64_t(-4242), 4200), -42);
+    constexpr auto i64_min = std::numeric_limits<int64_t>::min();
+    EXPECT_RESULT(execute_binary_operation(Instr::i64_rem_s, uint64_t(i64_min), uint64_t(-1)), 0);
 }
 
 TEST(execute_numeric, i64_rem_s_by_zero)


### PR DESCRIPTION
I guess this case is not mentioned in the spec, because unlike for `div_s` which traps, `rem_s` should return a valid result for this case (0), so there's nothing special to mention.

It's just an implementation detail that `%` is not working for these inputs.