### PR TITLE
Parser rework

### DIFF
--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -16,8 +16,8 @@ struct parser<FuncType>
         ++pos;
 
         FuncType result;
-        std::tie(result.inputs, pos) = parser<std::vector<ValType>>{}(pos);
-        std::tie(result.outputs, pos) = parser<std::vector<ValType>>{}(pos);
+        std::tie(result.inputs, pos) = parse_vec<ValType>(pos);
+        std::tie(result.outputs, pos) = parse_vec<ValType>(pos);
         return {result, pos};
     }
 };
@@ -121,7 +121,7 @@ struct parser<std::string>
     parser_result<std::string> operator()(const uint8_t* pos)
     {
         std::vector<uint8_t> value;
-        std::tie(value, pos) = parser<std::vector<uint8_t>>{}(pos);
+        std::tie(value, pos) = parse_vec<uint8_t>(pos);
 
         // FIXME: need to validate that string is a valid UTF-8
 
@@ -212,7 +212,7 @@ struct parser<Element>
         std::tie(offset, pos) = parser<ConstantExpression>{}(pos);
 
         std::vector<FuncIdx> init;
-        std::tie(init, pos) = parser<std::vector<FuncIdx>>{}(pos);
+        std::tie(init, pos) = parse_vec<FuncIdx>(pos);
 
         return {{offset, std::move(init)}, pos};
     }
@@ -232,7 +232,7 @@ struct parser<Data>
         std::tie(offset, pos) = parser<ConstantExpression>{}(pos);
 
         std::vector<uint8_t> init;
-        std::tie(init, pos) = parser<std::vector<uint8_t>>{}(pos);
+        std::tie(init, pos) = parse_vec<uint8_t>(pos);
 
         return {{offset, bytes(init.data(), init.size())}, pos};
     }
@@ -255,37 +255,37 @@ Module parse(bytes_view input)
         switch (id)
         {
         case SectionId::type:
-            std::tie(module.typesec, it) = parser<std::vector<FuncType>>{}(it);
+            std::tie(module.typesec, it) = parse_vec<FuncType>(it);
             break;
         case SectionId::import:
-            std::tie(module.importsec, it) = parser<std::vector<Import>>{}(it);
+            std::tie(module.importsec, it) = parse_vec<Import>(it);
             break;
         case SectionId::function:
-            std::tie(module.funcsec, it) = parser<std::vector<TypeIdx>>{}(it);
+            std::tie(module.funcsec, it) = parse_vec<TypeIdx>(it);
             break;
         case SectionId::table:
-            std::tie(module.tablesec, it) = parser<std::vector<Table>>{}(it);
+            std::tie(module.tablesec, it) = parse_vec<Table>(it);
             break;
         case SectionId::memory:
-            std::tie(module.memorysec, it) = parser<std::vector<Memory>>{}(it);
+            std::tie(module.memorysec, it) = parse_vec<Memory>(it);
             break;
         case SectionId::global:
-            std::tie(module.globalsec, it) = parser<std::vector<Global>>{}(it);
+            std::tie(module.globalsec, it) = parse_vec<Global>(it);
             break;
         case SectionId::export_:
-            std::tie(module.exportsec, it) = parser<std::vector<Export>>{}(it);
+            std::tie(module.exportsec, it) = parse_vec<Export>(it);
             break;
         case SectionId::start:
             std::tie(module.startfunc, it) = leb128u_decode<uint32_t>(it);
             break;
         case SectionId::element:
-            std::tie(module.elementsec, it) = parser<std::vector<Element>>{}(it);
+            std::tie(module.elementsec, it) = parse_vec<Element>(it);
             break;
         case SectionId::code:
-            std::tie(module.codesec, it) = parser<std::vector<Code>>{}(it);
+            std::tie(module.codesec, it) = parse_vec<Code>(it);
             break;
         case SectionId::data:
-            std::tie(module.datasec, it) = parser<std::vector<Data>>{}(it);
+            std::tie(module.datasec, it) = parse_vec<Data>(it);
             break;
         case SectionId::custom:
             // These sections are ignored for now.

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -22,7 +22,7 @@ struct parser<FuncType>
     }
 };
 
