### PR TITLE
validation: Reject modules with memory instructions but without memory

### DIFF
--- a/lib/fizzy/exceptions.hpp
+++ b/lib/fizzy/exceptions.hpp
@@ -9,6 +9,11 @@ struct parser_error : public std::runtime_error
     using runtime_error::runtime_error;
 };
 
+struct validation_error : public std::runtime_error
+{
+    using runtime_error::runtime_error;
+};
+
 struct instantiate_error : public std::runtime_error
 {
     using runtime_error::runtime_error;

--- a/lib/fizzy/parser.hpp
+++ b/lib/fizzy/parser.hpp
@@ -23,7 +23,13 @@ inline const uint8_t* skip(size_t num_bytes, const uint8_t* input, const uint8_t
     return ret;
 }
 
-parser_result<Code> parse_expr(const uint8_t* input, const uint8_t* end);
+/// Parse `expr`, i.e. a function's instructions residing in the code section.
+/// https://webassembly.github.io/spec/core/binary/instructions.html#binary-expr
+///
+/// @param input        The beginning of the expr binary input.
+/// @param end          The end of the binary input.
+/// @param have_memory  If the module (the context) contains imported or defined memory.
+parser_result<Code> parse_expr(const uint8_t* input, const uint8_t* end, bool have_memory);
 
 parser_result<std::string> parse_string(const uint8_t* pos, const uint8_t* end);
 

--- a/test/unittests/execute_test.cpp
+++ b/test/unittests/execute_test.cpp
@@ -620,6 +620,47 @@ TEST(execute, i32_store_overflow)
     ASSERT_TRUE(execute(instance, 0, {0x80000001}).trapped);
 }
 
+TEST(execute, i32_store_no_memory)
+{
+    /* wat2wasm --no-check
+    (func (param i32)
+      get_local 0
+      i32.const 0
+      i32.store
+    )
+    */
+    const auto wasm = from_hex("0061736d0100000001050160017f00030201000a0b010900200041003602000b");
+    EXPECT_THROW_MESSAGE(
+        parse(wasm), validation_error, "memory instructions require imported or defined memory");
+}
+
+TEST(execute, f32_store_no_memory)
+{
+    /* wat2wasm --no-check
+    (func (param f32)
+      get_local 0
+      f32.const 0
+      f32.store
+    )
+    */
+    const auto wasm =
+        from_hex("0061736d0100000001050160017d00030201000a0e010c00200043000000003802000b");
+    EXPECT_THROW_MESSAGE(
+        parse(wasm), validation_error, "memory instructions require imported or defined memory");
+}
+
+TEST(execute, memory_size_no_memory)
+{
+    /* wat2wasm --no-check
+    (func (result i32)
+      memory.size
+    )
+    */
+    const auto wasm = from_hex("0061736d010000000105016000017f030201000a060104003f000b");
+    EXPECT_THROW_MESSAGE(
+        parse(wasm), validation_error, "memory instructions require imported or defined memory");
+}
+
 TEST(execute, i64_store)
 {
     Module module;

--- a/test/unittests/parser_expr_test.cpp
+++ b/test/unittests/parser_expr_test.cpp
@@ -9,7 +9,7 @@ namespace
 {
 inline auto parse_expr(const bytes& input)
 {
-    return fizzy::parse_expr(input.data(), input.data() + input.size());
+    return fizzy::parse_expr(input.data(), input.data() + input.size(), false);
 }
 }  // namespace
 

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -3,7 +3,6 @@
 #include <test/utils/asserts.hpp>
 #include <test/utils/hex.hpp>
 #include <test/utils/leb128_encode.hpp>
-#include <array>
 
 using namespace fizzy;
 
@@ -1037,8 +1036,8 @@ TEST(parser, code_section_with_memory_size)
         "3f000b"_bytes;
     const auto code_bin = add_size_prefix(func_bin);
     const auto section_contents = make_vec({code_bin});
-    const auto bin =
-        bytes{wasm_prefix} + make_section(3, "0100"_bytes) + make_section(10, section_contents);
+    const auto bin = bytes{wasm_prefix} + make_section(3, "0100"_bytes) +
+                     make_section(5, make_vec({"0000"_bytes})) + make_section(10, section_contents);
     const auto module = parse(bin);
     ASSERT_EQ(module.codesec.size(), 1);
     EXPECT_EQ(module.codesec[0].local_count, 0);
@@ -1065,8 +1064,8 @@ TEST(parser, code_section_with_memory_grow)
         "410040001a0b"_bytes;
     const auto code_bin = add_size_prefix(func_bin);
     const auto code_section = make_vec({code_bin});
-    const auto bin =
-        bytes{wasm_prefix} + make_section(3, "0100"_bytes) + make_section(10, code_section);
+    const auto bin = bytes{wasm_prefix} + make_section(3, "0100"_bytes) +
+                     make_section(5, make_vec({"0000"_bytes})) + make_section(10, code_section);
 
     const auto module = parse(bin);
     ASSERT_EQ(module.codesec.size(), 1);
@@ -1120,8 +1119,8 @@ TEST(parser, code_section_fp_instructions)
         const auto code_bin = add_size_prefix(func_bin);
         const auto code_section = make_vec({code_bin});
         const auto function_section = make_vec({"00"_bytes});
-        const auto bin =
-            bytes{wasm_prefix} + make_section(3, function_section) + make_section(10, code_section);
+        const auto bin = bytes{wasm_prefix} + make_section(3, function_section) +
+                         make_section(5, make_vec({"0000"_bytes})) + make_section(10, code_section);
 
         const auto module = parse(bin);
         EXPECT_EQ(module.codesec.size(), 1);


### PR DESCRIPTION
Requires: #238.

Issue: when there is no memory defined in a module any memory access instruction (store, load) causes a crash.

I noticed that wabt rejects such module on parsing. We should confirm it is valid solution because it is a nice one (no additional check is needed during execution).