### PR TITLE
ci: Enable UBSan errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if(ENABLE_ASSERTIONS)
 endif()
 
 if(FIZZY_FUZZING)
-    set(fuzzing_flags -fsanitize=fuzzer-no-link,address,undefined,implicit-conversion,nullability)
+    set(fuzzing_flags -fsanitize=fuzzer-no-link,address,undefined,nullability,implicit-unsigned-integer-truncation,implicit-signed-integer-truncation)
     add_compile_options(${fuzzing_flags})
     add_link_options(${fuzzing_flags})
 endif()

--- a/circle.yml
+++ b/circle.yml
@@ -88,8 +88,6 @@ commands:
           working_directory: ~/build
           command: |
             set +e
-            # TODO: Make UBSan warnings fatal.
-            # export UBSAN_OPTIONS=halt_on_error=1
             expected="  PASSED 4433, FAILED 42, SKIPPED 7338."
             result=$(bin/fizzy-spectests --skip-validation wasm-spec/test/core/json | tail -1)
             echo "Expected: $expected"
@@ -208,6 +206,7 @@ jobs:
     environment:
       BUILD_TYPE: RelWithDebInfo
       CMAKE_OPTIONS: -DENABLE_ASSERTIONS=ON -DSANITIZE=address,undefined,implicit-conversion,nullability
+      UBSAN_OPTIONS: halt_on_error=1
     steps:
       - build
       - test

--- a/circle.yml
+++ b/circle.yml
@@ -205,7 +205,7 @@ jobs:
     executor: linux-clang-9
     environment:
       BUILD_TYPE: RelWithDebInfo
-      CMAKE_OPTIONS: -DENABLE_ASSERTIONS=ON -DSANITIZE=address,undefined,implicit-conversion,nullability
+      CMAKE_OPTIONS: -DENABLE_ASSERTIONS=ON -DSANITIZE=address,undefined,nullability,implicit-unsigned-integer-truncation,implicit-signed-integer-truncation
       UBSAN_OPTIONS: halt_on_error=1
     steps:
       - build

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -587,7 +587,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
     assert(code_idx < instance.module.codesec.size());
 
     const auto& code = instance.module.codesec[code_idx];
-    auto& memory = *instance.memory;
+    auto* const memory = instance.memory.get();
 
     std::vector<uint64_t> locals = std::move(args);
     locals.resize(locals.size() + code.local_count);
