### PR TITLE
Check imported function type

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -88,7 +88,7 @@ commands:
           working_directory: ~/build
           command: |
             set +e
-            expected="  PASSED 4433, FAILED 42, SKIPPED 7338."
+            expected="  PASSED 4451, FAILED 24, SKIPPED 7338."
             result=$(bin/fizzy-spectests --skip-validation wasm-spec/test/core/json | tail -1)
             echo "Expected: $expected"
             echo "Result: $result"

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -18,6 +18,16 @@ struct LabelContext
     size_t stack_height = 0;             ///< The stack height at the label instruction.
 };
 
+inline bool operator==(const FuncType& lhs, const FuncType& rhs)
+{
+    return lhs.inputs == rhs.inputs && lhs.outputs == rhs.outputs;
+}
+
+inline bool operator!=(const FuncType& lhs, const FuncType& rhs)
+{
+    return !(lhs == rhs);
+}
+
 void match_imported_functions(const std::vector<FuncType>& module_imported_types,
     const std::vector<ExternalFunction>& imported_functions)
 {
@@ -30,10 +40,7 @@ void match_imported_functions(const std::vector<FuncType>& module_imported_types
 
     for (size_t i = 0; i < imported_functions.size(); ++i)
     {
-        const auto& module_imported_type = module_imported_types[i];
-        const auto& imported_type = imported_functions[i].type;
-        if (module_imported_type.inputs != imported_type.inputs ||
-            module_imported_type.outputs != imported_type.outputs)
+        if (module_imported_types[i] != imported_functions[i].type)
         {
             throw instantiate_error("Function " + std::to_string(i) +
                                     " type doesn't match module's imported function type");
@@ -774,8 +781,7 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
             // check actual type against expected type
             const auto& actual_type = function_type(instance, *called_func_idx);
             const auto& expected_type = instance.module.typesec[expected_type_idx];
-            if (expected_type.inputs != actual_type.inputs ||
-                expected_type.outputs != actual_type.outputs)
+            if (expected_type != actual_type)
             {
                 trap = true;
                 goto end;

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -63,7 +63,6 @@ struct Instance
     table_ptr table = {nullptr, [](table_elements*) {}};
     std::vector<uint64_t> globals;
     std::vector<ExternalFunction> imported_functions;
-    std::vector<TypeIdx> imported_function_types;
     std::vector<ExternalGlobal> imported_globals;
 };
 

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -20,7 +20,11 @@ struct execution_result
 
 struct Instance;
 
-using ExternalFunction = std::function<execution_result(Instance&, std::vector<uint64_t>)>;
+struct ExternalFunction
+{
+    std::function<execution_result(Instance&, std::vector<uint64_t>)> function;
+    FuncType type;
+};
 
 using table_elements = std::vector<std::optional<FuncIdx>>;
 using table_ptr = std::unique_ptr<table_elements, void (*)(table_elements*)>;

--- a/test/unittests/execute_call_test.cpp
+++ b/test/unittests/execute_call_test.cpp
@@ -219,8 +219,9 @@ TEST(execute_call, imported_function_call)
     auto host_foo = [](Instance&, std::vector<uint64_t>) -> execution_result {
         return {false, {42}};
     };
+    const auto host_foo_type = module.typesec[0];
 
-    auto instance = instantiate(module, {host_foo});
+    auto instance = instantiate(module, {{host_foo, host_foo_type}});
 
     const auto [trap, ret] = execute(instance, 1, {});
 
@@ -242,8 +243,9 @@ TEST(execute_call, imported_function_call_with_arguments)
     auto host_foo = [](Instance&, std::vector<uint64_t> args) -> execution_result {
         return {false, {args[0] * 2}};
     };
+    const auto host_foo_type = module.typesec[0];
 
-    auto instance = instantiate(module, {host_foo});
+    auto instance = instantiate(module, {{host_foo, host_foo_type}});
 
     const auto [trap, ret] = execute(instance, 1, {20});
 
@@ -293,7 +295,7 @@ TEST(execute_call, imported_functions_call_indirect)
         return {false, {(11 + args[0] / 11) / 2}};
     };
 
-    auto instance = instantiate(module, {sqr, isqrt});
+    auto instance = instantiate(module, {{sqr, module.typesec[0]}, {isqrt, module.typesec[0]}});
     EXPECT_RESULT(execute(instance, 3, {0, 10}), 20);  // double(10)
     EXPECT_RESULT(execute(instance, 3, {1, 9}), 81);   // sqr(9)
     EXPECT_RESULT(execute(instance, 3, {2, 50}), 7);   // isqrt(50)
@@ -338,7 +340,7 @@ TEST(execute_call, imported_function_from_another_module)
         return fizzy::execute(instance1, *func_idx, std::move(args));
     };
 
-    auto instance2 = instantiate(module2, {sub});
+    auto instance2 = instantiate(module2, {{sub, module1.typesec[0]}});
 
     EXPECT_RESULT(execute(instance2, 1, {44, 2}), 42);
 }

--- a/test/unittests/execute_control_test.cpp
+++ b/test/unittests/execute_control_test.cpp
@@ -662,7 +662,7 @@ TEST(execute_control, br_1_out_of_function_and_imported_function)
         [](Instance&, std::vector<uint64_t>) noexcept -> execution_result { return {}; };
 
     const auto module = parse(bin);
-    auto instance = instantiate(module, {fake_imported_function});
+    auto instance = instantiate(module, {{fake_imported_function, module.typesec[0]}});
     const auto [trap, ret] = execute(instance, 1, {});
     ASSERT_FALSE(trap);
     ASSERT_EQ(ret.size(), 1);

--- a/test/unittests/execute_test.cpp
+++ b/test/unittests/execute_test.cpp
@@ -903,7 +903,7 @@ TEST(execute, imported_function)
         return {false, {args[0] + args[1]}};
     };
 
