### PR TITLE
Rework "execute" benchmark

### DIFF
--- a/test/bench/bench.cpp
+++ b/test/bench/bench.cpp
@@ -100,17 +100,16 @@ void benchmark_execute(
     }
 
     if (!engine->instantiate())
-        return state.SkipWithError("Instantiaton failed");
+        return state.SkipWithError("Instantiation failed");
 
-    auto initial_memory = fizzy::bytes{engine->get_memory()};
+    const bool has_memory = !benchmark_case.memory.empty();
+    if (has_memory)
+    {
+        if (!engine->init_memory(benchmark_case.memory))
+            state.SkipWithError("Memory initialization failed");
+    }
 
-    // TODO: Check if memory is exported or imported.
-    if (benchmark_case.memory.size() > initial_memory.size())
-        return state.SkipWithError("Cannot init memory");
-
-    std::copy(std::begin(benchmark_case.memory), std::end(benchmark_case.memory),
-        std::begin(initial_memory));
-    engine->set_memory(initial_memory);
+    const auto initial_memory = fizzy::bytes{engine->get_memory()};
 
     {  // Execute once and check results against expectations.
         const auto result = engine->execute(*func_ref, benchmark_case.func_args);

--- a/test/bench/bench.cpp
+++ b/test/bench/bench.cpp
@@ -109,8 +109,6 @@ void benchmark_execute(
             state.SkipWithError("Memory initialization failed");
     }
 
-    const auto initial_memory = fizzy::bytes{engine->get_memory()};
-
     {  // Execute once and check results against expectations.
         const auto result = engine->execute(*func_ref, benchmark_case.func_args);
         if (result.trapped)
@@ -139,11 +137,11 @@ void benchmark_execute(
 
     for ([[maybe_unused]] auto _ : state)
     {
-        // Reset instance to its initial state.
-        // At this point we only reset memory, so this works only while globals
-        // and imports are not used. If this become a problem doing full
-        // instantiate() should be considered.
-        engine->set_memory(initial_memory);
+        state.PauseTiming();
+        engine->instantiate();
+        if (has_memory)
+            engine->init_memory(benchmark_case.memory);
+        state.ResumeTiming();
 
         const auto result = engine->execute(*func_ref, benchmark_case.func_args);
         benchmark::DoNotOptimize(result);

--- a/test/unittests/wasm_engine_test.cpp
+++ b/test/unittests/wasm_engine_test.cpp
@@ -178,16 +178,15 @@ TEST(wasm_engine, memory)
         ASSERT_TRUE(engine->instantiate());
         const auto func = engine->find_function("test");
         ASSERT_TRUE(func.has_value());
-        auto mem_input = bytes{engine->get_memory()};
-        // Memory shouldn't be empty...
-        // ASSERT_FALSE(mem_input.empty());
-        mem_input[0] = 0x12;
-        mem_input[3] = 0x34;
-        EXPECT_EQ(mem_input[4], 0);
-        EXPECT_EQ(mem_input[5], 0);
-        EXPECT_EQ(mem_input[6], 0);
-        EXPECT_EQ(mem_input[7], 0);
-        engine->set_memory(mem_input);
+        const auto mem_input = bytes{engine->get_memory()};
+        ASSERT_FALSE(mem_input.empty());
+        EXPECT_EQ(mem_input, bytes(64 * 1024, 0));
+
+        const auto mem_init = bytes{0x12, 0, 0, 0x34};
+        engine->init_memory(mem_init);
+        const auto mem_check = engine->get_memory();
+        EXPECT_EQ(mem_check.substr(0, 4), mem_init);
+
         // Copy 32-bits from memory offset 0 to offset 4
         const auto result = engine->execute(*func, {0, 4});
         EXPECT_FALSE(result.trapped);

--- a/test/unittests/wasm_engine_test.cpp
+++ b/test/unittests/wasm_engine_test.cpp
@@ -148,11 +148,9 @@ TEST(wasm_engine, no_memory)
         ASSERT_TRUE(engine->parse(wasm));
         ASSERT_TRUE(engine->instantiate());
         const auto func = engine->find_function("test");
-        ASSERT_TRUE(func.has_value());
+        EXPECT_TRUE(func.has_value());
         const auto mem = engine->get_memory();
-        ASSERT_TRUE(mem.empty());
-        // This should not fail as long as the above was true.
-        engine->set_memory(mem);
+        EXPECT_TRUE(mem.empty());
     }
 }
 

--- a/test/utils/fizzy_engine.cpp
+++ b/test/utils/fizzy_engine.cpp
@@ -17,7 +17,6 @@ public:
     bool instantiate() final;
     bool init_memory(bytes_view memory) final;
     bytes_view get_memory() const final;
-    void set_memory(bytes_view memory) final;
     Result execute(FuncRef func_ref, const std::vector<uint64_t>& args) final;
 };
 
@@ -67,15 +66,6 @@ bytes_view FizzyEngine::get_memory() const
         return {};
 
     return {m_instance.memory->data(), m_instance.memory->size()};
-}
-
-void FizzyEngine::set_memory(bytes_view memory)
-{
-    if (memory.empty())
-        return;
-
-    assert(m_instance.memory != nullptr);
-    *m_instance.memory = memory;
 }
 
 std::optional<WasmEngine::FuncRef> FizzyEngine::find_function(std::string_view name) const

