### PR TITLE
Fix custom section name parsing

### DIFF
--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -339,7 +339,7 @@ Module parse(bytes_view input)
             break;
         case SectionId::custom:
             // NOTE: this section can be ignored, but the name must be parseable (and valid UTF-8)
-            parse_string(it, input.end());
+            parse_string(it, expected_section_end);
             // These sections are ignored for now.
             it += size;
             break;

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -165,6 +165,13 @@ TEST(parser, custom_section_name_out_of_bounds)
     EXPECT_THROW_MESSAGE(parse(bin), parser_error, "Unexpected EOF");
 }
 
+TEST(parser, custom_section_name_exceeds_section_size)
+{
+    const auto bin = bytes{wasm_prefix} + make_invalid_size_section(0, 1, "01aa"_bytes) +
+                     make_section(0, "00"_bytes);
+    EXPECT_THROW_MESSAGE(parse(bin), parser_error, "Unexpected EOF");
+}
+
 TEST(parser, custom_section_out_of_bounds)
 {
     const auto wasm = bytes{wasm_prefix} + make_invalid_size_section(0, 31, {});
@@ -1124,9 +1131,9 @@ TEST(parser, interleaved_custom_section)
     const auto type_section = make_vec({functype_void_to_void});
     const auto func_section = make_vec({"00"_bytes});
     const auto code_section = make_vec({add_size_prefix("000b"_bytes)});
-    const auto bin = bytes{wasm_prefix} + make_section(0, bytes{4}) +
-                     make_section(1, type_section) + make_section(0, bytes{5}) +
-                     make_section(3, func_section) + make_section(0, bytes{6}) +
+    const auto bin = bytes{wasm_prefix} + make_section(0, "01aa"_bytes) +
+                     make_section(1, type_section) + make_section(0, "01bb"_bytes) +
+                     make_section(3, func_section) + make_section(0, "01cc"_bytes) +
                      make_section(10, code_section);
 
     const auto module = parse(bin);

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -143,10 +143,21 @@ TEST(parser, custom_section_empty)
     EXPECT_EQ(module.codesec.size(), 0);
 }
 
-TEST(parser, custom_section_nonempty)
+TEST(parser, custom_section_nonempty_name_only)
 {
     // Section consists of only the name "abc"
     const auto bin = bytes{wasm_prefix} + make_section(0, "03616263"_bytes);
+    const auto module = parse(bin);
+    EXPECT_EQ(module.typesec.size(), 0);
+    EXPECT_EQ(module.funcsec.size(), 0);
+    EXPECT_EQ(module.codesec.size(), 0);
+}
+
+TEST(parser, custom_section_nonempty)
+{
+    // Section consists of the name "abc" and 14 bytes of unparsed data
+    const auto bin =
+        bytes{wasm_prefix} + make_section(0, "036162630000112233445566778899000099"_bytes);
     const auto module = parse(bin);
     EXPECT_EQ(module.typesec.size(), 0);
     EXPECT_EQ(module.funcsec.size(), 0);


### PR DESCRIPTION
Do not allow a custom section which name length exceeds the total size of the section.