-    auto instance = instantiate(module, {host_foo});
+    auto instance = instantiate(module, {{host_foo, module.typesec[0]}});
 
     const auto [trap, ret] = execute(instance, 0, {20, 22});
 
@@ -926,7 +926,8 @@ TEST(execute, imported_two_functions)
         return {false, {args[0] * args[1]}};
     };
 
-    auto instance = instantiate(module, {host_foo1, host_foo2});
+    auto instance =
+        instantiate(module, {{host_foo1, module.typesec[0]}, {host_foo2, module.typesec[0]}});
 
     const auto [trap1, ret1] = execute(instance, 0, {20, 22});
 
@@ -958,7 +959,8 @@ TEST(execute, imported_functions_and_regular_one)
         return {false, {args[0] * args[0]}};
     };
 
-    auto instance = instantiate(module, {host_foo1, host_foo2});
+    auto instance =
+        instantiate(module, {{host_foo1, module.typesec[0]}, {host_foo2, module.typesec[0]}});
 
     const auto [trap1, ret1] = execute(instance, 0, {20, 22});
 
@@ -977,7 +979,8 @@ TEST(execute, imported_functions_and_regular_one)
         return {false, {args.size()}};
     };
 
-    auto instance_couner = instantiate(module, {count_args, count_args});
+    auto instance_couner =
+        instantiate(module, {{count_args, module.typesec[0]}, {count_args, module.typesec[0]}});
 
     const auto [trap3, ret3] = execute(instance_couner, 0, {20, 22});
 
@@ -1009,7 +1012,8 @@ TEST(execute, imported_two_functions_different_type)
         return {false, {args[0] * args[0]}};
     };
 
-    auto instance = instantiate(module, {host_foo1, host_foo2});
+    auto instance =
+        instantiate(module, {{host_foo1, module.typesec[0]}, {host_foo2, module.typesec[0]}});
 
     const auto [trap1, ret1] = execute(instance, 0, {20, 22});
 
@@ -1038,7 +1042,7 @@ TEST(execute, imported_function_traps)
 
     auto host_foo = [](Instance&, std::vector<uint64_t>) -> execution_result { return {true, {}}; };
 
-    auto instance = instantiate(module, {host_foo});
+    auto instance = instantiate(module, {{host_foo, module.typesec[0]}});
 
     const auto [trap, ret] = execute(instance, 0, {20, 22});
 

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -56,6 +56,17 @@ TEST(instantiate, imported_functions_not_enough)
         "Module requires 1 imported functions, 0 provided");
 }
 
+TEST(instantiate, imported_function_wrong_type)
+{
+    Module module;
+    module.typesec.emplace_back(FuncType{{ValType::i32}, {ValType::i32}});
+    module.importsec.emplace_back(Import{"mod", "foo", ExternalKind::Function, {0}});
+
+    auto host_foo = [](Instance&, std::vector<uint64_t>) -> execution_result { return {true, {}}; };
+
+    ASSERT_THROW(instantiate(module, {host_foo}), instantiate_error);
+}
+
 TEST(instantiate, imported_table)
 {
     Module module;

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -22,8 +22,6 @@ TEST(instantiate, imported_functions)
     EXPECT_EQ(instance.imported_functions[0].type.inputs[0], ValType::i32);
     ASSERT_EQ(instance.imported_functions[0].type.outputs.size(), 1);
     EXPECT_EQ(instance.imported_functions[0].type.outputs[0], ValType::i32);
-    ASSERT_EQ(instance.imported_function_types.size(), 1);
-    EXPECT_EQ(instance.imported_function_types[0], TypeIdx{0});
 }
 
 TEST(instantiate, imported_functions_multiple)