--- a/test/utils/fizzy_engine.cpp
+++ b/test/utils/fizzy_engine.cpp
@@ -3,6 +3,7 @@
 
 #include <test/utils/wasm_engine.hpp>
 #include <cassert>
+#include <cstring>
 
 namespace fizzy::test
 {
@@ -14,6 +15,7 @@ public:
     bool parse(bytes_view input) final;
     std::optional<FuncRef> find_function(std::string_view name) const final;
     bool instantiate() final;
+    bool init_memory(bytes_view memory) final;
     bytes_view get_memory() const final;
     void set_memory(bytes_view memory) final;
     Result execute(FuncRef func_ref, const std::vector<uint64_t>& args) final;
@@ -47,6 +49,15 @@ bool FizzyEngine::instantiate()
     {
         return false;
     }
+    return true;
+}
+
+bool FizzyEngine::init_memory(bytes_view memory)
+{
+    if (m_instance.memory == nullptr || m_instance.memory->size() < memory.size())
+        return false;
+
+    std::memcpy(m_instance.memory->data(), memory.data(), memory.size());
     return true;
 }
 

--- a/test/utils/wabt_engine.cpp
+++ b/test/utils/wabt_engine.cpp
@@ -17,7 +17,6 @@ public:
     bool instantiate() final;
     bool init_memory(fizzy::bytes_view memory) final;
     bytes_view get_memory() const final;
-    void set_memory(bytes_view memory) final;
     Result execute(FuncRef func_ref, const std::vector<uint64_t>& args) final;
 };
 
@@ -60,18 +59,6 @@ bytes_view WabtEngine::get_memory() const
     auto& env = const_cast<wabt::interp::Environment&>(m_env);
     const auto& memory = env.GetMemory(0);
     return {reinterpret_cast<uint8_t*>(memory->data.data()), memory->data.size()};
-}
-
-void WabtEngine::set_memory(bytes_view memory)
-{
-    if (memory.empty())
-        return;
-
-    assert(m_env.GetMemoryCount() != 0);
-
-    auto& dst = *m_env.GetMemory(0);
-    const auto begin = reinterpret_cast<const char*>(memory.data());
-    dst.data.assign(begin, begin + memory.size());
 }
 
 std::optional<WasmEngine::FuncRef> WabtEngine::find_function(std::string_view name) const

--- a/test/utils/wabt_engine.cpp
+++ b/test/utils/wabt_engine.cpp
@@ -15,6 +15,7 @@ public:
     bool parse(bytes_view input) final;
     std::optional<FuncRef> find_function(std::string_view name) const final;
     bool instantiate() final;
