### PR TITLE
Make LEB128 decoding procedures inline

### DIFF
--- a/lib/fizzy/leb128.hpp
+++ b/lib/fizzy/leb128.hpp
@@ -11,7 +11,7 @@ static_assert((int8_t{-1} >> 1) == int8_t{-1},
 namespace fizzy
 {
 template <typename T>
-std::pair<T, const uint8_t*> leb128u_decode(const uint8_t* input, const uint8_t* end)
+inline std::pair<T, const uint8_t*> leb128u_decode(const uint8_t* input, const uint8_t* end)
 {
     static_assert(!std::numeric_limits<T>::is_signed);
 
@@ -37,7 +37,7 @@ std::pair<T, const uint8_t*> leb128u_decode(const uint8_t* input, const uint8_t*
 }
 
 template <typename T>
-std::pair<T, const uint8_t*> leb128s_decode(const uint8_t* input, const uint8_t* end)
+inline std::pair<T, const uint8_t*> leb128s_decode(const uint8_t* input, const uint8_t* end)
 {
     static_assert(std::numeric_limits<T>::is_signed);
 


### PR DESCRIPTION
```
Comparing bin/fizzy-bench-master to bin/fizzy-bench
Benchmark                                   Time             CPU      Time Old      Time New       CPU Old       CPU New
------------------------------------------------------------------------------------------------------------------------
fizzy/parse/blake2b                      -0.0870         -0.0873         10146          9263         10146          9260
fizzy/parse/memset                       -0.0730         -0.0732          2876          2666          2876          2665
fizzy/parse/mul256_opt0                  -0.1041         -0.1044          3330          2983          3330          2982
fizzy/parse/sha1                         -0.0664         -0.0680         14003         13073         14003         13050
fizzy/parse/micro/spinner                +0.0004         +0.0004           549           549           549           549
```