### PR TITLE
Fix handling of unused bits in LEB128 decoder

### DIFF
--- a/lib/fizzy/leb128.hpp
+++ b/lib/fizzy/leb128.hpp
@@ -1,8 +1,12 @@
 #pragma once
 
 #include "exceptions.hpp"
-#include "types.hpp"
 #include <cstdint>
+#include <limits>
+#include <utility>
+
+static_assert((int8_t{-1} >> 1) == int8_t{-1},
+    "signed LEB128 decoder assumes arithmetic shift of negative values");
 
 namespace fizzy
 {
@@ -19,11 +23,14 @@ std::pair<T, const uint8_t*> leb128u_decode(const uint8_t* input, const uint8_t*
         if (input == end)
             throw parser_error("Unexpected EOF");
 
-        // TODO this ignores the bits in the last byte other than the least significant one
-        // So would not reject some invalid encoding with those bits set.
         result |= static_cast<T>((static_cast<T>(*input) & 0x7F) << result_shift);
         if ((*input & 0x80) == 0)
+        {
+            if (*input != (result >> result_shift))
+                throw parser_error("Invalid LEB128 encoding: unused bits set.");
+
             return {result, input + 1};
+        }
     }
 
     throw parser_error("Invalid LEB128 encoding: too many bytes.");
@@ -46,13 +53,29 @@ std::pair<T, const uint8_t*> leb128s_decode(const uint8_t* input, const uint8_t*
         result |= static_cast<T_unsigned>((static_cast<T_unsigned>(*input) & 0x7F) << result_shift);
         if ((*input & 0x80) == 0)
         {
-            // sign extend
-            if ((*input & 0x40) != 0 && (result_shift + 7 < sizeof(T_unsigned) * 8))
+            if (result_shift + 7 < sizeof(T_unsigned) * 8)
             {
-                constexpr auto all_ones = std::numeric_limits<T_unsigned>::max();
-                const auto mask = static_cast<T_unsigned>(all_ones << (result_shift + 7));
-                result |= mask;
+                // non-terminal byte of the encoding, extend the sign bit, if needed
+                if ((*input & 0x40) != 0)
+                {
+                    constexpr auto all_ones = std::numeric_limits<T_unsigned>::max();
+                    const auto mask = static_cast<T_unsigned>(all_ones << (result_shift + 7));
+                    result |= mask;
+                }
             }
+            else
+            {
+                // terminal byte of the encoding, need to check unused bits
+                const auto expected =
+                    (static_cast<uint8_t>(static_cast<T>(result) >> result_shift) & 0x7F);
+
+                if (*input != expected)
+                {
+                    throw parser_error(
+                        "Invalid LEB128 encoding: unused bits not equal to sign bit.");
+                }
+            }
+
             return {static_cast<T>(result), input + 1};
         }
     }

--- a/test/unittests/leb128_test.cpp
+++ b/test/unittests/leb128_test.cpp
@@ -40,8 +40,6 @@ TEST(leb128, decode_u64)
         {{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f}, 0x7fffffffffffffff},
         {{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01}, 0x8000000000000000},
         {{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01}, std::numeric_limits<uint64_t>::max()}, // max
-        // this is not really correct encoding, but is not rejected by our decoder
-        {{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f}, std::numeric_limits<uint64_t>::max()},
     };
     // clang-format on
 
@@ -68,6 +66,15 @@ TEST(leb128, decode_u64_invalid)
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x81, 0x00};
     EXPECT_THROW_MESSAGE(leb128u_decode<uint64_t>(encoded_max_leading_zeroes), parser_error,
         "Invalid LEB128 encoding: too many bytes.");
+
+    bytes encoded_max_unused_bits_set{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f};
+    EXPECT_THROW_MESSAGE(leb128u_decode<uint64_t>(encoded_max_unused_bits_set), parser_error,
+        "Invalid LEB128 encoding: unused bits set.");
+
+    bytes encoded_max_some_unused_bits_set{
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x19};
+    EXPECT_THROW_MESSAGE(leb128u_decode<uint64_t>(encoded_max_some_unused_bits_set), parser_error,
+        "Invalid LEB128 encoding: unused bits set.");
 }
 
 TEST(leb128, decode_u32)
@@ -79,13 +86,12 @@ TEST(leb128, decode_u32)
         {{1}, 1}, // 1
         {{0x81, 0x80, 0x80, 0x00}, 1}, // 1 with leading zeroes
         {{0x81, 0x80, 0x80, 0x80, 0x00}, 1}, // 1 with max leading zeroes
