### PR TITLE
parser: Do not reserve memory for vec elements

### DIFF
--- a/lib/fizzy/parser.hpp
+++ b/lib/fizzy/parser.hpp
@@ -79,7 +79,13 @@ inline parser_result<std::vector<T>> parse_vec(const uint8_t* pos, const uint8_t
     std::tie(size, pos) = leb128u_decode<uint32_t>(pos, end);
 
     std::vector<T> result;
-    result.reserve(size);
+
+    // Reserve memory for vec elements if `size` value is reasonable.
+    // TODO: Adjust the limit constant by inspecting max vec size value
+    //       appearing in big set of example wasm binaries.
+    if (size < 128)
+        result.reserve(size);
+
     auto inserter = std::back_inserter(result);
     for (uint32_t i = 0; i < size; ++i)
         std::tie(inserter, pos) = parse<T>(pos, end);

--- a/test/bench_internal/CMakeLists.txt
+++ b/test/bench_internal/CMakeLists.txt
@@ -7,5 +7,5 @@ target_sources(fizzy-bench-internal PRIVATE
     parser_noinline.cpp
 )
 
-target_link_libraries(fizzy-bench-internal PRIVATE fizzy::fizzy benchmark::benchmark_main)
+target_link_libraries(fizzy-bench-internal PRIVATE fizzy::fizzy fizzy::test-utils benchmark::benchmark_main)
 target_include_directories(fizzy-bench-internal PRIVATE ${fizzy_include_dir})

--- a/test/bench_internal/experimental.cpp
+++ b/test/bench_internal/experimental.cpp
@@ -2,21 +2,6 @@
 #include <cstdint>
 #include <utility>
 
-// Adapted from LLVM.
-// https://github.com/llvm/llvm-project/blob/master/llvm/include/llvm/Support/LEB128.h#L80
-fizzy::bytes leb128u_encode(uint64_t value)
-{
-    fizzy::bytes result;
-    do
-    {
-        uint8_t byte = value & 0x7f;
-        value >>= 7;
-        if (value != 0)
-            byte |= 0x80;  // Mark this byte to show that more bytes will follow.
-        result.push_back(byte);
-    } while (value != 0);
-    return result;
-}
 
 std::pair<uint64_t, const uint8_t*> nop(const uint8_t* p, const uint8_t* end)
 {

--- a/test/bench_internal/parser_benchmarks.cpp
+++ b/test/bench_internal/parser_benchmarks.cpp
@@ -1,5 +1,6 @@
 #include "parser.hpp"
 #include <benchmark/benchmark.h>
+#include <test/utils/leb128_encode.hpp>
 #include <algorithm>
 #include <random>
 #include <vector>
@@ -8,8 +9,6 @@ std::pair<uint64_t, const uint8_t*> nop(const uint8_t* p, const uint8_t* end);
 std::pair<uint64_t, const uint8_t*> leb128u_decode_u64_noinline(
     const uint8_t* input, const uint8_t* end);
 std::pair<uint64_t, const uint8_t*> decodeULEB128(const uint8_t* p, const uint8_t* end);
-
-fizzy::bytes leb128u_encode(uint64_t value);
 
 namespace
 {
@@ -30,7 +29,7 @@ fizzy::bytes generate_ascii_vec(size_t size)
 {
     std::uniform_int_distribution<uint8_t> dist{0, 0x7f};
 
-    const auto size_encoded = leb128u_encode(size);
+    const auto size_encoded = fizzy::test::leb128u_encode(size);
     fizzy::bytes result;
     result.reserve(size + size_encoded.size());
     result += size_encoded;
@@ -48,7 +47,7 @@ static void leb128u_decode_u64(benchmark::State& state)
     fizzy::bytes input;
     input.reserve(size * ((sizeof(uint64_t) * 8) / 7 + 1));
     for (const auto sample : samples)
-        input += leb128u_encode(sample);
+        input += fizzy::test::leb128u_encode(sample);
 
     benchmark::ClobberMemory();
 

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 #include <test/utils/asserts.hpp>
 #include <test/utils/hex.hpp>
+#include <test/utils/leb128_encode.hpp>
 #include <array>
 
 using namespace fizzy;
@@ -14,14 +15,12 @@ namespace
 {
 bytes add_size_prefix(const bytes& content)
 {
-    assert(content.size() < 0x80);
-    return bytes{static_cast<uint8_t>(content.size())} + content;
+    return test::leb128u_encode(content.size()) + content;
 }
 
 bytes make_vec(std::initializer_list<bytes_view> contents)
 {
-    assert(contents.size() < 0x80);
-    bytes ret{static_cast<uint8_t>(contents.size())};
+    bytes ret = test::leb128u_encode(contents.size());
     for (const auto& content : contents)
         ret.append(content);
     return ret;
@@ -34,8 +33,7 @@ bytes make_section(uint8_t id, const bytes& content)
 
 bytes make_invalid_size_section(uint8_t id, size_t size, const bytes& content)
 {
-    assert(size < 0x80);
-    return bytes{id, static_cast<uint8_t>(size)} + content;
+    return bytes{id} + test::leb128u_encode(size) + content;
 }
 }  // namespace
 

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -10,6 +10,8 @@ target_sources(
     fizzy_engine.cpp
     hex.cpp
     hex.hpp
+    leb128_encode.cpp
+    leb128_encode.hpp
     wabt_engine.cpp
     wasm3_engine.cpp
     wasm_engine.hpp

--- a/test/utils/leb128_encode.cpp
+++ b/test/utils/leb128_encode.cpp
@@ -1,0 +1,20 @@
+#include "leb128_encode.hpp"
+
+namespace fizzy::test
+{
+fizzy::bytes leb128u_encode(uint64_t value) noexcept
+{
+    // Adapted from LLVM.
+    // https://github.com/llvm/llvm-project/blob/master/llvm/include/llvm/Support/LEB128.h#L80
+    fizzy::bytes result;
+    do
+    {
+        uint8_t byte = value & 0x7f;
+        value >>= 7;
+        if (value != 0)
+            byte |= 0x80;  // Mark this byte to show that more bytes will follow.
+        result.push_back(byte);
+    } while (value != 0);
+    return result;
+}
+}  // namespace fizzy::test

--- a/test/utils/leb128_encode.hpp
+++ b/test/utils/leb128_encode.hpp
@@ -1,0 +1,7 @@
+#include "bytes.hpp"
+
+namespace fizzy::test
+{
+/// Encodes the value as unsigned LEB128.
+fizzy::bytes leb128u_encode(uint64_t value) noexcept;
+}  // namespace fizzy::test


### PR DESCRIPTION
Do not reserve memory for `size` number of elements. It can be a lie causing huge allocation without actual elements to follow.