### PR TITLE
test: Replace parser locals tests with full wasm modules

### DIFF
--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -95,12 +95,43 @@ TEST(parser, limits_invalid)
     EXPECT_THROW(parse_limits(input.data()), parser_error);
 }
 
-TEST(parser, locals)
+TEST(parser, code_locals)
 {
-    const auto input = "81017f"_bytes;
-    const auto [l, p] = parse<Locals>(input.data());
-    EXPECT_EQ(l.count, 0x81);
-    EXPECT_EQ(l.type, ValType::i32);
+    const auto wasm_locals = "81017f"_bytes;  // 0x81 x i32.
+    const auto wasm =
+        bytes{wasm_prefix} +
+        make_section(10, make_vec({add_size_prefix(make_vec({wasm_locals}) + "0b"_bytes)}));
+
+    const auto module = parse(wasm);
+    ASSERT_EQ(module.codesec.size(), 1);
+    EXPECT_EQ(module.codesec[0].local_count, 0x81);
+}
+
+TEST(parser, code_locals_2)
+{
+    const auto wasm_locals1 = "017e"_bytes;  // 1 x i64.
+    const auto wasm_locals2 = "027f"_bytes;  // 2 x i32.
+    const auto wasm_locals3 = "037e"_bytes;  // 3 x i64.
+    const auto wasm_locals4 = "047e"_bytes;  // 4 x i64.
+    const auto wasm =
+        bytes{wasm_prefix} +
+        make_section(10,
+            make_vec({add_size_prefix(
+                make_vec({wasm_locals1, wasm_locals2, wasm_locals3, wasm_locals4}) + "0b"_bytes)}));
+
+    const auto module = parse(wasm);
+    ASSERT_EQ(module.codesec.size(), 1);
+    EXPECT_EQ(module.codesec[0].local_count, 1 + 2 + 3 + 4);
+}
+
+TEST(parser, code_locals_invalid_type)
+{
+    const auto wasm_locals = "017b"_bytes;  // 1 x <invalid_type>.
+    const auto wasm =
+        bytes{wasm_prefix} +
+        make_section(10, make_vec({add_size_prefix(make_vec({wasm_locals}) + "0b"_bytes)}));
+
+    EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "invalid valtype 123");
 }
 
 TEST(parser, empty_module)


### PR DESCRIPTION
This replaces the unit test for `Locals` with a one using full wasm module. This removes the need of exposing `parse<Locals>()` function in `fizzy` library.