### PR TITLE
Optimize push() helper in parse_expr()

### DIFF
--- a/lib/fizzy/parser_expr.cpp
+++ b/lib/fizzy/parser_expr.cpp
@@ -15,8 +15,9 @@ inline void store(uint8_t* dst, T value) noexcept
 template <typename T>
 inline void push(bytes& b, T value)
 {
-    b.resize(b.size() + sizeof(value));
-    store(&b[b.size() - sizeof(value)], value);
+    uint8_t storage[sizeof(T)];
+    store(storage, value);
+    b.append(storage, sizeof(storage));
 }
 
 struct LabelPosition


### PR DESCRIPTION
Requires #158, #163.

```
Comparing bin/fizzy-bench-master to bin/fizzy-bench
Benchmark                                          Time             CPU      Time Old      Time New       CPU Old       CPU New
-------------------------------------------------------------------------------------------------------------------------------
fizzy/parse/blake2b                             -0.2990         -0.2990         14528         10183         14528         10183
fizzy/parse/blake2b                             -0.3017         -0.3017         14533         10148         14533         10148
fizzy/parse/blake2b                             -0.3015         -0.3015         14520         10143         14520         10143
fizzy/parse/blake2b                             -0.3001         -0.3002         14603         10220         14603         10220
fizzy/parse/blake2b                             -0.2980         -0.2980         14537         10206         14537         10206
fizzy/parse/blake2b                             -0.3004         -0.3004         14538         10170         14538         10170
fizzy/parse/blake2b                             -0.2993         -0.2993         14549         10195         14549         10195
fizzy/parse/blake2b                             -0.3004         -0.3004         14560         10186         14560         10187
fizzy/parse/blake2b                             -0.3024         -0.3024         14579         10170         14579         10170
fizzy/parse/blake2b                             -0.3000         -0.3000         14582         10208         14582         10208
fizzy/parse/blake2b_pvalue                       0.0002          0.0002      U Test, Repetitions: 10 vs 10
fizzy/parse/blake2b_mean                        -0.3003         -0.3003         14553         10183         14553         10183
fizzy/parse/blake2b_median                      -0.2997         -0.2997         14544         10185         14544         10185
fizzy/parse/blake2b_stddev                      -0.0640         -0.0653            27            25            27            25
fizzy/parse/memset                              -0.2521         -0.2521          3778          2826          3778          2826
fizzy/parse/memset                              -0.2523         -0.2523          3773          2821          3773          2821
fizzy/parse/memset                              -0.2516         -0.2516          3774          2824          3774          2824
fizzy/parse/memset                              -0.2577         -0.2577          3781          2807          3781          2807
fizzy/parse/memset                              -0.2535         -0.2535          3772          2816          3772          2816
fizzy/parse/memset                              -0.2557         -0.2557          3773          2809          3773          2809
fizzy/parse/memset                              -0.2535         -0.2535          3770          2814          3770          2814
fizzy/parse/memset                              -0.2574         -0.2574          3786          2812          3786          2812
fizzy/parse/memset                              -0.2557         -0.2557          3778          2812          3778          2812
fizzy/parse/memset                              -0.2550         -0.2550          3773          2811          3773          2811
fizzy/parse/memset_pvalue                        0.0002          0.0002      U Test, Repetitions: 10 vs 10
fizzy/parse/memset_mean                         -0.2545         -0.2545          3776          2815          3776          2815
fizzy/parse/memset_median                       -0.2545         -0.2545          3774          2813          3774          2813
fizzy/parse/memset_stddev                       +0.3188         +0.3213             5             7             5             7
fizzy/parse/mul256_opt0                         -0.3247         -0.3247          4674          3156          4674          3156
fizzy/parse/mul256_opt0                         -0.3233         -0.3233          4667          3158          4667          3158
fizzy/parse/mul256_opt0                         -0.3212         -0.3212          4659          3162          4659          3162
fizzy/parse/mul256_opt0                         -0.3223         -0.3223          4663          3160          4663          3160
fizzy/parse/mul256_opt0                         -0.3219         -0.3219          4663          3162          4663          3162
fizzy/parse/mul256_opt0                         -0.3258         -0.3258          4694          3165          4694          3165
fizzy/parse/mul256_opt0                         -0.3259         -0.3259          4696          3166          4696          3166
fizzy/parse/mul256_opt0                         -0.3262         -0.3262          4686          3158          4686          3158
fizzy/parse/mul256_opt0                         -0.3254         -0.3254          4688          3163          4688          3163
fizzy/parse/mul256_opt0                         -0.3214         -0.3214          4687          3181          4687          3181
fizzy/parse/mul256_opt0_pvalue                   0.0002          0.0002      U Test, Repetitions: 10 vs 10
fizzy/parse/mul256_opt0_mean                    -0.3238         -0.3238          4678          3163          4678          3163
fizzy/parse/mul256_opt0_median                  -0.3244         -0.3244          4680          3162          4680          3162
fizzy/parse/mul256_opt0_stddev                  -0.5155         -0.5149            14             7            14             7
fizzy/parse/sha1                                -0.3198         -0.3198         19905         13539         19905         13539
fizzy/parse/sha1                                -0.3238         -0.3238         19915         13466         19915         13466
fizzy/parse/sha1                                -0.3214         -0.3214         19896         13502         19896         13502
fizzy/parse/sha1                                -0.3243         -0.3243         19896         13443         19896         13443
fizzy/parse/sha1                                -0.3217         -0.3217         19904         13501         19904         13501
fizzy/parse/sha1                                -0.3230         -0.3230         19891         13466         19891         13467
fizzy/parse/sha1                                -0.3241         -0.3241         19937         13475         19937         13475
fizzy/parse/sha1                                -0.3244         -0.3244         19934         13467         19934         13467
fizzy/parse/sha1                                -0.3249         -0.3249         19911         13441         19911         13441
fizzy/parse/sha1                                -0.3251         -0.3251         19975         13481         19975         13481
fizzy/parse/sha1_pvalue                          0.0002          0.0002      U Test, Repetitions: 10 vs 10
fizzy/parse/sha1_mean                           -0.3233         -0.3233         19916         13478         19916         13478
fizzy/parse/sha1_median                         -0.3233         -0.3233         19908         13471         19908         13471
fizzy/parse/sha1_stddev                         +0.1515         +0.1550            26            30            26            30
fizzy/parse/micro/spinner                       -0.0323         -0.0323           624           604           624           604
fizzy/parse/micro/spinner                       -0.0362         -0.0362           627           604           627           604
fizzy/parse/micro/spinner                       -0.0346         -0.0346           627           605           627           605
fizzy/parse/micro/spinner                       -0.0315         -0.0315           625           605           625           605
fizzy/parse/micro/spinner                       -0.0291         -0.0291           624           606           624           606
fizzy/parse/micro/spinner                       -0.0301         -0.0301           624           605           624           605
fizzy/parse/micro/spinner                       -0.0329         -0.0329           624           604           624           604
fizzy/parse/micro/spinner                       -0.0352         -0.0352           626           604           626           604
fizzy/parse/micro/spinner                       -0.0342         -0.0342           626           605           626           605
fizzy/parse/micro/spinner                       -0.0330         -0.0330           625           604           625           604
fizzy/parse/micro/spinner_pvalue                 0.0002          0.0002      U Test, Repetitions: 10 vs 10
fizzy/parse/micro/spinner_mean                  -0.0329         -0.0329           625           605           625           605
fizzy/parse/micro/spinner_median                -0.0327         -0.0326           625           604           625           604
fizzy/parse/micro/spinner_stddev                -0.4834         -0.4855             1             1             1             1
```