@@ -876,7 +876,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         }
         case Instr::i32_load:
         {
-            if (!load_from_memory<uint32_t>(memory, stack, immediates))
+            if (!load_from_memory<uint32_t>(*memory, stack, immediates))
             {
                 trap = true;
                 goto end;
@@ -885,7 +885,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         }
         case Instr::i64_load:
         {
-            if (!load_from_memory<uint64_t>(memory, stack, immediates))
+            if (!load_from_memory<uint64_t>(*memory, stack, immediates))
             {
                 trap = true;
                 goto end;
@@ -894,7 +894,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         }
         case Instr::i32_load8_s:
         {
-            if (!load_from_memory<uint32_t, int8_t>(memory, stack, immediates))
+            if (!load_from_memory<uint32_t, int8_t>(*memory, stack, immediates))
             {
                 trap = true;
                 goto end;
@@ -903,7 +903,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         }
         case Instr::i32_load8_u:
         {
-            if (!load_from_memory<uint32_t, uint8_t>(memory, stack, immediates))
+            if (!load_from_memory<uint32_t, uint8_t>(*memory, stack, immediates))
             {
                 trap = true;
                 goto end;
@@ -912,7 +912,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         }
         case Instr::i32_load16_s:
         {
-            if (!load_from_memory<uint32_t, int16_t>(memory, stack, immediates))
+            if (!load_from_memory<uint32_t, int16_t>(*memory, stack, immediates))
             {
                 trap = true;
                 goto end;
@@ -921,7 +921,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         }
         case Instr::i32_load16_u:
         {
-            if (!load_from_memory<uint32_t, uint16_t>(memory, stack, immediates))
+            if (!load_from_memory<uint32_t, uint16_t>(*memory, stack, immediates))
             {
                 trap = true;
                 goto end;
@@ -930,7 +930,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         }
         case Instr::i64_load8_s:
         {
-            if (!load_from_memory<uint64_t, int8_t>(memory, stack, immediates))
+            if (!load_from_memory<uint64_t, int8_t>(*memory, stack, immediates))
             {
                 trap = true;
                 goto end;
@@ -939,7 +939,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         }
         case Instr::i64_load8_u:
         {
-            if (!load_from_memory<uint64_t, uint8_t>(memory, stack, immediates))
+            if (!load_from_memory<uint64_t, uint8_t>(*memory, stack, immediates))
             {
                 trap = true;
                 goto end;
@@ -948,7 +948,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         }
         case Instr::i64_load16_s:
         {
-            if (!load_from_memory<uint64_t, int16_t>(memory, stack, immediates))
+            if (!load_from_memory<uint64_t, int16_t>(*memory, stack, immediates))
             {
                 trap = true;
                 goto end;
@@ -957,7 +957,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         }
         case Instr::i64_load16_u:
         {
-            if (!load_from_memory<uint64_t, uint16_t>(memory, stack, immediates))
+            if (!load_from_memory<uint64_t, uint16_t>(*memory, stack, immediates))
             {
                 trap = true;
                 goto end;
@@ -966,7 +966,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         }
         case Instr::i64_load32_s:
         {
-            if (!load_from_memory<uint64_t, int32_t>(memory, stack, immediates))
+            if (!load_from_memory<uint64_t, int32_t>(*memory, stack, immediates))
             {
                 trap = true;
                 goto end;
@@ -975,7 +975,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         }
         case Instr::i64_load32_u:
         {
-            if (!load_from_memory<uint64_t, uint32_t>(memory, stack, immediates))
+            if (!load_from_memory<uint64_t, uint32_t>(*memory, stack, immediates))
             {
                 trap = true;
                 goto end;
@@ -984,7 +984,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         }
         case Instr::i32_store:
         {
-            if (!store_into_memory<uint32_t>(memory, stack, immediates))
+            if (!store_into_memory<uint32_t>(*memory, stack, immediates))
             {
                 trap = true;
                 goto end;
@@ -993,7 +993,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         }
         case Instr::i64_store:
         {
-            if (!store_into_memory<uint64_t>(memory, stack, immediates))
+            if (!store_into_memory<uint64_t>(*memory, stack, immediates))
             {
                 trap = true;
                 goto end;
@@ -1003,7 +1003,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         case Instr::i32_store8:
         case Instr::i64_store8:
         {
-            if (!store_into_memory<uint8_t>(memory, stack, immediates))
+            if (!store_into_memory<uint8_t>(*memory, stack, immediates))
             {
                 trap = true;
                 goto end;
@@ -1013,7 +1013,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         case Instr::i32_store16:
         case Instr::i64_store16:
         {
-            if (!store_into_memory<uint16_t>(memory, stack, immediates))
+            if (!store_into_memory<uint16_t>(*memory, stack, immediates))
             {
                 trap = true;
                 goto end;
@@ -1022,7 +1022,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         }
         case Instr::i64_store32:
         {
-            if (!store_into_memory<uint32_t>(memory, stack, immediates))
+            if (!store_into_memory<uint32_t>(*memory, stack, immediates))
             {
                 trap = true;
                 goto end;
@@ -1031,13 +1031,13 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         }
         case Instr::memory_size:
         {
-            stack.push(static_cast<uint32_t>(memory.size() / PageSize));
+            stack.push(static_cast<uint32_t>(memory->size() / PageSize));
             break;
         }
         case Instr::memory_grow:
         {
             const auto delta = static_cast<uint32_t>(stack.pop());
-            const auto cur_pages = memory.size() / PageSize;
+            const auto cur_pages = memory->size() / PageSize;
             assert(cur_pages <= size_t(std::numeric_limits<int32_t>::max()));
             const auto new_pages = cur_pages + delta;
             assert(new_pages >= cur_pages);
@@ -1046,7 +1046,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
             {
                 if (new_pages > instance.memory_max_pages)
                     throw std::bad_alloc();
-                memory.resize(new_pages * PageSize);
+                memory->resize(new_pages * PageSize);
             }
             catch (std::bad_alloc const&)
             {


### PR DESCRIPTION
This makes CI to fail on UBSan warnings (previously silently ignored). And fixes issues we accumulated over time.

Requires #229, #225.