-std::tuple<bool, const uint8_t*> parseGlobalType(const uint8_t* pos)
+std::tuple<bool, const uint8_t*> parse_global_type(const uint8_t* pos)
 {
     // will throw if invalid type
     std::tie(std::ignore, pos) = parser<ValType>{}(pos);
@@ -88,7 +88,7 @@ struct parser<Global>
     parser_result<Global> operator()(const uint8_t* pos)
     {
         Global result;
-        std::tie(result.is_mutable, pos) = parseGlobalType((pos));
+        std::tie(result.is_mutable, pos) = parse_global_type(pos);
         std::tie(result.expression, pos) = parse_constant_expression(pos);
 
         return {result, pos};
@@ -151,7 +151,7 @@ struct parser<Import>
             break;
         case 0x03:
             result.kind = ExternalKind::Global;
-            std::tie(result.desc.global_mutable, pos) = parseGlobalType((pos));
+            std::tie(result.desc.global_mutable, pos) = parse_global_type(pos);
             break;
         default:
             throw parser_error{"unexpected import kind value " + std::to_string(kind)};

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -109,7 +109,7 @@ struct parser<Table>
             throw parser_error{"unexpected table elemtype: " + std::to_string(kind)};
 
         Limits limits;
-        std::tie(limits, pos) = parser<Limits>{}(pos);
+        std::tie(limits, pos) = parse_limits(pos);
 
         return {{limits}, pos};
     }

--- a/lib/fizzy/parser.hpp
+++ b/lib/fizzy/parser.hpp
@@ -98,21 +98,18 @@ struct parser<Locals>
 };
 
 template <typename T>
-struct parser<std::vector<T>>
+parser_result<std::vector<T>> parse_vec(const uint8_t* pos)
 {
-    parser_result<std::vector<T>> operator()(const uint8_t* pos)
-    {
-        uint32_t size;
-        std::tie(size, pos) = leb128u_decode<uint32_t>(pos);
+    uint32_t size;
+    std::tie(size, pos) = leb128u_decode<uint32_t>(pos);
 
-        std::vector<T> result;
-        result.reserve(size);
-        auto inserter = std::back_inserter(result);
-        for (uint32_t i = 0; i < size; ++i)
-            std::tie(inserter, pos) = parser<T>{}(pos);
-        return {result, pos};
-    }
-};
+    std::vector<T> result;
+    result.reserve(size);
+    auto inserter = std::back_inserter(result);
+    for (uint32_t i = 0; i < size; ++i)
+        std::tie(inserter, pos) = parser<T>{}(pos);
+    return {result, pos};
+}
 
 template <>
 struct parser<Memory>
@@ -132,7 +129,7 @@ struct parser<Code>
     {
         const auto [size, pos1] = leb128u_decode<uint32_t>(pos);
 
-        const auto [locals_vec, pos2] = parser<std::vector<Locals>>{}(pos1);
+        const auto [locals_vec, pos2] = parse_vec<Locals>(pos1);
 
         auto result = parse_expr(pos2);
 

--- a/lib/fizzy/parser.hpp
+++ b/lib/fizzy/parser.hpp
@@ -22,44 +22,41 @@ Module parse(bytes_view input);
 parser_result<Code> parse_expr(const uint8_t* input);
 
 template <typename T>
+parser_result<T> parse(const uint8_t* pos);
+
+template <typename T>
 struct parser
 {
 };
 
 template <>
-struct parser<uint8_t>
+inline parser_result<uint8_t> parse(const uint8_t* pos)
 {
-    parser_result<uint8_t> operator()(const uint8_t* pos)
-    {
-        const auto result = *pos;
-        ++pos;
-        return {result, pos};
-    }
-};
+    const auto result = *pos;
+    ++pos;
+    return {result, pos};
+}
 
 template <>
-struct parser<uint32_t>
+inline parser_result<uint32_t> parse(const uint8_t* pos)
 {
-    parser_result<uint32_t> operator()(const uint8_t* pos) { return leb128u_decode<uint32_t>(pos); }
-};
+    return leb128u_decode<uint32_t>(pos);
+}
 
 template <>
-struct parser<ValType>
+inline parser_result<ValType> parse(const uint8_t* pos)
 {
-    parser_result<ValType> operator()(const uint8_t* pos)
+    const auto b = *pos++;
+    switch (b)
     {
-        const auto b = *pos++;
-        switch (b)
-        {
-        case 0x7F:
-            return {ValType::i32, pos};
-        case 0x7E:
-            return {ValType::i64, pos};
-        default:
-            throw parser_error{"invalid valtype " + std::to_string(b)};
-        }
+    case 0x7F:
+        return {ValType::i32, pos};
+    case 0x7E:
+        return {ValType::i64, pos};
+    default:
+        throw parser_error{"invalid valtype " + std::to_string(b)};
     }
-};
+}
 
 inline parser_result<Limits> parse_limits(const uint8_t* pos)
 {
@@ -82,16 +79,13 @@ inline parser_result<Limits> parse_limits(const uint8_t* pos)
 }
 
 template <>
