### PR TITLE
Add APIs to find exports

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -95,6 +95,7 @@ jobs:
         name: "Check wat2wasm4cpp"
         command: |
           export PATH=$PATH:~/bin
+          ./wat2wasm4cpp.py test/unittests/api_test.cpp
           ./wat2wasm4cpp.py test/unittests/end_to_end_test.cpp
           ./wat2wasm4cpp.py test/unittests/execute_call_test.cpp
           ./wat2wasm4cpp.py test/unittests/execute_control_test.cpp

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -1451,6 +1451,17 @@ std::optional<FuncIdx> find_exported_function(const Module& module, std::string_
     return {};
 }
 
+std::optional<ExternalFunction> find_exported_function(Instance& instance, std::string_view name)
+{
+    const auto opt_index = find_export(instance, ExternalKind::Function, name);
+    if (!opt_index.has_value())
+        return std::nullopt;
+
+    return [idx = *opt_index, &instance](fizzy::Instance&, std::vector<uint64_t> args) {
+        return execute(instance, idx, std::move(args));
+    };
+}
+
 std::optional<ExternalGlobal> find_exported_global(Instance& instance, std::string_view name)
 {
     const auto opt_index = find_export(instance, ExternalKind::Global, name);

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -79,4 +79,8 @@ std::optional<FuncIdx> find_exported_function(const Module& module, std::string_
 
 // Find exported global by name.
 std::optional<ExternalGlobal> find_exported_global(Instance& instance, std::string_view name);
+
+// Find exported table by name.
+std::optional<ExternalTable> find_exported_table(Instance& instance, std::string_view name);
+
 }  // namespace fizzy

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -83,4 +83,7 @@ std::optional<ExternalGlobal> find_exported_global(Instance& instance, std::stri
 // Find exported table by name.
 std::optional<ExternalTable> find_exported_table(Instance& instance, std::string_view name);
 
+// Find exported memory by name.
+std::optional<ExternalMemory> find_exported_memory(Instance& instance, std::string_view name);
+
 }  // namespace fizzy

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -77,6 +77,9 @@ execution_result execute(const Module& module, FuncIdx func_idx, std::vector<uin
 // Find exported function index by name.
 std::optional<FuncIdx> find_exported_function(const Module& module, std::string_view name);
 
+// Find exported function by name.
+std::optional<ExternalFunction> find_exported_function(Instance& instance, std::string_view name);
+
 // Find exported global by name.
 std::optional<ExternalGlobal> find_exported_global(Instance& instance, std::string_view name);
 

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -76,4 +76,7 @@ execution_result execute(const Module& module, FuncIdx func_idx, std::vector<uin
 
 // Find exported function index by name.
 std::optional<FuncIdx> find_exported_function(const Module& module, std::string_view name);
+
+// Find exported global by name.
+std::optional<ExternalGlobal> find_exported_global(Instance& instance, std::string_view name);
 }  // namespace fizzy

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -78,6 +78,7 @@ TEST(api, find_exported_global)
     EXPECT_EQ(*opt_global->value, 3);
     EXPECT_FALSE(opt_global->is_mutable);
 
+    EXPECT_FALSE(find_exported_global(instance, "g5"));
     EXPECT_FALSE(find_exported_global(instance, "f"));
     EXPECT_FALSE(find_exported_global(instance, "tab"));
     EXPECT_FALSE(find_exported_global(instance, "mem"));
@@ -125,4 +126,112 @@ TEST(api, find_exported_global)
     auto instance_no_globals = instantiate(parse(wasm_no_globals));
 
     EXPECT_FALSE(find_exported_global(instance_no_globals, "g1").has_value());
+}
+
+TEST(api, find_exported_table)
+{
+    /* wat2wasm
+    (module
+      (func $f (export "f") nop)
+      (func $g nop)
+      (global (export "g1") i32 (i32.const 0))
+      (table (export "tab") 2 20 anyfunc)
+      (elem 0 (i32.const 0) $g $f)
+      (memory (export "mem") 0)
+    )
+     */
+    const auto wasm = from_hex(
+        "0061736d0100000001040160000003030200000405017001021405030100000606017f0041000b071604016600"
+        "000267310300037461620100036d656d02000908010041000b0201000a09020300010b0300010b");
+
+    auto instance = instantiate(parse(wasm));
+
+    auto opt_table = find_exported_table(instance, "tab");
+    ASSERT_TRUE(opt_table);
+    EXPECT_EQ(opt_table->table, instance.table.get());
+    EXPECT_EQ(opt_table->table->size(), 2);
+    EXPECT_EQ((*opt_table->table)[0], 1);
+    EXPECT_EQ((*opt_table->table)[1], 0);
+    EXPECT_EQ(opt_table->limits.min, 2);
+    ASSERT_TRUE(opt_table->limits.max.has_value());
+    EXPECT_EQ(opt_table->limits.max, 20);
+
+    EXPECT_FALSE(find_exported_table(instance, "ttt").has_value());
+
+    /* wat2wasm
+    (module
+      (table (import "test" "table") 2 20 anyfunc)
+      (export "tab" (table 0))
+      (func $f (export "f") nop)
+      (func $g nop)
+      (global (export "g1") i32 (i32.const 0))
+      (memory (export "mem") 0)
+    )
+     */
+    const auto wasm_reexported_table = from_hex(
+        "0061736d010000000104016000000211010474657374057461626c650170010214030302000005030100000606"
+        "017f0041000b071604037461620100016600000267310300036d656d02000a09020300010b0300010b");
+
+    std::vector<FuncIdx> table = {1, 0};
+    auto instance_reexported_table =
+        instantiate(parse(wasm_reexported_table), {}, {ExternalTable{&table, {2, 20}}});
+
+    opt_table = find_exported_table(instance_reexported_table, "tab");
+    ASSERT_TRUE(opt_table);
+    EXPECT_EQ(opt_table->table, &table);
+    EXPECT_EQ(opt_table->limits.min, 2);
+    ASSERT_TRUE(opt_table->limits.max.has_value());
+    EXPECT_EQ(opt_table->limits.max, 20);
+
+    EXPECT_FALSE(find_exported_table(instance, "ttt").has_value());
+
+    /* wat2wasm
+    (module
+      (func $f (export "f") nop)
+      (global (export "g1") i32 (i32.const 0))
+      (memory (export "mem") 0)
+    )
+    */
+    const auto wasm_no_table = from_hex(
+        "0061736d010000000104016000000302010005030100000606017f0041000b071003016600000267310300036d"
+        "656d02000a05010300010b");
+
+    auto instance_no_table = instantiate(parse(wasm_no_table));
+
+    EXPECT_FALSE(find_exported_table(instance_no_table, "tab").has_value());
+}
+
+TEST(api, DISABLED_find_exported_table_reimport)
+{
+    /* wat2wasm
+    (module
+      (table (import "test" "table") 2 20 anyfunc)
+      (export "tab" (table 0))
+    )
+    */
+    const auto wasm =
+        from_hex("0061736d010000000211010474657374057461626c650170010214070701037461620100");
+
+    // importing the table with limits narrower than defined in the module
+    std::vector<FuncIdx> table(5);
+    auto instance = instantiate(parse(wasm), {}, {ExternalTable{&table, {5, 10}}});
+
+    auto opt_table = find_exported_table(instance, "tab");
+    ASSERT_TRUE(opt_table);
+    EXPECT_EQ(opt_table->table, &table);
+    // table should have the limits it was imported with
+    EXPECT_EQ(opt_table->limits.min, 5);
+    ASSERT_TRUE(opt_table->limits.max.has_value());
+    EXPECT_EQ(*opt_table->limits.max, 10);
+
+    /* wat2wasm
+    (module
+      (table (import "test" "table") 5 10 anyfunc)
+    )
+    */
+    const auto wasm_reimported_table =
+        from_hex("0061736d010000000211010474657374057461626c65017001050a");
+
+    // importing the same table into the module with equal limits, instantiate should succeed
+    instantiate(parse(wasm_reimported_table), {}, {*opt_table});
 }

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -1,5 +1,7 @@
 #include "execute.hpp"
+#include "parser.hpp"
 #include <gtest/gtest.h>
+#include <test/utils/hex.hpp>
 
 using namespace fizzy;
 
@@ -34,4 +36,93 @@ TEST(api, find_exported_function)
     EXPECT_FALSE(find_exported_function(module, "mem"));
     EXPECT_FALSE(find_exported_function(module, "glob"));
     EXPECT_FALSE(find_exported_function(module, "table"));
+}
+
+TEST(api, find_exported_global)
+{
+    /* wat2wasm
+    (module
+      (func $f (export "f") nop)
+      (global (export "g1") (mut i32) (i32.const 0))
+      (global (export "g2") i32 (i32.const 1))
+      (global (export "g3") (mut i32) (i32.const 2))
+      (global (export "g4") i32 (i32.const 3))
+      (table (export "tab") 0 anyfunc)
+      (memory (export "mem") 0)
+    )
+     */
+    const auto wasm = from_hex(
+        "0061736d010000000104016000000302010004040170000005030100000615047f0141000b7f0041010b7f0141"
+        "020b7f0041030b072507016600000267310300026732030102673303020267340303037461620100036d656d02"
+        "000a05010300010b");
+
+    auto instance = instantiate(parse(wasm));
+
+    auto opt_global = find_exported_global(instance, "g1");
+    ASSERT_TRUE(opt_global);
+    EXPECT_EQ(*opt_global->value, 0);
+    EXPECT_TRUE(opt_global->is_mutable);
+
+    opt_global = find_exported_global(instance, "g2");
+    ASSERT_TRUE(opt_global);
+    EXPECT_EQ(*opt_global->value, 1);
+    EXPECT_FALSE(opt_global->is_mutable);
+
+    opt_global = find_exported_global(instance, "g3");
+    ASSERT_TRUE(opt_global);
+    EXPECT_EQ(*opt_global->value, 2);
+    EXPECT_TRUE(opt_global->is_mutable);
+
+    opt_global = find_exported_global(instance, "g4");
+    ASSERT_TRUE(opt_global);
+    EXPECT_EQ(*opt_global->value, 3);
+    EXPECT_FALSE(opt_global->is_mutable);
+
+    EXPECT_FALSE(find_exported_global(instance, "f"));
+    EXPECT_FALSE(find_exported_global(instance, "tab"));
+    EXPECT_FALSE(find_exported_global(instance, "mem"));
+
+    /* wat2wasm
+    (module
+      (global (export "g1") (import "test" "g2") i32)
+      (global (export "g2") (mut i32) (i32.const 1))
+      (table (export "tab") 0 anyfunc)
+      (func (export "f") nop)
+      (memory (export "mem") 0)
+    )
+     */
+    const auto wasm_reexported_global = from_hex(
+        "0061736d01000000010401600000020c010474657374026732037f000302010004040170000005030100000606"
+        "017f0141010b071b050267310300026732030103746162010001660000036d656d02000a05010300010b");
+
+    uint64_t g1 = 42;
+    auto instance_reexported_global =
+        instantiate(parse(wasm_reexported_global), {}, {}, {}, {ExternalGlobal{&g1, false}});
+
+    opt_global = find_exported_global(instance_reexported_global, "g1");
+    ASSERT_TRUE(opt_global);
+    EXPECT_EQ(opt_global->value, &g1);
+    EXPECT_FALSE(opt_global->is_mutable);
+
+    opt_global = find_exported_global(instance_reexported_global, "g2");
+    ASSERT_TRUE(opt_global);
+    EXPECT_EQ(*opt_global->value, 1);
+    EXPECT_TRUE(opt_global->is_mutable);
+
+    EXPECT_FALSE(find_exported_global(instance_reexported_global, "g3").has_value());
+
+    /* wat2wasm
+    (module
+      (table (export "tab") 0 anyfunc)
+      (func (export "f") nop)
+      (memory (export "mem") 0)
+    )
+     */
+    const auto wasm_no_globals = from_hex(
+        "0061736d0100000001040160000003020100040401700000050301000007110303746162010001660000036d65"
+        "6d02000a05010300010b");
+
+    auto instance_no_globals = instantiate(parse(wasm_no_globals));
+
+    EXPECT_FALSE(find_exported_global(instance_no_globals, "g1").has_value());
 }

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -2,11 +2,12 @@
 #include "parser.hpp"
 #include <gtest/gtest.h>
 #include <lib/fizzy/limits.hpp>
