### PR TITLE
call_indirect for functions from another modules

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -93,7 +93,7 @@ commands:
           working_directory: ~/build
           command: |
             set +e
-            expected="  PASSED 4451, FAILED 24, SKIPPED 7338."
+            expected="  PASSED 4468, FAILED 7, SKIPPED 7338."
             result=$(bin/fizzy-spectests --skip-validation wasm-spec/test/core/json | tail -1)
             echo "Expected: $expected"
             echo "Result: $result"

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -26,12 +26,16 @@ struct ExternalFunction
     FuncType type;
 };
 
-using table_elements = std::vector<std::optional<ExternalFunction>>;
-using table_ptr = std::unique_ptr<table_elements, void (*)(table_elements*)>;
+struct TableElements
+{
+    std::vector<std::optional<ExternalFunction>> functions;
+    std::vector<std::unique_ptr<Instance>> dependency_instances;
+};
+using table_ptr = std::unique_ptr<TableElements, void (*)(TableElements*)>;
 
 struct ExternalTable
 {
-    table_elements* table = nullptr;
+    TableElements* table = nullptr;
     Limits limits;
 };
 
@@ -60,7 +64,7 @@ struct Instance
     size_t memory_max_pages = 0;
     // Table is either allocated and owned by the instance or imported and owned externally.
     // For these cases unique_ptr would either have a normal deleter or noop deleter respectively.
-    table_ptr table = {nullptr, [](table_elements*) {}};
+    table_ptr table = {nullptr, [](TableElements*) {}};
     std::vector<uint64_t> globals;
     std::vector<ExternalFunction> imported_functions;
     std::vector<ExternalGlobal> imported_globals;

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -26,7 +26,7 @@ struct ExternalFunction
     FuncType type;
 };
 
-using table_elements = std::vector<std::optional<FuncIdx>>;
+using table_elements = std::vector<std::optional<ExternalFunction>>;
 using table_ptr = std::unique_ptr<table_elements, void (*)(table_elements*)>;
 
 struct ExternalTable
@@ -64,10 +64,23 @@ struct Instance
     std::vector<uint64_t> globals;
     std::vector<ExternalFunction> imported_functions;
     std::vector<ExternalGlobal> imported_globals;
+
+    Instance(Module _module, bytes_ptr _memory, size_t _memory_max_pages, table_ptr _table,
+        std::vector<uint64_t> _globals, std::vector<ExternalFunction> _imported_functions,
+        std::vector<ExternalGlobal> _imported_globals)
+      : module(std::move(_module)),
+        memory(std::move(_memory)),
+        memory_max_pages(_memory_max_pages),
+        table(std::move(_table)),
+        globals(std::move(_globals)),
+        imported_functions(std::move(_imported_functions)),
+        imported_globals(std::move(_imported_globals))
+    {}
 };
 
 // Instantiate a module.
-Instance instantiate(Module module, std::vector<ExternalFunction> imported_functions = {},
+std::unique_ptr<Instance> instantiate(Module module,
+    std::vector<ExternalFunction> imported_functions = {},
     std::vector<ExternalTable> imported_tables = {},
     std::vector<ExternalMemory> imported_memories = {},
     std::vector<ExternalGlobal> imported_globals = {});

--- a/test/spectests/spectests.cpp
+++ b/test/spectests/spectests.cpp
@@ -378,7 +378,7 @@ private:
             return nullptr;
         }
 
-        return &it_instance->second;
+        return it_instance->second.get();
     }
 
     std::optional<fizzy::execution_result> invoke(const json& action)
