### PR TITLE
Fix i32.{shr, div, rem}_s instructions

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -98,6 +98,7 @@ jobs:
           ./wat2wasm4cpp.py test/unittests/end_to_end_test.cpp
           ./wat2wasm4cpp.py test/unittests/execute_call_test.cpp
           ./wat2wasm4cpp.py test/unittests/execute_control_test.cpp
+          ./wat2wasm4cpp.py test/unittests/execute_numeric_test.cpp
           ./wat2wasm4cpp.py test/unittests/execute_test.cpp
           ./wat2wasm4cpp.py test/unittests/parser_test.cpp
           ./wat2wasm4cpp.py test/unittests/wasm_engine_test.cpp

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -385,7 +385,7 @@ inline void unary_op(Stack<uint64_t>& stack, Op op) noexcept
 {
     using T = decltype(op(stack.pop()));
     const auto a = static_cast<T>(stack.pop());
-    stack.push(static_cast<uint64_t>(op(a)));
+    stack.push(op(a));
 }
 
 template <typename Op>

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -394,7 +394,7 @@ inline void binary_op(Stack<uint64_t>& stack, Op op) noexcept
     using T = decltype(op(stack.pop(), stack.pop()));
     const auto val2 = static_cast<T>(stack.pop());
     const auto val1 = static_cast<T>(stack.pop());
-    stack.push(static_cast<uint64_t>(op(val1, val2)));
+    stack.push(static_cast<std::make_unsigned_t<T>>(op(val1, val2)));
 }
 
 template <typename T, template <typename> class Op>

--- a/test/unittests/execute_numeric_test.cpp
+++ b/test/unittests/execute_numeric_test.cpp
@@ -653,7 +653,7 @@ TEST(execute_numeric, i32_div_s)
 
     ASSERT_FALSE(trap);
     ASSERT_EQ(ret.size(), 1);
-    EXPECT_EQ(ret[0], uint64_t(-42));
+    EXPECT_EQ(ret[0], uint32_t(-42));
 }
 
 TEST(execute_numeric, i32_div_s_by_zero)
@@ -702,7 +702,7 @@ TEST(execute_numeric, i32_div_u_by_zero)
 
 TEST(execute_numeric, i32_rem_s)
 {
-    EXPECT_RESULT(execute_binary_operation(Instr::i32_rem_s, uint64_t(-4242), 4200), -42);
+    EXPECT_RESULT(execute_binary_operation(Instr::i32_rem_s, uint64_t(-4242), 4200), uint32_t(-42));
     constexpr auto i32_min = std::numeric_limits<int32_t>::min();
     EXPECT_RESULT(execute_binary_operation(Instr::i32_rem_s, uint64_t(i32_min), uint64_t(-1)), 0);
 }
@@ -783,21 +783,21 @@ TEST(execute_numeric, i32_shl)
 
 TEST(execute_numeric, i32_shr_s)
 {
-    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, uint64_t(-84), 1), uint64_t(-42));
-    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0xffffffff, 0), int32_t(0xffffffff));
-    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0xffffffff, 1), int32_t(0xffffffff));
-    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0xffffffff, 31), int32_t(0xffffffff));
-    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0xffffffff, 32), int32_t(0xffffffff));
-    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0xffffffff, 33), int32_t(0xffffffff));
-    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0xffffffff, 63), int32_t(0xffffffff));
-    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0x7fffffff, 0), int32_t(0x7fffffff));
-    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0x7fffffff, 1), int32_t(0x3fffffff));
-    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0x7fffffff, 30), int32_t(1));
-    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0x7fffffff, 31), int32_t(0));
-    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0x7fffffff, 32), int32_t(0x7fffffff));
-    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0x7fffffff, 33), int32_t(0x3fffffff));
-    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0x7fffffff, 62), int32_t(1));
-    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0x7fffffff, 63), int32_t(0));
+    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, uint64_t(-84), 1), uint32_t(-42));
+    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0xffffffff, 0), 0xffffffff);
+    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0xffffffff, 1), 0xffffffff);
+    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0xffffffff, 31), 0xffffffff);
+    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0xffffffff, 32), 0xffffffff);
+    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0xffffffff, 33), 0xffffffff);
+    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0xffffffff, 63), 0xffffffff);
+    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0x7fffffff, 0), 0x7fffffff);
+    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0x7fffffff, 1), 0x3fffffff);
+    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0x7fffffff, 30), 1);
+    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0x7fffffff, 31), 0);
+    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0x7fffffff, 32), 0x7fffffff);
+    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0x7fffffff, 33), 0x3fffffff);
+    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0x7fffffff, 62), 1);
+    EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0x7fffffff, 63), 0);
 }
 
 TEST(execute_numeric, i32_shr_s_stack_value)

--- a/test/unittests/execute_numeric_test.cpp
+++ b/test/unittests/execute_numeric_test.cpp
@@ -774,6 +774,21 @@ TEST(execute_numeric, i32_shr_s)
     EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_s, 0x7fffffff, 63), int32_t(0));
 }
 
+TEST(execute_numeric, i32_shr_s_stack_value)
+{
+    /* wat2wasm
+    (func (result i64)
+      i32.const -1
+      i32.const 0
+      i32.shr_s         ;; Must put 0xffffffff on the stack.
+      i64.extend_u/i32
+    )
+    */
+    const auto wasm = from_hex("0061736d010000000105016000017e030201000a0a010800417f410075ad0b");
+
+    EXPECT_RESULT(execute(parse(wasm), 0, {}), 0xffffffff);
+}
+
 TEST(execute_numeric, i32_shr_u)
 {
     EXPECT_RESULT(execute_binary_operation(Instr::i32_shr_u, 84, 1), 42);

--- a/test/unittests/execute_numeric_test.cpp
+++ b/test/unittests/execute_numeric_test.cpp
@@ -671,6 +671,19 @@ TEST(execute_numeric, i32_div_s_overflow)
     ASSERT_TRUE(trap);
 }
 
+TEST(execute_numeric, i32_div_s_stack_value)
+{
+    /* wat2wasm
+    (func (result i64)
+      (i32.div_s (i32.const -3) (i32.const 2))  ;; Should put 0xffffffff on the stack.
+      i64.extend_u/i32
+    )
+    */
+    const auto wasm = from_hex("0061736d010000000105016000017e030201000a0a010800417d41026dad0b");
+
+    EXPECT_RESULT(execute(parse(wasm), 0, {}), 0xffffffff);
+}
+
 TEST(execute_numeric, i32_div_u)
 {
     const auto [trap, ret] = execute_binary_operation(Instr::i32_div_u, 84, 2);
@@ -699,6 +712,19 @@ TEST(execute_numeric, i32_rem_s_by_zero)
     const auto [trap, ret] = execute_binary_operation(Instr::i32_rem_s, uint64_t(-4242), 0);
 
     ASSERT_TRUE(trap);
+}
+
+TEST(execute_numeric, i32_rem_s_stack_value)
+{
+    /* wat2wasm
+    (func (result i64)
+      (i32.rem_s (i32.const -3) (i32.const 2))  ;; Should put 0xffffffff on the stack.
+      i64.extend_u/i32
+    )
+    */
+    const auto wasm = from_hex("0061736d010000000105016000017e030201000a0a010800417d41026fad0b");
+
+    EXPECT_RESULT(execute(parse(wasm), 0, {}), 0xffffffff);
 }
 
 TEST(execute_numeric, i32_rem_u)


### PR DESCRIPTION
If the binary_op() operates on i32 values, we want to zero-extend the final value to i64 so avoid int32_t -> uint64_t conversion which is the sign-extend one.