### PR TITLE
cmake: Build Debug Hunter debs for Debug build type 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,7 @@ commands:
 
             # Create the toolchain.info file for cache key.
             echo $TOOLCHAIN >> toolchain.info
+            echo $BUILD_TYPE >> toolchain.info
             $CXX --version >> toolchain.info
       - restore_cache:
           name: "Restore Hunter cache"

--- a/cmake/Hunter/init.cmake
+++ b/cmake/Hunter/init.cmake
@@ -14,7 +14,13 @@ if(NOT huntergate_POPULATED)
     include(${huntergate_SOURCE_DIR}/cmake/HunterGate.cmake)
 endif()
 
-set(HUNTER_CONFIGURATION_TYPES Release)
+if(NOT CMAKE_CONFIGURATION_TYPES)
+    if(CMAKE_BUILD_TYPE STREQUAL Debug)
+        set(HUNTER_CONFIGURATION_TYPES Debug)
+    else()
+        set(HUNTER_CONFIGURATION_TYPES Release)
+    endif()
+endif()
 
 HunterGate(
     URL https://github.com/cpp-pm/hunter/archive/v0.23.239.tar.gz


### PR DESCRIPTION
Because we accidentally discovered issue with usage of libbenchmark let the Debug build use Debug Hunter deps officially. This is going to be tested by clang-latest-asan.