### PR TITLE
Remove Instance from ImportedFunction signature

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -558,7 +558,7 @@ Instance instantiate(Module module, std::vector<ImportedFunction> imported_funct
 execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint64_t> args)
 {
     if (func_idx < instance.imported_functions.size())
-        return instance.imported_functions[func_idx](instance, std::move(args));
+        return instance.imported_functions[func_idx](std::move(args));
 
     const auto code_idx = func_idx - instance.imported_functions.size();
     assert(code_idx < instance.module.codesec.size());

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -20,7 +20,7 @@ struct execution_result
 
 struct Instance;
 
-using ImportedFunction = std::function<execution_result(Instance&, std::vector<uint64_t>)>;
+using ImportedFunction = std::function<execution_result(std::vector<uint64_t>)>;
 
 using table_ptr = std::unique_ptr<std::vector<FuncIdx>, void (*)(std::vector<FuncIdx>*)>;
 

--- a/test/unittests/execute_control_test.cpp
+++ b/test/unittests/execute_control_test.cpp
@@ -667,8 +667,9 @@ TEST(execute_control, br_1_out_of_function_and_imported_function)
         "0061736d010000000108026000006000017f02150108696d706f727465640866756e6374696f6e000003020101"
         "0a0d010b00034041010c010b41000b");
 
-    constexpr auto fake_imported_function =
-        [](Instance&, std::vector<uint64_t>) noexcept -> execution_result { return {}; };
+    constexpr auto fake_imported_function = [](std::vector<uint64_t>) noexcept -> execution_result {
+        return {};
+    };
 
     const auto module = parse(bin);
     auto instance = instantiate(module, {fake_imported_function});

--- a/test/unittests/execute_test.cpp
+++ b/test/unittests/execute_test.cpp
@@ -921,7 +921,7 @@ TEST(execute, imported_function)
     module.typesec.emplace_back(FuncType{{ValType::i32, ValType::i32}, {ValType::i32}});
     module.importsec.emplace_back(Import{"mod", "foo", ExternalKind::Function, {0}});
 
-    auto host_foo = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    auto host_foo = [](std::vector<uint64_t> args) -> execution_result {
         return {false, {args[0] + args[1]}};
     };
 
@@ -941,10 +941,10 @@ TEST(execute, imported_two_functions)
     module.importsec.emplace_back(Import{"mod", "foo1", ExternalKind::Function, {0}});
     module.importsec.emplace_back(Import{"mod", "foo2", ExternalKind::Function, {0}});
 
-    auto host_foo1 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    auto host_foo1 = [](std::vector<uint64_t> args) -> execution_result {
         return {false, {args[0] + args[1]}};
     };
-    auto host_foo2 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    auto host_foo2 = [](std::vector<uint64_t> args) -> execution_result {
         return {false, {args[0] * args[1]}};
     };
 
@@ -972,10 +972,10 @@ TEST(execute, imported_functions_and_regular_one)
     module.importsec.emplace_back(Import{"mod", "foo2", ExternalKind::Function, {0}});
     module.codesec.emplace_back(Code{0, {Instr::i32_const, Instr::end}, {42, 0, 42, 0}});
 
-    auto host_foo1 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    auto host_foo1 = [](std::vector<uint64_t> args) -> execution_result {
         return {false, {args[0] + args[1]}};
     };
-    auto host_foo2 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    auto host_foo2 = [](std::vector<uint64_t> args) -> execution_result {
         return {false, {args[0] * args[0]}};
     };
 
@@ -994,7 +994,7 @@ TEST(execute, imported_functions_and_regular_one)
     EXPECT_EQ(ret2[0], 400);
 
     // check correct number of arguments is passed to host
-    auto count_args = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    auto count_args = [](std::vector<uint64_t> args) -> execution_result {
         return {false, {args.size()}};
     };
 
@@ -1022,10 +1022,10 @@ TEST(execute, imported_two_functions_different_type)
     module.importsec.emplace_back(Import{"mod", "foo2", ExternalKind::Function, {0}});
     module.codesec.emplace_back(Code{0, {Instr::i32_const, Instr::end}, {42, 0, 42, 0}});
 
-    auto host_foo1 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    auto host_foo1 = [](std::vector<uint64_t> args) -> execution_result {
         return {false, {args[0] + args[1]}};
     };
-    auto host_foo2 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    auto host_foo2 = [](std::vector<uint64_t> args) -> execution_result {
         return {false, {args[0] * args[0]}};
     };
 
