### PR TITLE
Parser bounds checking

### DIFF
--- a/lib/fizzy/leb128.hpp
+++ b/lib/fizzy/leb128.hpp
@@ -30,7 +30,7 @@ std::pair<T, const uint8_t*> leb128u_decode(const uint8_t* input, const uint8_t*
 }
 
 template <typename T>
-std::pair<T, const uint8_t*> leb128s_decode(const uint8_t* input)
+std::pair<T, const uint8_t*> leb128s_decode(const uint8_t* input, const uint8_t* end)
 {
     static_assert(std::numeric_limits<T>::is_signed);
 
@@ -40,6 +40,9 @@ std::pair<T, const uint8_t*> leb128s_decode(const uint8_t* input)
 
     for (; result_shift < std::numeric_limits<T_unsigned>::digits; ++input, result_shift += 7)
     {
+        if (input == end)
+            throw parser_error("Unexpected EOF");
+
         result |= static_cast<T_unsigned>((static_cast<T_unsigned>(*input) & 0x7F) << result_shift);
         if ((*input & 0x80) == 0)
         {

--- a/lib/fizzy/leb128.hpp
+++ b/lib/fizzy/leb128.hpp
@@ -7,7 +7,7 @@
 namespace fizzy
 {
 template <typename T>
-std::pair<T, const uint8_t*> leb128u_decode(const uint8_t* input)
+std::pair<T, const uint8_t*> leb128u_decode(const uint8_t* input, const uint8_t* end)
 {
     static_assert(!std::numeric_limits<T>::is_signed);
 
@@ -16,6 +16,9 @@ std::pair<T, const uint8_t*> leb128u_decode(const uint8_t* input)
 
     for (; result_shift < std::numeric_limits<T>::digits; ++input, result_shift += 7)
     {
+        if (input == end)
+            throw parser_error("Unexpected EOF");
+
         // TODO this ignores the bits in the last byte other than the least significant one
         // So would not reject some invalid encoding with those bits set.
         result |= static_cast<T>((static_cast<T>(*input) & 0x7F) << result_shift);

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -292,8 +292,7 @@ Module parse(bytes_view input)
             std::tie(module.exportsec, it) = parse_vec<Export>(it);
             break;
         case SectionId::start:
-            std::tie(module.startfunc, it) =
-                leb128u_decode<uint32_t>(it, it + 4);  // FIXME: Bounds checking.
+            std::tie(module.startfunc, it) = leb128u_decode<uint32_t>(it, input.end());
             break;
         case SectionId::element:
             std::tie(module.elementsec, it) = parse_vec<Element>(it);

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -8,10 +8,10 @@ namespace fizzy
 template <>
 inline parser_result<uint8_t> parse(const uint8_t* pos, const uint8_t* end)
 {
-    (void)end;  // FIXME: Bounds checking.
-    const auto result = *pos;
-    ++pos;
-    return {result, pos};
+    if (pos == end)
+        throw parser_error{"Unexpected EOF"};
+
+    return {*pos, pos + 1};
 }
 
 template <>
@@ -126,7 +126,6 @@ inline parser_result<Memory> parse(const uint8_t* pos, const uint8_t* end)
 
 inline parser_result<std::string> parse_string(const uint8_t* pos, const uint8_t* end)
 {
-    // FIXME: Add bounds checking test, the implementation is likely to be changed.
     std::vector<uint8_t> value;
     std::tie(value, pos) = parse_vec<uint8_t>(pos, end);
 

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -267,7 +267,11 @@ Module parse(bytes_view input)
         const auto id = static_cast<SectionId>(*it++);
         uint32_t size;
         std::tie(size, it) = leb128u_decode<uint32_t>(it, input.end());
-        const auto expected_end_pos = it + size;
+
+        const auto expected_section_end = it + size;
+        if (expected_section_end > input.end())
+            throw parser_error("Unexpected EOF");
+
         switch (id)
         {
         case SectionId::type:
@@ -312,10 +316,10 @@ Module parse(bytes_view input)
                 "unknown section encountered " + std::to_string(static_cast<int>(id))};
         }
 
-        if (it != expected_end_pos)
+        if (it != expected_section_end)
         {
             throw parser_error{"incorrect section " + std::to_string(static_cast<int>(id)) +
-                               " size, difference: " + std::to_string(it - expected_end_pos)};
+                               " size, difference: " + std::to_string(it - expected_section_end)};
         }
     }
 

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -55,12 +55,14 @@ inline std::tuple<bool, const uint8_t*> parse_global_type(const uint8_t* pos, co
 inline parser_result<ConstantExpression> parse_constant_expression(
     const uint8_t* pos, const uint8_t* end)
 {
-    (void)end;  // FIXME: Bounds checking.
     ConstantExpression result;
 
     Instr instr;
     do
     {
+        if (pos == end)
+            throw parser_error{"Unexpected EOF"};
+
         instr = static_cast<Instr>(*pos++);
         switch (instr)
         {

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -186,9 +186,11 @@ inline parser_result<Import> parse(const uint8_t* pos, const uint8_t* end)
 template <>
 inline parser_result<Export> parse(const uint8_t* pos, const uint8_t* end)
 {
-    (void)end;  // FIXME: Bounds checking.
     Export result;
     std::tie(result.name, pos) = parse_string(pos, end);
+
+    if (pos == end)
+        throw parser_error{"Unexpected EOF"};
 
     const uint8_t kind = *pos++;
     switch (kind)

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -84,7 +84,7 @@ inline parser_result<ConstantExpression> parse_constant_expression(
         {
             result.kind = ConstantExpression::Kind::Constant;
             int32_t value;
-            std::tie(value, pos) = leb128s_decode<int32_t>(pos);  // FIXME: Bounds checking.
+            std::tie(value, pos) = leb128s_decode<int32_t>(pos, end);
             result.value.constant = static_cast<uint32_t>(value);
             break;
         }
@@ -93,7 +93,7 @@ inline parser_result<ConstantExpression> parse_constant_expression(
         {
             result.kind = ConstantExpression::Kind::Constant;
             int64_t value;
-            std::tie(value, pos) = leb128s_decode<int64_t>(pos);  // FIXME: Bounds checking.
+            std::tie(value, pos) = leb128s_decode<int64_t>(pos, end);
             result.value.constant = static_cast<uint64_t>(value);
             break;
         }

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -150,10 +150,12 @@ inline parser_result<std::string> parse_string(const uint8_t* pos, const uint8_t
 template <>
 inline parser_result<Import> parse(const uint8_t* pos, const uint8_t* end)
 {
-    (void)end;  // FIXME: Bounds checking.
     Import result{};
     std::tie(result.module, pos) = parse_string(pos, end);
     std::tie(result.name, pos) = parse_string(pos, end);
+
+    if (pos == end)
+        throw parser_error{"Unexpected EOF"};
 
     const uint8_t kind = *pos++;
     switch (kind)

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -17,11 +17,15 @@ inline parser_result<uint8_t> parse(const uint8_t* pos, const uint8_t* end)
 template <>
 inline parser_result<FuncType> parse(const uint8_t* pos, const uint8_t* end)
 {
-    (void)end;  // FIXME: Bounds checking.
-    if (*pos != 0x60)
+    if (pos == end)
+        throw parser_error{"Unexpected EOF"};
+
+    const uint8_t kind = *pos++;
+    if (kind != 0x60)
+    {
         throw parser_error{
-            "unexpected byte value " + std::to_string(*pos) + ", expected 0x60 for functype"};
-    ++pos;
+            "unexpected byte value " + std::to_string(kind) + ", expected 0x60 for functype"};
+    }
 
     FuncType result;
     std::tie(result.inputs, pos) = parse_vec<ValType>(pos, end);

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -116,10 +116,12 @@ inline parser_result<Global> parse(const uint8_t* pos, const uint8_t* end)
 template <>
 inline parser_result<Table> parse(const uint8_t* pos, const uint8_t* end)
 {
-    (void)end;  // FIXME: Bounds checking.
-    const uint8_t kind = *pos++;
-    if (kind != FuncRef)
-        throw parser_error{"unexpected table elemtype: " + std::to_string(kind)};
+    if (pos == end)
+        throw parser_error{"Unexpected EOF"};
+
+    const uint8_t elemtype = *pos++;
+    if (elemtype != FuncRef)
+        throw parser_error{"unexpected table elemtype: " + std::to_string(elemtype)};
 
     Limits limits;
     std::tie(limits, pos) = parse_limits(pos, end);

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -266,7 +266,7 @@ Module parse(bytes_view input)
     {
         const auto id = static_cast<SectionId>(*it++);
         uint32_t size;
-        std::tie(size, it) = leb128u_decode<uint32_t>(it, it + 4);  // FIXME: Bounds checking.
+        std::tie(size, it) = leb128u_decode<uint32_t>(it, input.end());
         const auto expected_end_pos = it + size;
         switch (id)
         {

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -35,15 +35,20 @@ inline parser_result<FuncType> parse(const uint8_t* pos, const uint8_t* end)
 
 inline std::tuple<bool, const uint8_t*> parse_global_type(const uint8_t* pos, const uint8_t* end)
 {
-    (void)end;  // FIXME: Bounds checking.
     // will throw if invalid type
     std::tie(std::ignore, pos) = parse<ValType>(pos, end);
 
-    if (*pos != 0x00 && *pos != 0x01)
-        throw parser_error{"unexpected byte value " + std::to_string(*pos) +
+    if (pos == end)
+        throw parser_error{"Unexpected EOF"};
+
+    const uint8_t mutability = *pos++;
+    if (mutability != 0x00 && mutability != 0x01)
+    {
+        throw parser_error{"unexpected byte value " + std::to_string(mutability) +
                            ", expected 0x00 or 0x01 for global mutability"};
-    const bool is_mutable = (*pos == 0x01);
-    ++pos;
+    }
+
+    const bool is_mutable = (mutability == 0x01);
     return {is_mutable, pos};
 }
 

--- a/lib/fizzy/parser.hpp
+++ b/lib/fizzy/parser.hpp
@@ -66,10 +66,10 @@ inline parser_result<Limits> parse_limits(const uint8_t* pos)
 }
 
 template <typename T>
-parser_result<std::vector<T>> parse_vec(const uint8_t* pos)
+inline parser_result<std::vector<T>> parse_vec(const uint8_t* pos, const uint8_t* end)
 {
     uint32_t size;
-    std::tie(size, pos) = leb128u_decode<uint32_t>(pos, pos + 4);  // FIXME: Bounds checking.
+    std::tie(size, pos) = leb128u_decode<uint32_t>(pos, end);
 
     std::vector<T> result;
     result.reserve(size);

--- a/lib/fizzy/parser.hpp
+++ b/lib/fizzy/parser.hpp
@@ -17,17 +17,18 @@ Module parse(bytes_view input);
 parser_result<Code> parse_expr(const uint8_t* input);
 
 template <typename T>
-parser_result<T> parse(const uint8_t* pos);
+parser_result<T> parse(const uint8_t* pos, const uint8_t* end);
 
 template <>
-inline parser_result<uint32_t> parse(const uint8_t* pos)
+inline parser_result<uint32_t> parse(const uint8_t* pos, const uint8_t* end)
 {
-    return leb128u_decode<uint32_t>(pos, pos + 4);  // FIXME: Bounds checking.
+    return leb128u_decode<uint32_t>(pos, end);
 }
 
 template <>
-inline parser_result<ValType> parse(const uint8_t* pos)
+inline parser_result<ValType> parse(const uint8_t* pos, const uint8_t* end)
 {
+    (void)end;  // FIXME: Bounds checking.
     const auto b = *pos++;
     switch (b)
     {
@@ -43,20 +44,19 @@ inline parser_result<ValType> parse(const uint8_t* pos)
     }
 }
 
-inline parser_result<Limits> parse_limits(const uint8_t* pos)
+inline parser_result<Limits> parse_limits(const uint8_t* pos, const uint8_t* end)
 {
+    (void)end;  // FIXME: Bounds checking.
     Limits result;
     const auto b = *pos++;
     switch (b)
     {
     case 0x00:
-        // FIXME: Bounds checking.
-        std::tie(result.min, pos) = leb128u_decode<uint32_t>(pos, pos + 4);
+        std::tie(result.min, pos) = leb128u_decode<uint32_t>(pos, end);
         return {result, pos};
     case 0x01:
-        // FIXME: Bounds checking.
-        std::tie(result.min, pos) = leb128u_decode<uint32_t>(pos, pos + 4);
-        std::tie(result.max, pos) = leb128u_decode<uint32_t>(pos, pos + 4);
+        std::tie(result.min, pos) = leb128u_decode<uint32_t>(pos, end);
+        std::tie(result.max, pos) = leb128u_decode<uint32_t>(pos, end);
         if (result.min > *result.max)
             throw parser_error("malformed limits (minimum is larger than maximum)");
         return {result, pos};
@@ -75,7 +75,7 @@ inline parser_result<std::vector<T>> parse_vec(const uint8_t* pos, const uint8_t
     result.reserve(size);
     auto inserter = std::back_inserter(result);
     for (uint32_t i = 0; i < size; ++i)
-        std::tie(inserter, pos) = parse<T>(pos);
+        std::tie(inserter, pos) = parse<T>(pos, end);
     return {result, pos};
 }
 }  // namespace fizzy

--- a/lib/fizzy/parser.hpp
+++ b/lib/fizzy/parser.hpp
@@ -28,7 +28,9 @@ inline parser_result<uint32_t> parse(const uint8_t* pos, const uint8_t* end)
 template <>
 inline parser_result<ValType> parse(const uint8_t* pos, const uint8_t* end)
 {
-    (void)end;  // FIXME: Bounds checking.
+    if (pos == end)
+        throw parser_error{"Unexpected EOF"};
+
     const auto b = *pos++;
     switch (b)
     {

--- a/lib/fizzy/parser.hpp
+++ b/lib/fizzy/parser.hpp
@@ -48,7 +48,9 @@ inline parser_result<ValType> parse(const uint8_t* pos, const uint8_t* end)
 
 inline parser_result<Limits> parse_limits(const uint8_t* pos, const uint8_t* end)
 {
-    (void)end;  // FIXME: Bounds checking.
+    if (pos == end)
+        throw parser_error{"Unexpected EOF"};
+
     Limits result;
     const auto b = *pos++;
     switch (b)

--- a/lib/fizzy/parser.hpp
+++ b/lib/fizzy/parser.hpp
@@ -22,7 +22,7 @@ parser_result<T> parse(const uint8_t* pos);
 template <>
 inline parser_result<uint32_t> parse(const uint8_t* pos)
 {
-    return leb128u_decode<uint32_t>(pos);
+    return leb128u_decode<uint32_t>(pos, pos + 4);  // FIXME: Bounds checking.
 }
 
 template <>
@@ -50,11 +50,13 @@ inline parser_result<Limits> parse_limits(const uint8_t* pos)
     switch (b)
     {
     case 0x00:
-        std::tie(result.min, pos) = leb128u_decode<uint32_t>(pos);
+        // FIXME: Bounds checking.
+        std::tie(result.min, pos) = leb128u_decode<uint32_t>(pos, pos + 4);
         return {result, pos};
     case 0x01:
-        std::tie(result.min, pos) = leb128u_decode<uint32_t>(pos);
-        std::tie(result.max, pos) = leb128u_decode<uint32_t>(pos);
+        // FIXME: Bounds checking.
+        std::tie(result.min, pos) = leb128u_decode<uint32_t>(pos, pos + 4);
+        std::tie(result.max, pos) = leb128u_decode<uint32_t>(pos, pos + 4);
         if (result.min > *result.max)
             throw parser_error("malformed limits (minimum is larger than maximum)");
         return {result, pos};
@@ -67,7 +69,7 @@ template <typename T>
 parser_result<std::vector<T>> parse_vec(const uint8_t* pos)
 {
     uint32_t size;
-    std::tie(size, pos) = leb128u_decode<uint32_t>(pos);
+    std::tie(size, pos) = leb128u_decode<uint32_t>(pos, pos + 4);  // FIXME: Bounds checking.
 
     std::vector<T> result;
     result.reserve(size);

--- a/lib/fizzy/parser_expr.cpp
+++ b/lib/fizzy/parser_expr.cpp
@@ -340,7 +340,7 @@ parser_result<Code> parse_expr(const uint8_t* pos)
         case Instr::i32_const:
         {
             int32_t imm;
-            std::tie(imm, pos) = leb128s_decode<int32_t>(pos);
+            std::tie(imm, pos) = leb128s_decode<int32_t>(pos, pos + 5);  // FIXME: Bounds checking.
             push(code.immediates, static_cast<uint32_t>(imm));
             break;
         }
@@ -348,7 +348,7 @@ parser_result<Code> parse_expr(const uint8_t* pos)
         case Instr::i64_const:
         {
             int64_t imm;
-            std::tie(imm, pos) = leb128s_decode<int64_t>(pos);
+            std::tie(imm, pos) = leb128s_decode<int64_t>(pos, pos + 10);  // FIXME: Bounds checking.
             push(code.immediates, static_cast<uint64_t>(imm));
             break;
         }

--- a/lib/fizzy/parser_expr.cpp
+++ b/lib/fizzy/parser_expr.cpp
@@ -215,7 +215,8 @@ parser_result<Code> parse_expr(const uint8_t* pos)
             }
             else
             {
-                std::tie(std::ignore, pos) = parse<ValType>(pos);  // Report incorrect type.
+                std::tie(std::ignore, pos) = parse<ValType>(
+                    pos, pos + 1);  // FIXME: Bounds checking. // Report incorrect type.
                 arity = 1;
             }
 
@@ -236,8 +237,9 @@ parser_result<Code> parse_expr(const uint8_t* pos)
             if (type == BlockTypeEmpty)
                 ++pos;
             else
-                std::tie(std::ignore, pos) = parse<ValType>(pos);  // Report incorrect type.
-            label_positions.push_back({Instr::loop, 0});           // Mark as not interested.
+                std::tie(std::ignore, pos) = parse<ValType>(
+                    pos, pos + 1);  // FIXME: Bounds checking. // Report incorrect type.
+            label_positions.push_back({Instr::loop, 0});  // Mark as not interested.
             break;
         }
 
@@ -253,7 +255,8 @@ parser_result<Code> parse_expr(const uint8_t* pos)
             else
             {
                 // Will throw in case of incorrect type.
-                std::tie(std::ignore, pos) = parse<ValType>(pos);
+                std::tie(std::ignore, pos) =
+                    parse<ValType>(pos, pos + 1);  // FIXME: Bounds checking.
                 arity = 1;
             }
 

--- a/lib/fizzy/parser_expr.cpp
+++ b/lib/fizzy/parser_expr.cpp
@@ -309,7 +309,8 @@ parser_result<Code> parse_expr(const uint8_t* pos)
         case Instr::br_table:
         {
             std::vector<uint32_t> label_indices;
-            std::tie(label_indices, pos) = parse_vec<uint32_t>(pos);
+            std::tie(label_indices, pos) =
+                parse_vec<uint32_t>(pos, pos + 1000);  // FIXME: Bounds checking.
             uint32_t default_label_idx;
             std::tie(default_label_idx, pos) =
                 leb128u_decode<uint32_t>(pos, pos + 4);  // FIXME: Bounds checking.

--- a/lib/fizzy/parser_expr.cpp
+++ b/lib/fizzy/parser_expr.cpp
@@ -301,7 +301,7 @@ parser_result<Code> parse_expr(const uint8_t* pos)
         case Instr::call:
         {
             uint32_t imm;
-            std::tie(imm, pos) = leb128u_decode<uint32_t>(pos);
+            std::tie(imm, pos) = leb128u_decode<uint32_t>(pos, pos + 4);  // FIXME: Bounds checking.
             push(code.immediates, imm);
             break;
         }
@@ -311,7 +311,8 @@ parser_result<Code> parse_expr(const uint8_t* pos)
             std::vector<uint32_t> label_indices;
             std::tie(label_indices, pos) = parse_vec<uint32_t>(pos);
             uint32_t default_label_idx;
-            std::tie(default_label_idx, pos) = leb128u_decode<uint32_t>(pos);
+            std::tie(default_label_idx, pos) =
+                leb128u_decode<uint32_t>(pos, pos + 4);  // FIXME: Bounds checking.
 
             push(code.immediates, static_cast<uint32_t>(label_indices.size()));
             for (const auto idx : label_indices)
@@ -323,7 +324,7 @@ parser_result<Code> parse_expr(const uint8_t* pos)
         case Instr::call_indirect:
         {
             uint32_t imm;
-            std::tie(imm, pos) = leb128u_decode<uint32_t>(pos);
+            std::tie(imm, pos) = leb128u_decode<uint32_t>(pos, pos + 4);  // FIXME: Bounds checking.
             push(code.immediates, imm);
 
             const uint8_t tableidx{*pos++};
@@ -369,11 +370,12 @@ parser_result<Code> parse_expr(const uint8_t* pos)
         case Instr::i64_store32:
         {
             // alignment
-            std::tie(std::ignore, pos) = leb128u_decode<uint32_t>(pos);
+            std::tie(std::ignore, pos) =
+                leb128u_decode<uint32_t>(pos, pos + 4);  // FIXME: Bounds checking.
 
             // offset
             uint32_t imm;
-            std::tie(imm, pos) = leb128u_decode<uint32_t>(pos);
+            std::tie(imm, pos) = leb128u_decode<uint32_t>(pos, pos + 4);  // FIXME: Bounds checking.
             push(code.immediates, imm);
             break;
         }

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -585,6 +585,12 @@ TEST(parser, global_valtype_out_of_bounds)
     EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "Unexpected EOF");
 }
 
+TEST(parser, global_mutability_out_of_bounds)
+{
+    const auto wasm = bytes{wasm_prefix} + make_section(6, make_vec({"7f"_bytes}));
+    EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "Unexpected EOF");
+}
+
 TEST(parser, export_single_function)
 {
     const auto section_contents = make_vec({bytes{0x03, 'a', 'b', 'c', 0x00, 0x42}});

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -357,6 +357,12 @@ TEST(parser, import_invalid_kind)
     EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "unexpected import kind value 4");
 }
 
+TEST(parser, import_kind_out_of_bounds)
+{
+    const auto wasm = bytes{wasm_prefix} + make_section(2, make_vec({"0000"_bytes}));
+    EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "Unexpected EOF");
+}
+
 TEST(parser, memory_and_imported_memory)
 {
     // (import "js" "mem"(memory 1))

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -138,7 +138,7 @@ TEST(parser, code_locals_invalid_type)
     EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "invalid valtype 123");
 }
 
-TEST(parser, empty_module)
+TEST(parser, module_empty)
 {
     const auto module = parse(wasm_prefix);
     EXPECT_EQ(module.typesec.size(), 0);
@@ -172,6 +172,12 @@ TEST(parser, custom_section_nonempty)
     EXPECT_EQ(module.typesec.size(), 0);
     EXPECT_EQ(module.funcsec.size(), 0);
     EXPECT_EQ(module.codesec.size(), 0);
+}
+
+TEST(parser, custom_section_size_out_of_bounds)
+{
+    const auto wasm = bytes{wasm_prefix} + "0080"_bytes;
+    EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "Unexpected EOF");
 }
 
 TEST(parser, functype_wrong_prefix)

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -612,6 +612,14 @@ TEST(parser, global_constant_expression_out_of_bounds)
     // i32, immutable, i32_const, 0, EOF.
     const auto wasm2 = bytes{wasm_prefix} + make_section(6, make_vec({"7f004100"_bytes}));
     EXPECT_THROW_MESSAGE(parse(wasm2), parser_error, "Unexpected EOF");
+
+    // i32, immutable, i32_const, 0x81, EOF.
+    const auto wasm3 = bytes{wasm_prefix} + make_section(6, make_vec({"7f004181"_bytes}));
+    EXPECT_THROW_MESSAGE(parse(wasm3), parser_error, "Unexpected EOF");
+
+    // i32, immutable, i64_const, 0x808081, EOF.
+    const auto wasm4 = bytes{wasm_prefix} + make_section(6, make_vec({"7f0042808081"_bytes}));
+    EXPECT_THROW_MESSAGE(parse(wasm4), parser_error, "Unexpected EOF");
 }
 
 TEST(parser, export_single_function)

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -567,6 +567,12 @@ TEST(parser, global_initializer_expression_invalid_instruction)
         "unexpected instruction in the global initializer expression: 0");
 }
 
+TEST(parser, global_valtype_out_of_bounds)
+{
+    const auto wasm = bytes{wasm_prefix} + make_section(6, make_vec({""_bytes}));
+    EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "Unexpected EOF");
+}
+
 TEST(parser, export_single_function)
 {
     const auto section_contents = make_vec({bytes{0x03, 'a', 'b', 'c', 0x00, 0x42}});

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -465,6 +465,12 @@ TEST(parser, table_invalid_elemtype)
     EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "unexpected table elemtype: 113");
 }
 
+TEST(parser, table_elemtype_out_of_bounds)
+{
+    const auto wasm = bytes{wasm_prefix} + make_section(4, make_vec({""_bytes}));
+    EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "Unexpected EOF");
+}
+
 TEST(parser, memory_single_min_limit)
 {
     const auto section_contents = "01007f"_bytes;

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -655,6 +655,12 @@ TEST(parser, export_invalid_kind)
     EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "unexpected export kind value 4");
 }
 
+TEST(parser, export_kind_out_of_bounds)
+{
+    const auto wasm = bytes{wasm_prefix} + make_section(7, make_vec({"00"_bytes}));
+    EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "Unexpected EOF");
+}
+
 TEST(parser, export_name_out_of_bounds)
 {
     const auto wasm1 = bytes{wasm_prefix} + make_section(7, make_vec({"01"_bytes}));

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -180,6 +180,12 @@ TEST(parser, custom_section_size_out_of_bounds)
     EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "Unexpected EOF");
 }
 
+TEST(parser, custom_section_out_of_bounds)
+{
+    const auto wasm = bytes{wasm_prefix} + make_invalid_size_section(0, 31, {});
+    EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "Unexpected EOF");
+}
+
 TEST(parser, functype_wrong_prefix)
 {
     const auto section_contents =
@@ -204,7 +210,8 @@ TEST(parser, type_section_smaller_than_expected)
     const auto section_contents = "01"_bytes + functype_void_to_void + "fe"_bytes;
     const auto bin =
         bytes{wasm_prefix} +
-        make_invalid_size_section(1, size_t{section_contents.size() + 1}, section_contents);
+        make_invalid_size_section(1, size_t{section_contents.size() + 1}, section_contents) +
+        "00"_bytes;
     EXPECT_THROW_MESSAGE(parse(bin), parser_error, "incorrect section 1 size, difference: -2");
 }
 
@@ -382,6 +389,12 @@ TEST(parser, function_section_with_multiple_functions)
     EXPECT_EQ(module.funcsec[1], 1);
     EXPECT_EQ(module.funcsec[2], 0x42);
     EXPECT_EQ(module.funcsec[3], 0xff);
+}
+
+TEST(parser, function_section_end_out_of_bounds)
+{
+    const auto wasm = bytes{wasm_prefix} + make_invalid_size_section(3, 2, {});
+    EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "Unexpected EOF");
 }
 
 TEST(parser, table_single_min_limit)

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -608,6 +608,15 @@ TEST(parser, export_invalid_kind)
     EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "unexpected export kind value 4");
 }
 
+TEST(parser, export_name_out_of_bounds)
+{
+    const auto wasm1 = bytes{wasm_prefix} + make_section(7, make_vec({"01"_bytes}));
+    EXPECT_THROW_MESSAGE(parse(wasm1), parser_error, "Unexpected EOF");
+
+    const auto wasm2 = bytes{wasm_prefix} + make_section(7, make_vec({"7faabbccddeeff"_bytes}));
+    EXPECT_THROW_MESSAGE(parse(wasm2), parser_error, "Unexpected EOF");
+}
+
 TEST(parser, start)
 {
     const auto func_section = make_vec({"00"_bytes, "00"_bytes});

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -591,6 +591,17 @@ TEST(parser, global_mutability_out_of_bounds)
     EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "Unexpected EOF");
 }
 
+TEST(parser, global_constant_expression_out_of_bounds)
+{
+    // i32, immutable, EOF.
+    const auto wasm1 = bytes{wasm_prefix} + make_section(6, make_vec({"7f00"_bytes}));
+    EXPECT_THROW_MESSAGE(parse(wasm1), parser_error, "Unexpected EOF");
+
+    // i32, immutable, i32_const, 0, EOF.
+    const auto wasm2 = bytes{wasm_prefix} + make_section(6, make_vec({"7f004100"_bytes}));
+    EXPECT_THROW_MESSAGE(parse(wasm2), parser_error, "Unexpected EOF");
+}
+
 TEST(parser, export_single_function)
 {
     const auto section_contents = make_vec({bytes{0x03, 'a', 'b', 'c', 0x00, 0x42}});

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -635,6 +635,12 @@ TEST(parser, start_module_with_imports_invalid_index)
     EXPECT_THROW_MESSAGE(parse(bin), parser_error, "invalid start function index");
 }
 
+TEST(parser, start_index_decode_out_of_bounds)
+{
+    const auto wasm = bytes{wasm_prefix} + make_section(8, "ff"_bytes);
+    EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "Unexpected EOF");
+}
+
 TEST(parser, element_section)
 {
     const auto table_contents = bytes{0x01, 0x70, 0x00, 0x7f};

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -56,7 +56,7 @@ TEST(parser, valtype)
 TEST(parser, valtype_vec)
 {
     const auto input = "037f7e7fcc"_bytes;
-    const auto [vec, pos] = parse_vec<ValType>(input.data());
+    const auto [vec, pos] = parse_vec<ValType>(input.data(), input.data() + input.size());
     EXPECT_EQ(pos, input.data() + 4);
     ASSERT_EQ(vec.size(), 3);
     EXPECT_EQ(vec[0], ValType::i32);
@@ -154,6 +154,16 @@ TEST(parser, module_with_wrong_prefix)
         parse("006173d600000000"_bytes), parser_error, "invalid wasm module prefix");
     EXPECT_THROW_MESSAGE(
         parse("006173d602000000"_bytes), parser_error, "invalid wasm module prefix");
+}
+
+TEST(parser, section_vec_size_out_of_bounds)
+{
+    const auto malformed_vec_size = "81"_bytes;
+    for (auto secid : {1, 2, 3, 4, 5, 6, 7, 9, 10, 11})
+    {
+        const auto wasm = bytes{wasm_prefix} + make_section(uint8_t(secid), malformed_vec_size);
+        EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "Unexpected EOF");
+    }
 }
 
 TEST(parser, custom_section_empty)

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -290,6 +290,12 @@ TEST(parser, type_section_with_multiple_functypes)
     EXPECT_EQ(module.codesec.size(), 0);
 }
 
+TEST(parser, type_section_functype_out_of_bounds)
+{
+    const auto wasm = bytes{wasm_prefix} + make_section(1, make_vec({""_bytes}));
+    EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "Unexpected EOF");
+}
+
 TEST(parser, import_single_function)
 {
     const auto section_contents = bytes{0x01, 0x03, 'm', 'o', 'd', 0x03, 'f', 'o', 'o', 0x00, 0x42};

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -499,6 +499,12 @@ TEST(parser, memory_multi_min_limit)
         parse(bin), parser_error, "too many memory sections (at most one is allowed)");
 }
 
+TEST(parser, memory_limits_kind_out_of_bounds)
+{
+    const auto wasm = bytes{wasm_prefix} + make_section(5, make_vec({""_bytes}));
+    EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "Unexpected EOF");
+}
+
 TEST(parser, global_single_mutable_const_inited)
 {
     const auto section_contents = bytes{0x01, 0x7f, 0x01, uint8_t(Instr::i32_const), 0x10, 0x0b};


### PR DESCRIPTION
This adds input buffer bounds checking in wasm binary parser, except for `parse_expr` which parses instructions (to be done later).