### PR TITLE
Check element and data section bounds before modifying imported table and memory

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -106,7 +106,7 @@ commands:
           working_directory: ~/build
           command: |
             set +e
-            expected="  PASSED 4465, FAILED 25, SKIPPED 7323."
+            expected="  PASSED 4469, FAILED 21, SKIPPED 7323."
             result=$(bin/fizzy-spectests --skip-validation wasm-spec/test/core/json | tail -1)
             echo "Expected: $expected"
             echo "Result: $result"


### PR DESCRIPTION
[Instantiation algorithm](https://webassembly.github.io/spec/core/exec/modules.html#instantiation) in the spec has separate steps for checking the bounds, preceding the steps for filling table/memory:

![image](https://user-images.githubusercontent.com/1863135/77766623-32c1c900-7040-11ea-90e0-558f64e654ea.png)
[...]
![image](https://user-images.githubusercontent.com/1863135/77766670-40774e80-7040-11ea-902e-3698a8021f1c.png)
[...]
![image](https://user-images.githubusercontent.com/1863135/77766709-4e2cd400-7040-11ea-93fe-da49bd4e5501.png)


This resolves some failures in `linking.wast`