### PR TITLE
Trap when call_indirect chooses uninitialized table element

### DIFF
--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -22,11 +22,12 @@ struct Instance;
 
 using ExternalFunction = std::function<execution_result(Instance&, std::vector<uint64_t>)>;
 
-using table_ptr = std::unique_ptr<std::vector<FuncIdx>, void (*)(std::vector<FuncIdx>*)>;
+using table_elements = std::vector<std::optional<FuncIdx>>;
+using table_ptr = std::unique_ptr<table_elements, void (*)(table_elements*)>;
 
 struct ExternalTable
 {
-    std::vector<FuncIdx>* table = nullptr;
+    table_elements* table = nullptr;
     Limits limits;
 };
 
@@ -55,7 +56,7 @@ struct Instance
     size_t memory_max_pages = 0;
     // Table is either allocated and owned by the instance or imported and owned externally.
     // For these cases unique_ptr would either have a normal deleter or noop deleter respectively.
-    table_ptr table = {nullptr, [](std::vector<FuncIdx>*) {}};
+    table_ptr table = {nullptr, [](table_elements*) {}};
     std::vector<uint64_t> globals;
     std::vector<ExternalFunction> imported_functions;
     std::vector<TypeIdx> imported_function_types;

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -234,7 +234,7 @@ TEST(api, find_exported_table)
         "0061736d010000000104016000000211010474657374057461626c650170010214030302000005030100000606"
         "017f0041000b071604037461620100016600000267310300036d656d02000a09020300010b0300010b");
 
-    std::vector<FuncIdx> table = {1, 0};
+    table_elements table = {1, 0};
     auto instance_reexported_table =
         instantiate(parse(wasm_reexported_table), {}, {ExternalTable{&table, {2, 20}}});
 
@@ -275,7 +275,7 @@ TEST(api, DISABLED_find_exported_table_reimport)
         from_hex("0061736d010000000211010474657374057461626c650170010214070701037461620100");
 
     // importing the table with limits narrower than defined in the module
-    std::vector<FuncIdx> table(5);
+    table_elements table(5);
     auto instance = instantiate(parse(wasm), {}, {ExternalTable{&table, {5, 10}}});
 
     auto opt_table = find_exported_table(instance, "tab");

--- a/test/unittests/execute_call_test.cpp
+++ b/test/unittests/execute_call_test.cpp
@@ -158,7 +158,7 @@ TEST(execute_call, call_indirect_imported_table)
 
     const Module module = parse(bin);
 
-    std::vector<FuncIdx> table{2, 1, 0, 3, 4};
+    table_elements table{2, 1, 0, 3, 4};
     auto instance = instantiate(module, {}, {{&table, {5, 20}}});
 
     for (const auto param : {0u, 1u, 2u})

--- a/test/unittests/execute_call_test.cpp
+++ b/test/unittests/execute_call_test.cpp
@@ -181,6 +181,33 @@ TEST(execute_call, call_indirect_imported_table)
     EXPECT_TRUE(execute(instance, 5, {5}).trapped);
 }
 
+TEST(execute_call, call_indirect_uninited_table)
+{
+    /* wat2wasm
+      (type $out-i32 (func (result i32)))
+
+      (table 5 anyfunc)
+      (elem (i32.const 0) $f3 $f2 $f1)
+
+      (func $f1 (result i32) i32.const 1)
+      (func $f2 (result i32) i32.const 2)
+      (func $f3 (result i32) i32.const 3)
+
+      (func (param i32) (result i32)
+        (call_indirect (type $out-i32) (get_local 0))
+      )
+    */
+    const auto bin = from_hex(
+        "0061736d01000000010a026000017f60017f017f030504000000010404017000050909010041000b030201000a"
+        "1804040041010b040041020b040041030b070020001100000b");
+
+    const Module module = parse(bin);
+
+    // elements 3 and 4 are not initialized
+    EXPECT_TRUE(execute(module, 3, {3}).trapped);
+    EXPECT_TRUE(execute(module, 3, {4}).trapped);
+}
+
 TEST(execute_call, imported_function_call)
 {
     Module module;

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -63,7 +63,7 @@ TEST(instantiate, imported_table)
     imp.desc.table = Table{{10, 30}};
     module.importsec.emplace_back(imp);
 
-    std::vector<FuncIdx> table(10);
+    table_elements table(10);
     auto instance = instantiate(module, {}, {{&table, {10, 30}}});
 
     ASSERT_TRUE(instance.table);
@@ -78,7 +78,7 @@ TEST(instantiate, imported_table_stricter_limits)
     imp.desc.table = Table{{10, 30}};
     module.importsec.emplace_back(imp);
 
-    std::vector<FuncIdx> table(20);
+    table_elements table(20);
     auto instance = instantiate(module, {}, {{&table, {20, 20}}});
 
     ASSERT_TRUE(instance.table);
@@ -93,7 +93,7 @@ TEST(instantiate, imported_table_invalid)
     imp.desc.table = Table{{10, 30}};
     module.importsec.emplace_back(imp);
 
-    std::vector<FuncIdx> table(10);
+    table_elements table(10);
 
     // Providing more than 1 table
     EXPECT_THROW_MESSAGE(instantiate(module, {}, {{&table, {10, 30}}, {&table, {10, 10}}}),
@@ -109,7 +109,7 @@ TEST(instantiate, imported_table_invalid)
         "Module defines an imported table but none was provided.");
 
     // Provided min too low
-    std::vector<FuncIdx> table_empty;
+    table_elements table_empty;
     EXPECT_THROW_MESSAGE(instantiate(module, {}, {{&table_empty, {0, 3}}}), instantiate_error,
         "Provided import's min is below import's min defined in module.");
 
@@ -130,7 +130,7 @@ TEST(instantiate, imported_table_invalid)
         "Provided imported table doesn't fit provided limits");
 
     // Allocated more than max
