### PR TITLE
Fix sign extension in signed LEB128 decoder

### DIFF
--- a/lib/fizzy/leb128.hpp
+++ b/lib/fizzy/leb128.hpp
@@ -33,7 +33,7 @@ std::pair<T, const uint8_t*> leb128s_decode(const uint8_t* input)
 
     using T_unsigned = typename std::make_unsigned<T>::type;
     T_unsigned result = 0;
-    int result_shift = 0;
+    size_t result_shift = 0;
 
     for (; result_shift < std::numeric_limits<T_unsigned>::digits; ++input, result_shift += 7)
     {
@@ -41,7 +41,7 @@ std::pair<T, const uint8_t*> leb128s_decode(const uint8_t* input)
         if ((*input & 0x80) == 0)
         {
             // sign extend
-            if ((*input & 0x40) != 0)
+            if ((*input & 0x40) != 0 && (result_shift + 7 < sizeof(T_unsigned) * 8))
             {
                 constexpr auto all_ones = std::numeric_limits<T_unsigned>::max();
                 const auto mask = static_cast<T_unsigned>(all_ones << (result_shift + 7));

--- a/test/unittests/leb128_test.cpp
+++ b/test/unittests/leb128_test.cpp
@@ -142,6 +142,8 @@ TEST(leb128, decode_s32)
             {{0xe5, 0x8e, 0xa6, 0x80, 0x00}, 624485}, // 624485 with leading zeroes
             {{0xc0, 0xbb, 0x78}, -123456},
             {{0x9b, 0xf1, 0x59}, -624485},
+            {{0x81, 0x80, 0x80, 0x80, 0x78}, -2147483647},
+            {{0x80, 0x80, 0x80, 0x80, 0x78}, std::numeric_limits<int32_t>::min()},
     };
     // clang-format on
 
@@ -164,6 +166,8 @@ TEST(leb128, decode_s8)
             {{0xff, 0x01}, -1},
             {{0xfe, 0x01}, -2},
             {{0x40}, -64},
+            {{0x81, 0x7f}, -127},
+            {{0x80, 0x7f}, std::numeric_limits<int8_t>::min()},
     };
     // clang-format on
 


### PR DESCRIPTION
This fixes these tests in `int_literals.wast`
```
Line 40: assert_return FAILED Incorrect returned value. Expected: 18446744071562067969 (0xffffffff80000001) Actual: 18446744073709551609 (0xfffffffffffffff9)
Line 41: assert_return FAILED Incorrect returned value. Expected: 18446744071562067968 (0xffffffff80000000) Actual: 18446744073709551608 (0xfffffffffffffff8)
Line 42: assert_return FAILED Incorrect returned value. Expected: 18446744071562067968 (0xffffffff80000000) Actual: 18446744073709551608 (0xfffffffffffffff8)
Line 43: assert_return FAILED Incorrect returned value. Expected: 18446744071562067969 (0xffffffff80000001) Actual: 18446744073709551609 (0xfffffffffffffff9)

```
```
Line 52: assert_return FAILED Incorrect returned value. Expected: 9223372036854775809 (0x8000000000000001) Actual: 18446744073709551553 (0xffffffffffffffc1)
Line 53: assert_return FAILED Incorrect returned value. Expected: 9223372036854775808 (0x8000000000000000) Actual: 18446744073709551552 (0xffffffffffffffc0)
Line 54: assert_return FAILED Incorrect returned value. Expected: 9223372036854775808 (0x8000000000000000) Actual: 18446744073709551552 (0xffffffffffffffc0)
Line 55: assert_return FAILED Incorrect returned value. Expected: 9223372036854775809 (0x8000000000000001) Actual: 18446744073709551553 (0xffffffffffffffc1)
```

The problem happened when encoded signed value has max number of bytes, so for i32 on last iteration `result_shift == 28`, then in sign extension code `all_ones << (result_shift + 7)` was effectively calculated as `all_ones << 3` ((28 + 7) % 32 = 3)

But looks like shifting more bits than the width of type is actually undefined behaviour.

> In any case, if the value of the right operand is negative or is greater or equal to the number of bits in the promoted left operand, the behavior is undefined.