+    bool init_memory(fizzy::bytes_view memory) final;
     bytes_view get_memory() const final;
     void set_memory(bytes_view memory) final;
     Result execute(FuncRef func_ref, const std::vector<uint64_t>& args) final;
@@ -35,6 +36,19 @@ bool WabtEngine::parse(bytes_view input)
 
 bool WabtEngine::instantiate()
 {
+    return true;
+}
+
+bool WabtEngine::init_memory(bytes_view memory)
+{
+    if (m_env.GetMemoryCount() == 0)
+        return false;
+
+    auto& dst = *m_env.GetMemory(0);
+    if (dst.data.size() < memory.size())
+        return false;
+
+    std::memcpy(dst.data.data(), memory.data(), memory.size());
     return true;
 }
 

--- a/test/utils/wasm3_engine.cpp
+++ b/test/utils/wasm3_engine.cpp
@@ -25,6 +25,7 @@ public:
     bool parse(bytes_view input) final;
     std::optional<FuncRef> find_function(std::string_view name) const final;
     bool instantiate() final;
+    bool init_memory(fizzy::bytes_view memory) final;
     fizzy::bytes_view get_memory() const final;
     void set_memory(fizzy::bytes_view memory) final;
     Result execute(FuncRef func_ref, const std::vector<uint64_t>& args) final;
@@ -63,6 +64,16 @@ bool Wasm3Engine::parse(bytes_view input)
 bool Wasm3Engine::instantiate()
 {
     // Already done in parse (with owernship transfer).
+    return true;
+}
+
+bool Wasm3Engine::init_memory(fizzy::bytes_view memory)
+{
+    uint32_t size;
+    const auto data = m3_GetMemory(m_runtime, &size, 0);
+    if (data == nullptr || size < memory.size())
+        return false;
+    std::memcpy(data, memory.data(), memory.size());
     return true;
 }
 

--- a/test/utils/wasm3_engine.cpp
+++ b/test/utils/wasm3_engine.cpp
@@ -27,7 +27,6 @@ public:
     bool instantiate() final;
     bool init_memory(fizzy::bytes_view memory) final;
     fizzy::bytes_view get_memory() const final;
-    void set_memory(fizzy::bytes_view memory) final;
     Result execute(FuncRef func_ref, const std::vector<uint64_t>& args) final;
 };
 
@@ -84,17 +83,6 @@ fizzy::bytes_view Wasm3Engine::get_memory() const
     if (data == nullptr)
         return {};
     return {data, size};
-}
-
-void Wasm3Engine::set_memory(fizzy::bytes_view memory)
-{
-    if (memory.empty())
-        return;
-
-    uint32_t size;
-    const auto data = m3_GetMemory(m_runtime, &size, 0);
-    assert(data != nullptr);
-    std::memcpy(data, memory.data(), size);
 }
 
 std::optional<WasmEngine::FuncRef> Wasm3Engine::find_function(std::string_view name) const

--- a/test/utils/wasm_engine.hpp
+++ b/test/utils/wasm_engine.hpp
@@ -37,6 +37,11 @@ public:
     /// Requires instantiate().
     virtual std::optional<FuncRef> find_function(std::string_view name) const = 0;
 
+    /// Initializes the beginning of the instance's memory.
+    /// The `memory` must not be empty.
+    /// Requires instantiate().
+    virtual bool init_memory(bytes_view memory) = 0;
+
     /// Returns the entire memory of the internal instance.
     /// It must return memory index 0 and the size must be a multiple of the page size.
     /// Can return an empty view if no memory is available (exported).

--- a/test/utils/wasm_engine.hpp
+++ b/test/utils/wasm_engine.hpp
@@ -48,12 +48,6 @@ public:
     /// Requires instantiate().
     virtual bytes_view get_memory() const = 0;
 
