### PR TITLE
Inline Stack::push and Stack::peek

### DIFF
--- a/lib/fizzy/stack.hpp
+++ b/lib/fizzy/stack.hpp
@@ -19,7 +19,7 @@ public:
     using std::vector<T>::resize;
     using std::vector<T>::size;
 
-    void push(T val) { emplace_back(val); }
+    inline void push(T val) { emplace_back(val); }
 
     T pop()
     {
@@ -28,7 +28,7 @@ public:
         return res;
     }
 
-    T peek(size_t depth = 0) const noexcept { return (*this)[size() - depth - 1]; }
+    inline T peek(size_t depth = 0) const noexcept { return (*this)[size() - depth - 1]; }
 
     /// Drops @a num_elements elements from the top of the stack.
     void drop(size_t num_elements = 1) noexcept { resize(size() - num_elements); }


### PR DESCRIPTION
My local benchmarks:
```
[master]
fizzy/execute/blake2b/rounds_1       310471 ns       292874 ns         2229
fizzy/execute/blake2b/rounds_16     4003494 ns      3896790 ns          167
fizzy/execute/memset/256_bytes        24893 ns        24544 ns        28206
fizzy/execute/memset/60000_bytes    3993493 ns      3958829 ns          175
fizzy/execute/mul256_opt0/input0      80082 ns        78688 ns         8381
fizzy/execute/mul256_opt0/input1      80586 ns        79297 ns         8424
fizzy/execute/sha1/rounds_1          275679 ns       268028 ns         2706
fizzy/execute/sha1/rounds_16        3588870 ns      3519071 ns          198
fizzy/execute/micro/spinner/1           571 ns          553 ns      1241399
fizzy/execute/micro/spinner/1000      27215 ns        26600 ns        26926

[inline push]
fizzy/execute/blake2b/rounds_1       179701 ns       170681 ns         4175
fizzy/execute/blake2b/rounds_16     2293652 ns      2272563 ns          295
fizzy/execute/memset/256_bytes        18553 ns        18333 ns        37492
fizzy/execute/memset/60000_bytes    3770167 ns      3234547 ns          276
fizzy/execute/mul256_opt0/input0      47608 ns        46924 ns        14864
fizzy/execute/mul256_opt0/input1      48687 ns        47643 ns        14556
fizzy/execute/sha1/rounds_1          155615 ns       152120 ns         4368
fizzy/execute/sha1/rounds_16        2049515 ns      1998439 ns          355
fizzy/execute/micro/spinner/1           610 ns          575 ns      1167698
fizzy/execute/micro/spinner/1000      23293 ns        22061 ns        31590

[inline push+peek]
fizzy/execute/blake2b/rounds_1       155729 ns       155342 ns         4085
fizzy/execute/blake2b/rounds_16     2278417 ns      2251152 ns          297
fizzy/execute/memset/256_bytes        19398 ns        18681 ns        37464
fizzy/execute/memset/60000_bytes    2592330 ns      2539643 ns          277
fizzy/execute/mul256_opt0/input0      46472 ns        46376 ns        14924
fizzy/execute/mul256_opt0/input1      47329 ns        46952 ns        14001
fizzy/execute/sha1/rounds_1          153256 ns       151442 ns         4352
fizzy/execute/sha1/rounds_16        2084649 ns      2026153 ns          340
fizzy/execute/micro/spinner/1           643 ns          583 ns      1034539
fizzy/execute/micro/spinner/1000      20610 ns        20061 ns        34012
```