### PR TITLE
spectest: support "register" command

### DIFF
--- a/test/spectests/spectests.cpp
+++ b/test/spectests/spectests.cpp
@@ -89,6 +89,23 @@ public:
                 }
                 pass();
             }
+            else if (type == "register")
+            {
+                const auto module_name =
+                    (cmd.find("name") != cmd.end() ? cmd["name"] : UnnamedModule);
+
+                const auto it_instance = instances.find(module_name);
+                if (it_instance == instances.end())
+                {
+                    skip("Module not found.");
+                    continue;
+                }
+
+                const auto registered_name = cmd.at("as").get<std::string>();
+
+                registered_names[registered_name] = module_name;
+                pass();
+            }
             else if (type == "assert_return" || type == "action")
             {
                 const auto& action = cmd.at("action");
@@ -283,6 +300,7 @@ private:
 
     test_settings settings;
     std::unordered_map<std::string, fizzy::Instance> instances;
+    std::unordered_map<std::string, std::string> registered_names;
     test_results results;
 };
 


### PR DESCRIPTION
1. Implements `register` command, which saves the name of the module to be used in imports.
2. ~~Adds support for modules importing functions (other imports not supported yet)~~ 
Included in https://github.com/wasmx/fizzy/pull/182
3. ~~(requires https://github.com/wasmx/fizzy/pull/170) Adds the `spectest` module, available for all test files.~~
Moved to https://github.com/wasmx/fizzy/pull/215