-    /// Replaces the memory of the internal instance with the provided one.
-    /// It must change memory index 0.
-    /// Should not fail if the input is empty (no update) and there is no memory available.
-    /// Requires instantiate().
-    virtual void set_memory(bytes_view memory) = 0;
-
     /// Executes the function of the given index.
     /// Requires instantiate().
     virtual Result execute(FuncRef func_ref, const std::vector<uint64_t>& args) = 0;


### PR DESCRIPTION
We now recreate full instance for each run. This is safer and matches the normal usage. This also needs a simplified WasmEngine interface.

Timer is paused during instantiation but pause/resume functions are supposed to be quite heavy.
The timings are quite disturbed.

```
Comparing bin/fizzy-bench-master to bin/fizzy-bench
Benchmark                                          Time             CPU      Time Old      Time New       CPU Old       CPU New
-------------------------------------------------------------------------------------------------------------------------------
fizzy/execute/blake2b/rounds_1                  -0.0487         -0.0308        166130        158040        163046        158026
 wabt/execute/blake2b/rounds_1                  -0.0564         -0.0371        175538        165645        172137        165745
wasm3/execute/blake2b/rounds_1                  -0.2398         -0.2246         25367         19284         24888         19299
fizzy/execute/blake2b/rounds_16                 -0.0331         -0.0155       2458820       2377513       2414996       2377489
 wabt/execute/blake2b/rounds_16                 -0.0078         +0.0103       2177104       2160024       2138042       2160033
wasm3/execute/blake2b/rounds_16                 -0.1148         -0.0979        324059        286864        318004        286872
fizzy/execute/memset/256_bytes                  -0.2314         -0.2228         17501         13452         17285         13434
 wabt/execute/memset/256_bytes                  -0.1527         -0.1506         43164         36571         43165         36664
wasm3/execute/memset/256_bytes                  -0.6111         -0.6104          5631          2190          5631          2193
fizzy/execute/memset/60000_bytes                +0.0220         +0.0220       2829408       2891634       2829404       2891773
 wabt/execute/memset/60000_bytes                +0.0215         +0.0215       2323493       2373384       2323367       2373387
wasm3/execute/memset/60000_bytes                +0.1922         +0.1906        329939        393362        329929        392829
fizzy/execute/mul256_opt0/input0                -0.0887         -0.0903         50391         45921         50391         45840
 wabt/execute/mul256_opt0/input0                -0.0754         -0.0756         73587         68039         73587         68021
wasm3/execute/mul256_opt0/input0                -0.3709         -0.3701          9717          6113          9718          6121
fizzy/execute/mul256_opt0/input1                -0.0882         -0.0884         50529         46074         50528         46062
 wabt/execute/mul256_opt0/input1                -0.0801         -0.0788         73567         67675         73565         67767
wasm3/execute/mul256_opt0/input1                -0.3715         -0.3708          9742          6122          9742          6129
fizzy/execute/sha1/rounds_1                     -0.0335         -0.0336        166697        161111        166698        161102
 wabt/execute/sha1/rounds_1                     -0.0259         -0.0253        179256        174618        179255        174718
wasm3/execute/sha1/rounds_1                     -0.0533         -0.0529         24975         23644         24975         23653
fizzy/execute/sha1/rounds_16                    -0.0297         -0.0297       2284452       2216656       2284479       2216569
 wabt/execute/sha1/rounds_16                    +0.0064         +0.0064       2079362       2092573       2079364       2092667
wasm3/execute/sha1/rounds_16                    +0.1187         +0.1188        292781        327533        292782        327552
fizzy/execute/micro/spinner/1                   +5.0497         +5.0630            84           511            84           512
 wabt/execute/micro/spinner/1                   +0.0042         +0.0077         26256         26367         26255         26458
wasm3/execute/micro/spinner/1                  +23.2449        +23.3446            18           433            18           435
fizzy/execute/micro/spinner/1000                +0.0253         +0.0246         18880         19358         18880         19344
 wabt/execute/micro/spinner/1000                -0.0118         +0.0070         39352         38886         38707         38976
wasm3/execute/micro/spinner/1000                +0.3458         +0.3690          2371          3190          2332          3192
```