@@ -1056,7 +1056,7 @@ TEST(execute, imported_function_traps)
     module.typesec.emplace_back(FuncType{{ValType::i32, ValType::i32}, {ValType::i32}});
     module.importsec.emplace_back(Import{"mod", "foo", ExternalKind::Function, {0}});
 
-    auto host_foo = [](Instance&, std::vector<uint64_t>) -> execution_result { return {true, {}}; };
+    auto host_foo = [](std::vector<uint64_t>) -> execution_result { return {true, {}}; };
 
     auto instance = instantiate(module, {host_foo});
 
@@ -1073,9 +1073,7 @@ TEST(execute, imported_function_call)
     module.funcsec.emplace_back(TypeIdx{0});
     module.codesec.emplace_back(Code{0, {Instr::call, Instr::end}, {0, 0, 0, 0}});
 
-    auto host_foo = [](Instance&, std::vector<uint64_t>) -> execution_result {
-        return {false, {42}};
-    };
+    auto host_foo = [](std::vector<uint64_t>) -> execution_result { return {false, {42}}; };
 
     auto instance = instantiate(module, {host_foo});
 
@@ -1096,7 +1094,7 @@ TEST(execute, imported_function_call_with_arguments)
         Code{0, {Instr::local_get, Instr::call, Instr::i32_const, Instr::i32_add, Instr::end},
             {0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0}});
 
-    auto host_foo = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    auto host_foo = [](std::vector<uint64_t> args) -> execution_result {
         return {false, {args[0] * 2}};
     };
 
@@ -1143,10 +1141,10 @@ TEST(execute, imported_functions_call_indirect)
     ASSERT_EQ(module.importsec.size(), 2);
     ASSERT_EQ(module.codesec.size(), 2);
 
-    constexpr auto sqr = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto sqr = [](std::vector<uint64_t> args) -> execution_result {
         return {false, {args[0] * args[0]}};
     };
-    constexpr auto isqrt = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto isqrt = [](std::vector<uint64_t> args) -> execution_result {
         return {false, {(11 + args[0] / 11) / 2}};
     };
 
@@ -1191,7 +1189,7 @@ TEST(execute, imported_function_from_another_module)
     const auto func_idx = fizzy::find_exported_function(module1, "sub");
     ASSERT_TRUE(func_idx.has_value());
 
-    auto sub = [&instance1, func_idx](Instance&, std::vector<uint64_t> args) -> execution_result {
+    auto sub = [&instance1, func_idx](std::vector<uint64_t> args) -> execution_result {
         return fizzy::execute(instance1, *func_idx, std::move(args));
     };
 

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -13,7 +13,7 @@ TEST(instantiate, imported_functions)
     module.typesec.emplace_back(FuncType{{ValType::i32}, {ValType::i32}});
     module.importsec.emplace_back(Import{"mod", "foo", ExternalKind::Function, {0}});
 
-    auto host_foo = [](Instance&, std::vector<uint64_t>) -> execution_result { return {true, {}}; };
+    auto host_foo = [](std::vector<uint64_t>) -> execution_result { return {true, {}}; };
     auto instance = instantiate(module, {host_foo});
 
     ASSERT_EQ(instance.imported_functions.size(), 1);
@@ -30,12 +30,8 @@ TEST(instantiate, imported_functions_multiple)
     module.importsec.emplace_back(Import{"mod", "foo1", ExternalKind::Function, {0}});
     module.importsec.emplace_back(Import{"mod", "foo2", ExternalKind::Function, {1}});
 
-    auto host_foo1 = [](Instance&, std::vector<uint64_t>) -> execution_result {
-        return {true, {0}};
-    };
-    auto host_foo2 = [](Instance&, std::vector<uint64_t>) -> execution_result {
-        return {true, {}};
-    };
+    auto host_foo1 = [](std::vector<uint64_t>) -> execution_result { return {true, {0}}; };
+    auto host_foo2 = [](std::vector<uint64_t>) -> execution_result { return {true, {}}; };
     auto instance = instantiate(module, {host_foo1, host_foo2});
 
     ASSERT_EQ(instance.imported_functions.size(), 2);


### PR DESCRIPTION
Originally `Instance` was added to the signature of imported function due to this comment https://github.com/wasmx/fizzy/pull/49#discussion_r365550587

But since `ImportedFunction` is `std::function` now, `instance` can be captured on the host side by the lambda implementing the function.

Also if it's a function from another wasm module being imported, its memory instructions are going to access that external module's memory.