@@ -467,7 +467,7 @@ private:
 
             if (import.kind == fizzy::ExternalKind::Function)
             {
-                const auto func = fizzy::find_exported_function(instance, import.name);
+                const auto func = fizzy::find_exported_function(*instance, import.name);
                 if (!func.has_value())
                 {
                     return {{},
@@ -478,7 +478,7 @@ private:
             }
             else if (import.kind == fizzy::ExternalKind::Table)
             {
-                const auto table = fizzy::find_exported_table(instance, import.name);
+                const auto table = fizzy::find_exported_table(*instance, import.name);
                 if (!table.has_value())
                 {
                     return {{},
@@ -489,7 +489,7 @@ private:
             }
             else if (import.kind == fizzy::ExternalKind::Memory)
             {
-                const auto memory = fizzy::find_exported_memory(instance, import.name);
+                const auto memory = fizzy::find_exported_memory(*instance, import.name);
                 if (!memory.has_value())
                 {
                     return {{},
@@ -500,7 +500,7 @@ private:
             }
             else if (import.kind == fizzy::ExternalKind::Global)
             {
-                const auto global = fizzy::find_exported_global(instance, import.name);
+                const auto global = fizzy::find_exported_global(*instance, import.name);
                 if (!global.has_value())
                 {
                     return {{},
@@ -537,7 +537,7 @@ private:
     void log_no_newline(std::string_view message) const { std::cout << message << std::flush; }
 
     test_settings m_settings;
-    std::unordered_map<std::string, fizzy::Instance> m_instances;
+    std::unordered_map<std::string, std::unique_ptr<fizzy::Instance>> m_instances;
     std::unordered_map<std::string, std::string> m_registered_names;
     std::string m_last_module_name;
     test_results m_results;

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -219,7 +219,7 @@ TEST(api, find_exported_table)
     auto opt_table = find_exported_table(*instance, "tab");
     ASSERT_TRUE(opt_table);
     EXPECT_EQ(opt_table->table, instance->table.get());
-    EXPECT_EQ(opt_table->table->size(), 2);
+    EXPECT_EQ(opt_table->table->functions.size(), 2);
     // EXPECT_EQ((*opt_table->table)[0], 1);
     // EXPECT_EQ((*opt_table->table)[1], 0);
     EXPECT_EQ(opt_table->limits.min, 2);
@@ -242,7 +242,8 @@ TEST(api, find_exported_table)
         "0061736d010000000104016000000211010474657374057461626c650170010214030302000005030100000606"
         "017f0041000b071604037461620100016600000267310300036d656d02000a09020300010b0300010b");
 
-    table_elements table(2);  // = {/*1, 0*/std::nullopt, std::nullopt};
+    TableElements table;  // = {/*1, 0*/std::nullopt, std::nullopt};
+    table.functions.resize(2);
     auto instance_reexported_table =
         instantiate(parse(wasm_reexported_table), {}, {ExternalTable{&table, {2, 20}}});
 
@@ -283,7 +284,8 @@ TEST(api, DISABLED_find_exported_table_reimport)
         from_hex("0061736d010000000211010474657374057461626c650170010214070701037461620100");
 
     // importing the table with limits narrower than defined in the module
-    table_elements table(5);
+    TableElements table;
+    table.functions.resize(5);
     auto instance = instantiate(parse(wasm), {}, {ExternalTable{&table, {5, 10}}});
 
     auto opt_table = find_exported_table(*instance, "tab");

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -56,14 +56,14 @@ TEST(api, find_exported_function)
 
     auto instance = instantiate(parse(wasm));
 
-    auto opt_function = find_exported_function(instance, "foo");
+    auto opt_function = find_exported_function(*instance, "foo");
     ASSERT_TRUE(opt_function);
-    EXPECT_RESULT(opt_function->function(instance, {}), 42);
+    EXPECT_RESULT(opt_function->function(*instance, {}), 42);
     EXPECT_TRUE(opt_function->type.inputs.empty());
     ASSERT_EQ(opt_function->type.outputs.size(), 1);
     EXPECT_EQ(opt_function->type.outputs[0], ValType::i32);
 
-    EXPECT_FALSE(find_exported_function(instance, "bar").has_value());
+    EXPECT_FALSE(find_exported_function(*instance, "bar").has_value());
 
     /* wat2wasm
     (module
@@ -83,14 +83,14 @@ TEST(api, find_exported_function)
     auto instance_reexported_function =
         instantiate(parse(wasm_reexported_function), {{bar, bar_type}});
 
-    opt_function = find_exported_function(instance_reexported_function, "foo");
+    opt_function = find_exported_function(*instance_reexported_function, "foo");
     ASSERT_TRUE(opt_function);
-    EXPECT_RESULT(opt_function->function(instance, {}), 42);
+    EXPECT_RESULT(opt_function->function(*instance, {}), 42);
     EXPECT_TRUE(opt_function->type.inputs.empty());
     ASSERT_EQ(opt_function->type.outputs.size(), 1);
     EXPECT_EQ(opt_function->type.outputs[0], ValType::i32);
 
-    EXPECT_FALSE(find_exported_function(instance, "bar").has_value());
+    EXPECT_FALSE(find_exported_function(*instance, "bar").has_value());
 
     /* wat2wasm
     (module
@@ -105,7 +105,7 @@ TEST(api, find_exported_function)
 
     auto instance_no_function = instantiate(parse(wasm_no_function));
 
-    EXPECT_FALSE(find_exported_function(instance_no_function, "mem").has_value());
+    EXPECT_FALSE(find_exported_function(*instance_no_function, "mem").has_value());
 }
 
 TEST(api, find_exported_global)
@@ -128,30 +128,30 @@ TEST(api, find_exported_global)
 
     auto instance = instantiate(parse(wasm));
 
-    auto opt_global = find_exported_global(instance, "g1");
+    auto opt_global = find_exported_global(*instance, "g1");
     ASSERT_TRUE(opt_global);
     EXPECT_EQ(*opt_global->value, 0);
     EXPECT_TRUE(opt_global->is_mutable);
 
-    opt_global = find_exported_global(instance, "g2");
+    opt_global = find_exported_global(*instance, "g2");
     ASSERT_TRUE(opt_global);
     EXPECT_EQ(*opt_global->value, 1);
     EXPECT_FALSE(opt_global->is_mutable);
 
-    opt_global = find_exported_global(instance, "g3");
+    opt_global = find_exported_global(*instance, "g3");
     ASSERT_TRUE(opt_global);
     EXPECT_EQ(*opt_global->value, 2);
     EXPECT_TRUE(opt_global->is_mutable);
 
-    opt_global = find_exported_global(instance, "g4");
+    opt_global = find_exported_global(*instance, "g4");
     ASSERT_TRUE(opt_global);
     EXPECT_EQ(*opt_global->value, 3);
     EXPECT_FALSE(opt_global->is_mutable);
 
-    EXPECT_FALSE(find_exported_global(instance, "g5"));
-    EXPECT_FALSE(find_exported_global(instance, "f"));
-    EXPECT_FALSE(find_exported_global(instance, "tab"));
-    EXPECT_FALSE(find_exported_global(instance, "mem"));
+    EXPECT_FALSE(find_exported_global(*instance, "g5"));
+    EXPECT_FALSE(find_exported_global(*instance, "f"));
+    EXPECT_FALSE(find_exported_global(*instance, "tab"));
+    EXPECT_FALSE(find_exported_global(*instance, "mem"));
 
     /* wat2wasm
     (module
@@ -170,17 +170,17 @@ TEST(api, find_exported_global)
     auto instance_reexported_global =
         instantiate(parse(wasm_reexported_global), {}, {}, {}, {ExternalGlobal{&g1, false}});
 
-    opt_global = find_exported_global(instance_reexported_global, "g1");
+    opt_global = find_exported_global(*instance_reexported_global, "g1");
     ASSERT_TRUE(opt_global);
     EXPECT_EQ(opt_global->value, &g1);
     EXPECT_FALSE(opt_global->is_mutable);
 
-    opt_global = find_exported_global(instance_reexported_global, "g2");
+    opt_global = find_exported_global(*instance_reexported_global, "g2");
     ASSERT_TRUE(opt_global);
     EXPECT_EQ(*opt_global->value, 1);
     EXPECT_TRUE(opt_global->is_mutable);
 
-    EXPECT_FALSE(find_exported_global(instance_reexported_global, "g3").has_value());
+    EXPECT_FALSE(find_exported_global(*instance_reexported_global, "g3").has_value());
 
     /* wat2wasm
     (module
@@ -195,7 +195,7 @@ TEST(api, find_exported_global)
 
     auto instance_no_globals = instantiate(parse(wasm_no_globals));
 
-    EXPECT_FALSE(find_exported_global(instance_no_globals, "g1").has_value());
+    EXPECT_FALSE(find_exported_global(*instance_no_globals, "g1").has_value());
 }
 
 TEST(api, find_exported_table)
@@ -216,17 +216,17 @@ TEST(api, find_exported_table)
 
     auto instance = instantiate(parse(wasm));
 
-    auto opt_table = find_exported_table(instance, "tab");
+    auto opt_table = find_exported_table(*instance, "tab");
     ASSERT_TRUE(opt_table);
-    EXPECT_EQ(opt_table->table, instance.table.get());
+    EXPECT_EQ(opt_table->table, instance->table.get());
     EXPECT_EQ(opt_table->table->size(), 2);
-    EXPECT_EQ((*opt_table->table)[0], 1);
-    EXPECT_EQ((*opt_table->table)[1], 0);
+    // EXPECT_EQ((*opt_table->table)[0], 1);
+    // EXPECT_EQ((*opt_table->table)[1], 0);
     EXPECT_EQ(opt_table->limits.min, 2);
     ASSERT_TRUE(opt_table->limits.max.has_value());
     EXPECT_EQ(opt_table->limits.max, 20);
 
-    EXPECT_FALSE(find_exported_table(instance, "ttt").has_value());
+    EXPECT_FALSE(find_exported_table(*instance, "ttt").has_value());
 
     /* wat2wasm
     (module
@@ -242,18 +242,18 @@ TEST(api, find_exported_table)
         "0061736d010000000104016000000211010474657374057461626c650170010214030302000005030100000606"
         "017f0041000b071604037461620100016600000267310300036d656d02000a09020300010b0300010b");
 
-    table_elements table = {1, 0};
+    table_elements table(2);  // = {/*1, 0*/std::nullopt, std::nullopt};
     auto instance_reexported_table =
         instantiate(parse(wasm_reexported_table), {}, {ExternalTable{&table, {2, 20}}});
 
-    opt_table = find_exported_table(instance_reexported_table, "tab");
+    opt_table = find_exported_table(*instance_reexported_table, "tab");
     ASSERT_TRUE(opt_table);
     EXPECT_EQ(opt_table->table, &table);
     EXPECT_EQ(opt_table->limits.min, 2);
     ASSERT_TRUE(opt_table->limits.max.has_value());
     EXPECT_EQ(opt_table->limits.max, 20);
 
-    EXPECT_FALSE(find_exported_table(instance, "ttt").has_value());
+    EXPECT_FALSE(find_exported_table(*instance, "ttt").has_value());
 
     /* wat2wasm
     (module
@@ -268,7 +268,7 @@ TEST(api, find_exported_table)
 
     auto instance_no_table = instantiate(parse(wasm_no_table));
 
-    EXPECT_FALSE(find_exported_table(instance_no_table, "tab").has_value());
+    EXPECT_FALSE(find_exported_table(*instance_no_table, "tab").has_value());
 }
 
 TEST(api, DISABLED_find_exported_table_reimport)
@@ -286,7 +286,7 @@ TEST(api, DISABLED_find_exported_table_reimport)
     table_elements table(5);
     auto instance = instantiate(parse(wasm), {}, {ExternalTable{&table, {5, 10}}});
 
-    auto opt_table = find_exported_table(instance, "tab");
+    auto opt_table = find_exported_table(*instance, "tab");
     ASSERT_TRUE(opt_table);
     EXPECT_EQ(opt_table->table, &table);
     // table should have the limits it was imported with
@@ -322,14 +322,14 @@ TEST(api, find_exported_memory)
 
     auto instance = instantiate(parse(wasm));
 
-    auto opt_memory = find_exported_memory(instance, "mem");
+    auto opt_memory = find_exported_memory(*instance, "mem");
     ASSERT_TRUE(opt_memory);
     EXPECT_EQ(opt_memory->data->size(), PageSize);
     EXPECT_EQ(opt_memory->limits.min, 1);
     ASSERT_TRUE(opt_memory->limits.max.has_value());
     EXPECT_EQ(opt_memory->limits.max, 2);
 
-    EXPECT_FALSE(find_exported_memory(instance, "mem2").has_value());
+    EXPECT_FALSE(find_exported_memory(*instance, "mem2").has_value());
 
     /* wat2wasm
     (module
@@ -348,14 +348,14 @@ TEST(api, find_exported_memory)
     auto instance_reexported_memory =
         instantiate(parse(wasm_reexported_memory), {}, {}, {ExternalMemory{&memory, {1, 4}}});
 
-    opt_memory = find_exported_memory(instance_reexported_memory, "mem");
+    opt_memory = find_exported_memory(*instance_reexported_memory, "mem");
     ASSERT_TRUE(opt_memory);
     EXPECT_EQ(opt_memory->data, &memory);
     EXPECT_EQ(opt_memory->limits.min, 1);
     ASSERT_TRUE(opt_memory->limits.max.has_value());
     EXPECT_EQ(opt_memory->limits.max, 4);
 
-    EXPECT_FALSE(find_exported_memory(instance, "memory").has_value());
+    EXPECT_FALSE(find_exported_memory(*instance, "memory").has_value());
 
     /* wat2wasm
     (module
@@ -370,7 +370,7 @@ TEST(api, find_exported_memory)
 
     auto instance_no_memory = instantiate(parse(wasm_no_memory));
 
-    EXPECT_FALSE(find_exported_table(instance_no_memory, "mem").has_value());
+    EXPECT_FALSE(find_exported_table(*instance_no_memory, "mem").has_value());
 }
 
 TEST(api, DISABLED_find_exported_memory_reimport)
@@ -388,7 +388,7 @@ TEST(api, DISABLED_find_exported_memory_reimport)
     bytes memory(2 * PageSize, 0);
     auto instance = instantiate(parse(wasm), {}, {}, {ExternalMemory{&memory, {2, 5}}});
 
-    auto opt_memory = find_exported_memory(instance, "mem");
+    auto opt_memory = find_exported_memory(*instance, "mem");
     ASSERT_TRUE(opt_memory);
     EXPECT_EQ(opt_memory->data, &memory);
     // table should have the limits it was imported with

--- a/test/unittests/end_to_end_test.cpp
+++ b/test/unittests/end_to_end_test.cpp
@@ -70,7 +70,7 @@ TEST(end_to_end, milestone2)
 
     auto instance = instantiate(module);
 
-    auto& memory = *instance.memory;
+    auto& memory = *instance->memory;
     // This performs uint256 x uint256 -> uint512 multiplication.
     // Arg1: 2^255 + 1
     memory[0] = 1;
@@ -79,7 +79,7 @@ TEST(end_to_end, milestone2)
     memory[32] = 0xff;
     memory[63] = 0xc0;
     // TODO: use find_exported_function
-    const auto [trap, ret] = execute(instance, 0, {64, 0, 32});
+    const auto [trap, ret] = execute(*instance, 0, {64, 0, 32});
 
     ASSERT_FALSE(trap);
     ASSERT_EQ(ret.size(), 0);
@@ -176,9 +176,9 @@ TEST(end_to_end, memset)
     ASSERT_TRUE(func_idx);
 
     auto instance = instantiate(module);
-    const auto [trap, ret] = execute(instance, *func_idx, {0, 2});
+    const auto [trap, ret] = execute(*instance, *func_idx, {0, 2});
 
     ASSERT_FALSE(trap);
     ASSERT_EQ(ret.size(), 0);
-    EXPECT_EQ(hex(instance.memory->substr(0, 2 * sizeof(int))), "d2040000d2040000");
+    EXPECT_EQ(hex(instance->memory->substr(0, 2 * sizeof(int))), "d2040000d2040000");
 }

--- a/test/unittests/execute_call_test.cpp
+++ b/test/unittests/execute_call_test.cpp
@@ -344,3 +344,46 @@ TEST(execute_call, imported_function_from_another_module)
 
     EXPECT_RESULT(execute(instance2, 1, {44, 2}), 42);
 }
+
+TEST(execute_call, imported_table_from_another_module)
+{
+    /* wat2wasm
+    (module
+      (func $sub (param $lhs i32) (param $rhs i32) (result i32)
+        get_local $lhs
+        get_local $rhs
+        i32.sub)
+      (table (export "tab") 3 funcref)
+      (elem (i32.const 0) $sub)
+    )
+    */
+    const auto bin1 = from_hex(
+        "0061736d0100000001070160027f7f017f030201000404017000030707010374616201000907010041000b0100"
+        "0a09010700200020016b0b");
+    const auto module1 = parse(bin1);
+    auto instance1 = instantiate(module1);
+
+    /* wat2wasm
+    (module
+      (type $t1 (func (param $lhs i32) (param $rhs i32) (result i32)))
+      (import "m1" "tab" (table 3 funcref))
+
+      (func $main (param i32) (param i32) (result i32)
+        get_local 0
+        get_local 1
+        (call_indirect (type $t1) (i32.const 0))
+      )
+    )
+    */
+    const auto bin2 = from_hex(
+        "0061736d0100000001070160027f7f017f020c01026d310374616201700003030201000a0d010b002000200141"
+        "001100000b");
+    const auto module2 = parse(bin2);
+
+    const auto table = fizzy::find_exported_table(instance1, "tab");
+    ASSERT_TRUE(table.has_value());
+
+    auto instance2 = instantiate(module2, {}, {*table});
+
+    EXPECT_RESULT(execute(instance2, 0, {44, 2}), 42);
+}

--- a/test/unittests/execute_call_test.cpp
+++ b/test/unittests/execute_call_test.cpp
@@ -161,8 +161,8 @@ TEST(execute_call, call_indirect_imported_table)
     auto out_i32 = FuncType{{}, {ValType::i32}};
     auto out_i64 = FuncType{{}, {ValType::i64}};
 
-    table_elements table{
-        {{f3, out_i32}}, {{f2, out_i32}}, {{f1, out_i32}}, {{f4, out_i64}}, {{f5, out_i32}}};
+    TableElements table{
+        {{{f3, out_i32}}, {{f2, out_i32}}, {{f1, out_i32}}, {{f4, out_i64}}, {{f5, out_i32}}}, {}};
 
     auto instance = instantiate(module, {}, {{&table, {5, 20}}});
 

--- a/test/unittests/execute_control_test.cpp
+++ b/test/unittests/execute_control_test.cpp
@@ -663,7 +663,7 @@ TEST(execute_control, br_1_out_of_function_and_imported_function)
 
     const auto module = parse(bin);
     auto instance = instantiate(module, {{fake_imported_function, module.typesec[0]}});
-    const auto [trap, ret] = execute(instance, 1, {});
+    const auto [trap, ret] = execute(*instance, 1, {});
     ASSERT_FALSE(trap);
     ASSERT_EQ(ret.size(), 1);
     EXPECT_EQ(ret[0], 1);

--- a/test/utils/fizzy_engine.cpp
+++ b/test/utils/fizzy_engine.cpp
@@ -32,7 +32,7 @@ bool FizzyEngine::parse(bytes_view input)
         auto module = fizzy::parse(input);
         m_instance =
             std::make_unique<Instance>(std::move(module), bytes_ptr{nullptr, [](bytes*) {}}, 0,
-                table_ptr{nullptr, [](table_elements*) {}}, std::vector<uint64_t>{},
+                table_ptr{nullptr, [](TableElements*) {}}, std::vector<uint64_t>{},
                 std::vector<ExternalFunction>{}, std::vector<ExternalGlobal>{});
     }
     catch (const fizzy::parser_error&)


### PR DESCRIPTION
This fixes remaining failures in `elem.wast` and `linking.wast`. 

There are two scenarios:

1.
- module A has exported table
- module A adds via element section some of its functions into the table.
- module B imports this table
- `call_indirect` executed with this table in the instance of B will call a function in A.

Unit test demonstrating it: https://github.com/wasmx/fizzy/blob/0a51bc1ec4db349249113ed99a0c8371c1368c65/test/unittests/execute_call_test.cpp#L353

2. 
- module A has exported table
- module B imports this table and adds via element section some of its functions into this shared table.
- module B's start function traps, so it can't be instantiated.
- After this the change to shared table can't be rolled back, and so the table still must contain the functions of module B. They can be called from module A with `call_indirect`.
(Related discussion about this scenario:
https://github.com/WebAssembly/spec/issues/993
https://github.com/WebAssembly/spec/pull/994)

Unit test demonstrating it: https://github.com/wasmx/fizzy/blob/b5d12edf384710c0bb48f730cf0efedca2180c2a/test/unittests/execute_call_test.cpp#L396


Two problems are fixed in the same PR, because fixing only 1 leads to UB in the spectest for scenario 2 (calling a function from deleted instance)
https://github.com/WebAssembly/spec/blob/9f7b0ae427e5f078cf4951d1c974aa3bcda72bc2/test/core/linking.wast#L388