+#include <test/utils/asserts.hpp>
 #include <test/utils/hex.hpp>
 
 using namespace fizzy;
 
-TEST(api, find_exported_function)
+TEST(api, find_exported_function_index)
 {
     Module module;
     module.exportsec.emplace_back(Export{"foo1", ExternalKind::Function, 0});
@@ -37,6 +38,66 @@ TEST(api, find_exported_function)
     EXPECT_FALSE(find_exported_function(module, "mem"));
     EXPECT_FALSE(find_exported_function(module, "glob"));
     EXPECT_FALSE(find_exported_function(module, "table"));
+}
+
+TEST(api, find_exported_function)
+{
+    /* wat2wasm
+    (module
+      (func $f (export "foo") (result i32) (i32.const 42))
+      (global (export "g1") i32 (i32.const 0))
+      (table (export "tab") 0 anyfunc)
+      (memory (export "mem") 1 2)
+    )
+    */
+    const auto wasm = from_hex(
+        "0061736d010000000105016000017f030201000404017000000504010101020606017f0041000b07180403666f"
+        "6f00000267310300037461620100036d656d02000a06010400412a0b");
+
+    auto instance = instantiate(parse(wasm));
+
+    auto opt_function = find_exported_function(instance, "foo");
+    ASSERT_TRUE(opt_function);
+    EXPECT_RESULT((*opt_function)(instance, {}), 42);
+
+    EXPECT_FALSE(find_exported_function(instance, "bar").has_value());
+
+    /* wat2wasm
+    (module
+      (func (export "foo") (import "spectest" "bar") (result i32))
+      (global (export "g") i32 (i32.const 0))
+      (table (export "tab") 0 anyfunc)
+      (memory (export "mem") 1 2)
+    )
+    */
+    const auto wasm_reexported_function = from_hex(
+        "0061736d010000000105016000017f021001087370656374657374036261720000040401700000050401010102"
+        "0606017f0041000b07170403666f6f000001670300037461620100036d656d0200");
+
+    auto bar = [](Instance&, std::vector<uint64_t>) { return execution_result{false, {42}}; };
+
+    auto instance_reexported_function = instantiate(parse(wasm_reexported_function), {bar});
+
+    opt_function = find_exported_function(instance_reexported_function, "foo");
+    ASSERT_TRUE(opt_function);
+    EXPECT_RESULT((*opt_function)(instance, {}), 42);
+
+    EXPECT_FALSE(find_exported_function(instance, "bar").has_value());
+
+    /* wat2wasm
+    (module
+      (global (export "g") i32 (i32.const 0))
+      (table (export "tab") 0 anyfunc)
+      (memory (export "mem") 1 2)
+    )
+    */
+    const auto wasm_no_function = from_hex(
+        "0061736d010000000404017000000504010101020606017f0041000b07110301670300037461620100036d656d"
+        "0200");
+
+    auto instance_no_function = instantiate(parse(wasm_no_function));
+
+    EXPECT_FALSE(find_exported_function(instance_no_function, "mem").has_value());
 }
 
 TEST(api, find_exported_global)


### PR DESCRIPTION
Alternative to https://github.com/wasmx/fizzy/pull/181

Adds APIs for finding exported functions/globals/tables/memories in the form of `ExternalFunction`/`ExternalGlobal`/`ExternalTable`/`ExternalMemory` instances ready to be imported into another module.

~~The same should be done for functions, but this requires https://github.com/wasmx/fizzy/pull/171~~ Done.

Using this in spectests will look like this:
https://github.com/wasmx/fizzy/blob/b287cc004c3de064b469ed6e99f2ca262dd6dd92/test/spectests/spectests.cpp#L365-L410