+        {{0x82, 0x00}, 2}, // 2 with leading zeroes
         {{0xe5, 0x8e, 0x26}, 624485}, // 624485
         {{0xe5, 0x8e, 0xa6, 0x80, 0x00}, 624485}, // 624485 with leading zeroes
         {{0xff, 0xff, 0xff, 0xff, 0x07}, 0x7fffffff},
         {{0x80, 0x80, 0x80, 0x80, 0x08}, 0x80000000},
         {{0xff, 0xff, 0xff, 0xff, 0x0f}, std::numeric_limits<uint32_t>::max()}, // max
-        // this is not really correct encoding, but is not rejected by our decoder
-        {{0xff, 0xff, 0xff, 0xff, 0x7f}, std::numeric_limits<uint32_t>::max()},
     };
     // clang-format on
 
@@ -110,6 +116,18 @@ TEST(leb128, decode_u32_invalid)
     bytes encoded_max_leading_zeroes{0xff, 0xff, 0xff, 0xff, 0xff, 0x00};
     EXPECT_THROW_MESSAGE(leb128u_decode<uint32_t>(encoded_max_leading_zeroes), parser_error,
         "Invalid LEB128 encoding: too many bytes.");
+
+    bytes encoded_max_unused_bits_set{0xff, 0xff, 0xff, 0xff, 0x7f};
+    EXPECT_THROW_MESSAGE(leb128u_decode<uint32_t>(encoded_max_unused_bits_set), parser_error,
+        "Invalid LEB128 encoding: unused bits set.");
+
+    bytes encoded_2_unused_bits_set{0x82, 0x80, 0x80, 0x80, 0x70};
+    EXPECT_THROW_MESSAGE(leb128u_decode<uint32_t>(encoded_2_unused_bits_set), parser_error,
+        "Invalid LEB128 encoding: unused bits set.");
+
+    bytes encoded_0_some_unused_bits_set{0x80, 0x80, 0x80, 0x80, 0x1f};
+    EXPECT_THROW_MESSAGE(leb128u_decode<uint32_t>(encoded_0_some_unused_bits_set), parser_error,
+        "Invalid LEB128 encoding: unused bits set.");
 }
 
 TEST(leb128, decode_u8)
@@ -122,8 +140,6 @@ TEST(leb128, decode_u8)
         {{0x81, 0x00}, 1}, // 1 with leading zero
         {{0xe5, 0x01}, 229}, // 229
         {{0xff, 0x01}, 255}, // max
-        // this is not really correct encoding, but is not rejected by our decoder
-        {{0xff, 0x7f}, 255},
     };
     // clang-format on
 
@@ -144,6 +160,14 @@ TEST(leb128, decode_u8_invalid)
     bytes encoded_too_big{0xe5, 0x8e, 0x26};
     EXPECT_THROW_MESSAGE(leb128u_decode<uint8_t>(encoded_too_big.data()), parser_error,
         "Invalid LEB128 encoding: too many bytes.");
+
+    bytes encoded_max_unused_bits_set{0xff, 0x7f};
+    EXPECT_THROW_MESSAGE(leb128u_decode<uint8_t>(encoded_max_unused_bits_set), parser_error,
+        "Invalid LEB128 encoding: unused bits set.");
+
+    bytes encoded_max_some_unused_bits_set{0xff, 0x19};
+    EXPECT_THROW_MESSAGE(leb128u_decode<uint8_t>(encoded_max_some_unused_bits_set), parser_error,
+        "Invalid LEB128 encoding: unused bits set.");
 }
 
 TEST(leb128, decode_out_of_buffer)