-struct parser<Locals>
+inline parser_result<Locals> parse(const uint8_t* pos)
 {
-    parser_result<Locals> operator()(const uint8_t* pos)
-    {
-        Locals result;
-        std::tie(result.count, pos) = leb128u_decode<uint32_t>(pos);
-        std::tie(result.type, pos) = parser<ValType>{}(pos);
-        return {result, pos};
-    }
-};
+    Locals result;
+    std::tie(result.count, pos) = leb128u_decode<uint32_t>(pos);
+    std::tie(result.type, pos) = parse<ValType>(pos);
+    return {result, pos};
+}
 
 template <typename T>
 parser_result<std::vector<T>> parse_vec(const uint8_t* pos)
@@ -103,36 +97,30 @@ parser_result<std::vector<T>> parse_vec(const uint8_t* pos)
     result.reserve(size);
     auto inserter = std::back_inserter(result);
     for (uint32_t i = 0; i < size; ++i)
-        std::tie(inserter, pos) = parser<T>{}(pos);
+        std::tie(inserter, pos) = parse<T>(pos);
     return {result, pos};
 }
 
 template <>
-struct parser<Memory>
+inline parser_result<Memory> parse(const uint8_t* pos)
 {
-    parser_result<Memory> operator()(const uint8_t* pos)
-    {
-        Limits limits;
-        std::tie(limits, pos) = parse_limits(pos);
-        return {{limits}, pos};
-    }
-};
+    Limits limits;
+    std::tie(limits, pos) = parse_limits(pos);
+    return {{limits}, pos};
+}
 
 template <>
-struct parser<Code>
+inline parser_result<Code> parse(const uint8_t* pos)
 {
-    parser_result<Code> operator()(const uint8_t* pos)
-    {
-        const auto [size, pos1] = leb128u_decode<uint32_t>(pos);
+    const auto [size, pos1] = leb128u_decode<uint32_t>(pos);
 
-        const auto [locals_vec, pos2] = parse_vec<Locals>(pos1);
+    const auto [locals_vec, pos2] = parse_vec<Locals>(pos1);
 
-        auto result = parse_expr(pos2);
+    auto result = parse_expr(pos2);
 
-        for (const auto& l : locals_vec)
-            std::get<0>(result).local_count += l.count;
+    for (const auto& l : locals_vec)
+        std::get<0>(result).local_count += l.count;
 
-        return result;
-    }
-};
+    return result;
+}
 }  // namespace fizzy

--- a/lib/fizzy/parser_expr.cpp
+++ b/lib/fizzy/parser_expr.cpp
@@ -237,7 +237,7 @@ parser_result<Code> parse_expr(const uint8_t* pos)
         case Instr::br_table:
         {
             std::vector<uint32_t> label_indices;
-            std::tie(label_indices, pos) = parser<std::vector<uint32_t>>{}(pos);
+            std::tie(label_indices, pos) = parse_vec<uint32_t>(pos);
             uint32_t default_label_idx;
             std::tie(default_label_idx, pos) = leb128u_decode<uint32_t>(pos);
 

--- a/lib/fizzy/parser_expr.cpp
+++ b/lib/fizzy/parser_expr.cpp
@@ -143,7 +143,7 @@ parser_result<Code> parse_expr(const uint8_t* pos)
             }
             else
             {
-                std::tie(std::ignore, pos) = parser<ValType>{}(pos);  // Report incorrect type.
+                std::tie(std::ignore, pos) = parse<ValType>(pos);  // Report incorrect type.
                 arity = 1;
             }
 
@@ -164,8 +164,8 @@ parser_result<Code> parse_expr(const uint8_t* pos)
             if (type == BlockTypeEmpty)
                 ++pos;
             else
-                std::tie(std::ignore, pos) = parser<ValType>{}(pos);  // Report incorrect type.
-            label_positions.push_back({Instr::loop, 0});              // Mark as not interested.
+                std::tie(std::ignore, pos) = parse<ValType>(pos);  // Report incorrect type.
+            label_positions.push_back({Instr::loop, 0});           // Mark as not interested.
             break;
         }
 