-    std::vector<FuncIdx> table_big(40, 0);
+    table_elements table_big(40, 0);
     EXPECT_THROW_MESSAGE(instantiate(module, {}, {{&table_big, {10, 30}}}), instantiate_error,
         "Provided imported table doesn't fit provided limits");
 
@@ -402,7 +402,7 @@ TEST(instantiate, element_section)
     auto instance = instantiate(module);
 
     ASSERT_EQ(instance.table->size(), 4);
-    EXPECT_EQ((*instance.table)[0], 0);
+    EXPECT_FALSE((*instance.table)[0].has_value());
     EXPECT_EQ((*instance.table)[1], 0xaa);
     EXPECT_EQ((*instance.table)[2], 0x55);
     EXPECT_EQ((*instance.table)[3], 0x55);
@@ -420,10 +420,10 @@ TEST(instantiate, element_section_offset_from_global)
     auto instance = instantiate(module);
 
     ASSERT_EQ(instance.table->size(), 4);
-    EXPECT_EQ((*instance.table)[0], 0);
+    EXPECT_FALSE((*instance.table)[0].has_value());
     EXPECT_EQ((*instance.table)[1], 0xaa);
     EXPECT_EQ((*instance.table)[2], 0xff);
-    EXPECT_EQ((*instance.table)[3], 0x00);
+    EXPECT_FALSE((*instance.table)[3].has_value());
 }
 
 TEST(instantiate, element_section_offset_from_imported_global)
@@ -441,10 +441,10 @@ TEST(instantiate, element_section_offset_from_imported_global)
     auto instance = instantiate(module, {}, {}, {}, {g});
 
     ASSERT_EQ(instance.table->size(), 4);
-    EXPECT_EQ((*instance.table)[0], 0);
+    EXPECT_FALSE((*instance.table)[0].has_value());
     EXPECT_EQ((*instance.table)[1], 0xaa);
     EXPECT_EQ((*instance.table)[2], 0xff);
-    EXPECT_EQ((*instance.table)[3], 0x00);
+    EXPECT_FALSE((*instance.table)[3].has_value());
 }
 
 TEST(instantiate, element_section_offset_from_mutable_global)
@@ -486,7 +486,7 @@ TEST(instantiate, element_section_fills_imported_table)
     module.elementsec.emplace_back(
         Element{{ConstantExpression::Kind::Constant, {2}}, {0x55, 0x66}});
 
-    std::vector<FuncIdx> table(4);
+    table_elements table(4);
     table[0] = 0xbb;
     auto instance = instantiate(module, {}, {{&table, {4, std::nullopt}}});
 


### PR DESCRIPTION
From `call_indirect` [execution spec](https://webassembly.github.io/spec/core/exec/instructions.html#exec-call-indirect):

![image](https://user-images.githubusercontent.com/1863135/75346214-82c13a80-589e-11ea-8ab1-c21e115405ae.png)

Spec test for this: https://github.com/WebAssembly/spec/blob/e3a3c12f51221daaa901691e674d7ff990029122/test/core/elem.wast#L353

This PR changes table's internal representation to `std::vector<std::optional<FuncIdx>>`.

It would be possible to represent it with `std::vector<std::function<execution_result(std::vector<uint64_t>)>>`, but `call_indirect` also checks the type of the called function against opcode's immediate, so we would need to store addditionally table function types or function indices. Vector of optionals seems at least simpler for now.