@@ -185,22 +209,22 @@ TEST(leb128, decode_s64)
 {
     // clang-format off
     std::vector<std::pair<bytes, int64_t>> testcases = {
-            {{0}, 0}, // 0
-            {{0x80, 0x80, 0x00}, 0}, // 0 with leading zeroes
-            {{1}, 1},
-            {{0x81, 0x80, 0x80, 0x00}, 1}, // 1 with leading zeroes
-            {{0x81, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00}, 1}, // 1 with max leading zeroes
-            {{0x7f}, -1},
-            {{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01}, -1}, // -1 with leading 1s
-            {{0x7e}, -2},
-            {{0xfe, 0x7f}, -2}, // -2 with leading 1s
-            {{0xfe, 0xff, 0x7f}, -2},  // -2 with leading 1s
-            {{0xe5, 0x8e, 0x26}, 624485},
-            {{0xe5, 0x8e, 0xa6, 0x80, 0x80, 0x00}, 624485}, // 624485 with leading zeroes
-            {{0xc0, 0xbb, 0x78}, -123456},
-            {{0x9b, 0xf1, 0x59}, -624485},
-            {{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00}, 562949953421311}, // bigger than int32
-            {{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x80, 0x80, 0x00}, 562949953421311}, // bigger than int32 with zeroes
+        {{0}, 0}, // 0
+        {{0x80, 0x80, 0x00}, 0}, // 0 with leading zeroes
+        {{1}, 1},
+        {{0x81, 0x80, 0x80, 0x00}, 1}, // 1 with leading zeroes
+        {{0x81, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00}, 1}, // 1 with max leading zeroes
+        {{0x7f}, -1},
+        {{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f}, -1}, // -1 with leading 1s
+        {{0x7e}, -2},
+        {{0xfe, 0x7f}, -2}, // -2 with leading 1s
+        {{0xfe, 0xff, 0x7f}, -2},  // -2 with leading 1s
+        {{0xe5, 0x8e, 0x26}, 624485},
+        {{0xe5, 0x8e, 0xa6, 0x80, 0x80, 0x00}, 624485}, // 624485 with leading zeroes
+        {{0xc0, 0xbb, 0x78}, -123456},
+        {{0x9b, 0xf1, 0x59}, -624485},
+        {{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00}, 562949953421311}, // bigger than int32
+        {{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x80, 0x80, 0x00}, 562949953421311}, // bigger than int32 with zeroes
     };
     // clang-format on
 
@@ -223,28 +247,38 @@ TEST(leb128, decode_s64_invalid)
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01};
     EXPECT_THROW_MESSAGE(leb128s_decode<int64_t>(encoded_minus1_too_many_leading_1s), parser_error,
         "Invalid LEB128 encoding: too many bytes.");
+
+    const bytes minus1_unused_bits_unset{
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01};
+    EXPECT_THROW_MESSAGE(leb128s_decode<int64_t>(minus1_unused_bits_unset), parser_error,
+        "Invalid LEB128 encoding: unused bits not equal to sign bit.");
+
+    const bytes minus1_some_unused_bits_unset{
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x79};
+    EXPECT_THROW_MESSAGE(leb128s_decode<int64_t>(minus1_some_unused_bits_unset), parser_error,
+        "Invalid LEB128 encoding: unused bits not equal to sign bit.");
 }
 
 TEST(leb128, decode_s32)
 {
     // clang-format off
     std::vector<std::pair<bytes, int32_t>> testcases = {
-            {{0}, 0}, // 0
-            {{0x80, 0x80, 0x00}, 0}, // 0 with leading zeroes
-            {{1}, 1},
-            {{0x81, 0x80, 0x80, 0x00}, 1}, // 1 with leading zeroes
-            {{0x81, 0x80, 0x80, 0x80, 0x00}, 1}, // 1 with max leading zeroes
-            {{0x7f}, -1},
-            {{0xff, 0xff, 0xff, 0xff, 0x0f}, -1}, // -1 with leading 1s
-            {{0x7e}, -2},
-            {{0xfe, 0x7f}, -2}, // -2 with leading 1s
-            {{0xfe, 0xff, 0x7f}, -2}, // -2 with leading 1s
-            {{0xe5, 0x8e, 0x26}, 624485},
-            {{0xe5, 0x8e, 0xa6, 0x80, 0x00}, 624485}, // 624485 with leading zeroes
-            {{0xc0, 0xbb, 0x78}, -123456},
-            {{0x9b, 0xf1, 0x59}, -624485},
-            {{0x81, 0x80, 0x80, 0x80, 0x78}, -2147483647},
-            {{0x80, 0x80, 0x80, 0x80, 0x78}, std::numeric_limits<int32_t>::min()},
+        {{0}, 0}, // 0
+        {{0x80, 0x80, 0x00}, 0}, // 0 with leading zeroes
+        {{1}, 1},
+        {{0x81, 0x80, 0x80, 0x00}, 1}, // 1 with leading zeroes
+        {{0x81, 0x80, 0x80, 0x80, 0x00}, 1}, // 1 with max leading zeroes
+        {{0x7f}, -1},
+        {{0xff, 0xff, 0xff, 0xff, 0x7f}, -1}, // -1 with leading 1s
+        {{0x7e}, -2},
+        {{0xfe, 0x7f}, -2}, // -2 with leading 1s
+        {{0xfe, 0xff, 0x7f}, -2}, // -2 with leading 1s
+        {{0xe5, 0x8e, 0x26}, 624485},
+        {{0xe5, 0x8e, 0xa6, 0x80, 0x00}, 624485}, // 624485 with leading zeroes
+        {{0xc0, 0xbb, 0x78}, -123456},
+        {{0x9b, 0xf1, 0x59}, -624485},
+        {{0x81, 0x80, 0x80, 0x80, 0x78}, -2147483647},
+        {{0x80, 0x80, 0x80, 0x80, 0x78}, std::numeric_limits<int32_t>::min()},
     };
     // clang-format on
 
@@ -256,19 +290,38 @@ TEST(leb128, decode_s32)
     }
 }
 