@@ -181,7 +181,7 @@ parser_result<Code> parse_expr(const uint8_t* pos)
             else
             {
                 // Will throw in case of incorrect type.
-                std::tie(std::ignore, pos) = parser<ValType>{}(pos);
+                std::tie(std::ignore, pos) = parse<ValType>(pos);
                 arity = 1;
             }
 

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -52,7 +52,7 @@ TEST(parser, valtype)
 TEST(parser, valtype_vec)
 {
     const auto input = "037f7e7fcc"_bytes;
-    const auto [vec, pos] = parser<std::vector<ValType>>{}(input.data());
+    const auto [vec, pos] = parse_vec<ValType>(input.data());
     EXPECT_EQ(pos, input.data() + 4);
     ASSERT_EQ(vec.size(), 3);
     EXPECT_EQ(vec[0], ValType::i32);

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -42,11 +42,11 @@ TEST(parser, valtype)
 {
     uint8_t b;
     b = 0x7e;
-    EXPECT_EQ(std::get<0>(parser<ValType>{}(&b)), ValType::i64);
+    EXPECT_EQ(std::get<0>(parse<ValType>(&b)), ValType::i64);
     b = 0x7f;
-    EXPECT_EQ(std::get<0>(parser<ValType>{}(&b)), ValType::i32);
+    EXPECT_EQ(std::get<0>(parse<ValType>(&b)), ValType::i32);
     b = 0x7d;
-    EXPECT_THROW(std::get<0>(parser<ValType>{}(&b)), parser_error);
+    EXPECT_THROW(std::get<0>(parse<ValType>(&b)), parser_error);
 }
 
 TEST(parser, valtype_vec)
@@ -98,7 +98,7 @@ TEST(parser, limits_invalid)
 TEST(parser, locals)
 {
     const auto input = "81017f"_bytes;
-    const auto [l, p] = parser<Locals>{}(input.data());
+    const auto [l, p] = parse<Locals>(input.data());
     EXPECT_EQ(l.count, 0x81);
     EXPECT_EQ(l.type, ValType::i32);
 }
@@ -597,7 +597,7 @@ TEST(parser, code_with_empty_expr_2_locals)
     const auto func_2_locals_bin = "01027f0b"_bytes;
     const auto code_bin = add_size_prefix(func_2_locals_bin);
 
-    const auto [code_obj, end_pos1] = parser<Code>{}(code_bin.data());
+    const auto [code_obj, end_pos1] = parse<Code>(code_bin.data());
     EXPECT_EQ(code_obj.local_count, 2);
     ASSERT_EQ(code_obj.instructions.size(), 1);
     EXPECT_EQ(code_obj.instructions[0], Instr::end);
@@ -610,7 +610,7 @@ TEST(parser, code_with_empty_expr_5_locals)
     const auto func_5_locals_bin = "02017f047e0b"_bytes;
     const auto code_bin = add_size_prefix(func_5_locals_bin);
 
-    const auto [code_obj, end_pos1] = parser<Code>{}(code_bin.data());
+    const auto [code_obj, end_pos1] = parse<Code>(code_bin.data());
     EXPECT_EQ(code_obj.local_count, 5);
     ASSERT_EQ(code_obj.instructions.size(), 1);
     EXPECT_EQ(code_obj.instructions[0], Instr::end);

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -63,7 +63,7 @@ TEST(parser, valtype_vec)
 TEST(parser, limits_min)
 {
     const auto input = "007f"_bytes;
-    const auto [limits, pos] = parser<Limits>{}(input.data());
+    const auto [limits, pos] = parse_limits(input.data());
     EXPECT_EQ(limits.min, 0x7f);
     EXPECT_FALSE(limits.max.has_value());
 }
@@ -71,7 +71,7 @@ TEST(parser, limits_min)
 TEST(parser, limits_minmax)
 {
     const auto input = "01207f"_bytes;
-    const auto [limits, pos] = parser<Limits>{}(input.data());
+    const auto [limits, pos] = parse_limits(input.data());
     EXPECT_EQ(limits.min, 0x20);
     EXPECT_TRUE(limits.max.has_value());
     EXPECT_EQ(*limits.max, 0x7f);
@@ -80,19 +80,19 @@ TEST(parser, limits_minmax)
 TEST(parser, DISABLED_limits_min_invalid_too_short)
 {
     const auto input = "00"_bytes;
-    EXPECT_THROW(parser<Limits>{}(input.data()), parser_error);
+    EXPECT_THROW(parse_limits(input.data()), parser_error);
 }
 
 TEST(parser, DISABLED_limits_minmax_invalid_too_short)
 {
     const auto input = "0120"_bytes;
-    EXPECT_THROW(parser<Limits>{}(input.data()), parser_error);
+    EXPECT_THROW(parse_limits(input.data()), parser_error);
 }
 
 TEST(parser, limits_invalid)
 {
     const auto input = "02"_bytes;
-    EXPECT_THROW(parser<Limits>{}(input.data()), parser_error);
+    EXPECT_THROW(parse_limits(input.data()), parser_error);
 }
 
 TEST(parser, locals)


### PR DESCRIPTION
This is a proposal to change template struct specializations to template function specializations.

1. The types that are uses as vector element require template specialization of `parse()`.
2. All other types are implemented as `parse_xxx()`. Including `parse_vec`.

This is only a syntactic change.