@@ -52,9 +50,6 @@ TEST(instantiate, imported_functions_multiple)
     EXPECT_EQ(*instance.imported_functions[1].function.target<decltype(host_foo2)>(), host_foo2);
     EXPECT_TRUE(instance.imported_functions[1].type.inputs.empty());
     EXPECT_TRUE(instance.imported_functions[1].type.outputs.empty());
-    ASSERT_EQ(instance.imported_function_types.size(), 2);
-    EXPECT_EQ(instance.imported_function_types[0], TypeIdx{0});
-    EXPECT_EQ(instance.imported_function_types[1], TypeIdx{1});
 }
 
 TEST(instantiate, imported_functions_not_enough)

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -260,7 +260,7 @@ TEST(instantiate, imported_memory_invalid)
     // Provided max exceeds the hard limit
     Module module_without_max;
     Import imp_without_max{"mod", "m", ExternalKind::Memory, {}};
-    imp.desc.memory = Memory{{1, std::nullopt}};
+    imp_without_max.desc.memory = Memory{{1, std::nullopt}};
     module_without_max.importsec.emplace_back(imp_without_max);
     EXPECT_THROW_MESSAGE(
         instantiate(module_without_max, {}, {}, {{&memory, {1, MemoryPagesLimit + 1}}}),

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -11,7 +11,7 @@ TEST(instantiate, imported_functions)
 {
     Module module;
     module.typesec.emplace_back(FuncType{{ValType::i32}, {ValType::i32}});
-    module.importsec.emplace_back(Import{"mod", "foo", ExternalKind::Function, {0}});
+    module.importsec.emplace_back(Import{"mod", "foo", ExternalKind::Function, {FuncIdx{0}}});
 
     auto host_foo = [](Instance&, std::vector<uint64_t>) -> execution_result { return {true, {}}; };
     auto instance = instantiate(module, {{host_foo, module.typesec[0]}});
@@ -29,8 +29,8 @@ TEST(instantiate, imported_functions_multiple)
     Module module;
     module.typesec.emplace_back(FuncType{{ValType::i32}, {ValType::i32}});
     module.typesec.emplace_back(FuncType{{}, {}});
-    module.importsec.emplace_back(Import{"mod", "foo1", ExternalKind::Function, {0}});
-    module.importsec.emplace_back(Import{"mod", "foo2", ExternalKind::Function, {1}});
+    module.importsec.emplace_back(Import{"mod", "foo1", ExternalKind::Function, {FuncIdx{0}}});
+    module.importsec.emplace_back(Import{"mod", "foo2", ExternalKind::Function, {FuncIdx{1}}});
 
     auto host_foo1 = [](Instance&, std::vector<uint64_t>) -> execution_result {
         return {true, {0}};
@@ -56,7 +56,7 @@ TEST(instantiate, imported_functions_not_enough)
 {
     Module module;
     module.typesec.emplace_back(FuncType{{ValType::i32}, {ValType::i32}});
-    module.importsec.emplace_back(Import{"mod", "foo", ExternalKind::Function, {0}});
+    module.importsec.emplace_back(Import{"mod", "foo", ExternalKind::Function, {FuncIdx{0}}});
 
     EXPECT_THROW_MESSAGE(instantiate(module, {}), instantiate_error,
         "Module requires 1 imported functions, 0 provided");
@@ -66,7 +66,7 @@ TEST(instantiate, imported_function_wrong_type)
 {
     Module module;
     module.typesec.emplace_back(FuncType{{ValType::i32}, {ValType::i32}});
-    module.importsec.emplace_back(Import{"mod", "foo", ExternalKind::Function, {0}});
+    module.importsec.emplace_back(Import{"mod", "foo", ExternalKind::Function, {FuncIdx{0}}});
 
     auto host_foo = [](Instance&, std::vector<uint64_t>) -> execution_result { return {true, {}}; };
     const auto host_foo_type = FuncType{{}, {}};


### PR DESCRIPTION
1. Make `ExternalFunction` a struct containing `std::function` and `FuncType`.
2. In `match_imported_functions` check imported function types against import types declared in the module.
3. Refactor to get rid of `Instance::imported_function_types`, because this info is now included in `Instance::imported_functions`

This fixes failures in `imports.wast`