### PR TITLE
Parse names of custom sections (as required by the spec)

### DIFF
--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -338,6 +338,8 @@ Module parse(bytes_view input)
             std::tie(module.datasec, it) = parse_vec<Data>(it, input.end());
             break;
         case SectionId::custom:
+            // NOTE: this section can be ignored, but the name must be parseable (and valid UTF-8)
+            parse_string(it, input.end());
             // These sections are ignored for now.
             it += size;
             break;

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -190,7 +190,8 @@ TEST(parser, section_vec_size_out_of_bounds)
 
 TEST(parser, custom_section_empty)
 {
-    const auto bin = bytes{wasm_prefix} + make_section(0, bytes{});
+    // Section consists of an empty name
+    const auto bin = bytes{wasm_prefix} + make_section(0, "00"_bytes);
     const auto module = parse(bin);
     EXPECT_EQ(module.typesec.size(), 0);
     EXPECT_EQ(module.funcsec.size(), 0);
@@ -199,7 +200,8 @@ TEST(parser, custom_section_empty)
 
 TEST(parser, custom_section_nonempty)
 {
-    const auto bin = bytes{wasm_prefix} + make_section(0, "ff"_bytes);
+    // Section consists of only the name "abc"
+    const auto bin = bytes{wasm_prefix} + make_section(0, "03616263"_bytes);
     const auto module = parse(bin);
     EXPECT_EQ(module.typesec.size(), 0);
     EXPECT_EQ(module.funcsec.size(), 0);
@@ -210,6 +212,12 @@ TEST(parser, custom_section_size_out_of_bounds)
 {
     const auto wasm = bytes{wasm_prefix} + "0080"_bytes;
     EXPECT_THROW_MESSAGE(parse(wasm), parser_error, "Unexpected EOF");
+}
+
+TEST(parser, custom_section_name_out_of_bounds)
+{
+    const auto bin = bytes{wasm_prefix} + make_section(0, "01"_bytes);
+    EXPECT_THROW_MESSAGE(parse(bin), parser_error, "Unexpected EOF");
 }
 
 TEST(parser, custom_section_out_of_bounds)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20340/74775459-b0e6bf00-528d-11ea-994e-992e2bdd8439.png)