+TEST(leb128, decode_s32_invalid)
+{
+    const bytes encoded_0_unused_bits_set{0x80, 0x80, 0x80, 0x80, 0x70};
+    EXPECT_THROW_MESSAGE(leb128s_decode<int32_t>(encoded_0_unused_bits_set), parser_error,
+        "Invalid LEB128 encoding: unused bits not equal to sign bit.");
+
+    const bytes encoded_0_some_unused_bits_set{0x80, 0x80, 0x80, 0x80, 0x10};
+    EXPECT_THROW_MESSAGE(leb128s_decode<int32_t>(encoded_0_some_unused_bits_set), parser_error,
+        "Invalid LEB128 encoding: unused bits not equal to sign bit.");
+
+    const bytes minus1_unused_bits_unset{0xff, 0xff, 0xff, 0xff, 0x0f};
+    EXPECT_THROW_MESSAGE(leb128s_decode<int32_t>(minus1_unused_bits_unset), parser_error,
+        "Invalid LEB128 encoding: unused bits not equal to sign bit.");
+
+    const bytes minus1_some_unused_bits_set{0xff, 0xff, 0xff, 0xff, 0x4f};
+    EXPECT_THROW_MESSAGE(leb128s_decode<int32_t>(minus1_some_unused_bits_set), parser_error,
+        "Invalid LEB128 encoding: unused bits not equal to sign bit.");
+}
+
 TEST(leb128, decode_s8)
 {
     // clang-format off
     std::vector<std::pair<bytes, int64_t>> testcases = {
-            {{0}, 0}, // 0
-            {{0x80, 0x00}, 0}, // 0 with leading zero
-            {{1}, 1}, // 1
-            {{0x81, 0x00}, 1}, // 1 with leading zero
-            {{0xff, 0x01}, -1},
-            {{0xfe, 0x01}, -2},
-            {{0x40}, -64},
-            {{0x81, 0x7f}, -127},
-            {{0x80, 0x7f}, std::numeric_limits<int8_t>::min()},
+        {{0}, 0}, // 0
+        {{0x80, 0x00}, 0}, // 0 with leading zero
+        {{1}, 1}, // 1
+        {{0x81, 0x00}, 1}, // 1 with leading zero
+        {{0xff, 0x7f}, -1},
+        {{0xfe, 0x7f}, -2},
+        {{0x40}, -64},
+        {{0x81, 0x7f}, -127},
+        {{0x80, 0x7f}, std::numeric_limits<int8_t>::min()},
     };
     // clang-format on
 
@@ -289,6 +342,18 @@ TEST(leb128, decode_s8_invalid)
     const bytes encoded_too_big{0xe5, 0x8e, 0x26};
     EXPECT_THROW_MESSAGE(leb128s_decode<int8_t>(encoded_too_big), parser_error,
         "Invalid LEB128 encoding: too many bytes.");
+
+    const bytes minus1_unused_bits_unset{0xff, 0x01};
+    EXPECT_THROW_MESSAGE(leb128s_decode<int8_t>(minus1_unused_bits_unset), parser_error,
+        "Invalid LEB128 encoding: unused bits not equal to sign bit.");
+
+    const bytes minus2_unused_bits_unset{0xfe, 0x01};
+    EXPECT_THROW_MESSAGE(leb128s_decode<int8_t>(minus2_unused_bits_unset), parser_error,
+        "Invalid LEB128 encoding: unused bits not equal to sign bit.");
+
+    const bytes minus1_some_unused_bits_unset{0xff, 0x71};
+    EXPECT_THROW_MESSAGE(leb128s_decode<int8_t>(minus1_some_unused_bits_unset), parser_error,
+        "Invalid LEB128 encoding: unused bits not equal to sign bit.");
 }
 
 TEST(leb128, decode_s_out_of_buffer)


### PR DESCRIPTION
This adds the handling of the unused bits according to this note in the spec:
![image](https://user-images.githubusercontent.com/1863135/74948198-430cd580-53fc-11ea-85bf-331b9287784d.png)
https://webassembly.github.io/spec/core/binary/values.html#integers

All of the `binary-leb128.wast` spectests pass with this fix.