### PR TITLE
call_indirect for functions from another modules

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -248,8 +248,8 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 4734
-          expected_failed: 698
+          expected_passed: 4747
+          expected_failed: 685
           expected_skipped: 6381
 
   benchmark:
@@ -340,12 +340,12 @@ jobs:
           at: ~/build
       - spectest:
           skip_validation: true
-          expected_passed: 4469
-          expected_failed: 21
+          expected_passed: 4482
+          expected_failed: 8
           expected_skipped: 7323
       - spectest:
-          expected_passed: 4734
-          expected_failed: 698
+          expected_passed: 4747
+          expected_failed: 685
           expected_skipped: 6381
 
 workflows:

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -22,7 +22,7 @@ struct Instance;
 
 struct ExternalFunction
 {
-    std::function<execution_result(Instance&, std::vector<uint64_t>)> function;
+    std::function<execution_result(Instance&, std::vector<uint64_t>, int depth)> function;
     FuncType type;
 };
 

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -26,7 +26,7 @@ struct ExternalFunction
     FuncType type;
 };
 
-using table_elements = std::vector<std::optional<FuncIdx>>;
+using table_elements = std::vector<std::optional<ExternalFunction>>;
 using table_ptr = std::unique_ptr<table_elements, void (*)(table_elements*)>;
 
 struct ExternalTable

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -58,7 +58,7 @@ TEST(api, find_exported_function)
 
     auto opt_function = find_exported_function(*instance, "foo");
     ASSERT_TRUE(opt_function);
-    EXPECT_RESULT(opt_function->function(*instance, {}), 42);
+    EXPECT_RESULT(opt_function->function(*instance, {}, 0), 42);
     EXPECT_TRUE(opt_function->type.inputs.empty());
     ASSERT_EQ(opt_function->type.outputs.size(), 1);
     EXPECT_EQ(opt_function->type.outputs[0], ValType::i32);
@@ -77,7 +77,7 @@ TEST(api, find_exported_function)
         "0061736d010000000105016000017f021001087370656374657374036261720000040401700000050401010102"
         "0606017f0041000b07170403666f6f000001670300037461620100036d656d0200");
 
-    auto bar = [](Instance&, std::vector<uint64_t>) { return execution_result{false, {42}}; };
+    auto bar = [](Instance&, std::vector<uint64_t>, int) { return execution_result{false, {42}}; };
     const auto bar_type = FuncType{{}, {ValType::i32}};
 
     auto instance_reexported_function =
@@ -85,7 +85,7 @@ TEST(api, find_exported_function)
 
     opt_function = find_exported_function(*instance_reexported_function, "foo");
     ASSERT_TRUE(opt_function);
-    EXPECT_RESULT(opt_function->function(*instance, {}), 42);
+    EXPECT_RESULT(opt_function->function(*instance, {}, 0), 42);
     EXPECT_TRUE(opt_function->type.inputs.empty());
     ASSERT_EQ(opt_function->type.outputs.size(), 1);
     EXPECT_EQ(opt_function->type.outputs[0], ValType::i32);

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -202,8 +202,8 @@ TEST(api, find_exported_table)
 {
     /* wat2wasm
     (module
-      (func $f (export "f") nop)
-      (func $g nop)
+      (func $f (export "f") (result i32) (i32.const 1))
+      (func $g (result i32) (i32.const 2))
       (global (export "g1") i32 (i32.const 0))
       (table (export "tab") 2 20 anyfunc)
       (elem 0 (i32.const 0) $g $f)
@@ -211,8 +211,8 @@ TEST(api, find_exported_table)
     )
      */
     const auto wasm = from_hex(
-        "0061736d0100000001040160000003030200000405017001021405030100000606017f0041000b071604016600"
-        "000267310300037461620100036d656d02000908010041000b0201000a09020300010b0300010b");
+        "0061736d010000000105016000017f03030200000405017001021405030100000606017f0041000b0716040166"
+        "00000267310300037461620100036d656d02000908010041000b0201000a0b02040041010b040041020b");
 
     auto instance = instantiate(parse(wasm));
 
@@ -220,8 +220,8 @@ TEST(api, find_exported_table)
     ASSERT_TRUE(opt_table);
     EXPECT_EQ(opt_table->table, instance->table.get());
     EXPECT_EQ(opt_table->table->size(), 2);
-    EXPECT_EQ((*opt_table->table)[0], 1);
-    EXPECT_EQ((*opt_table->table)[1], 0);
+    EXPECT_THAT((*opt_table->table)[0]->function(*instance, {}, 0), Result(2));
+    EXPECT_THAT((*opt_table->table)[1]->function(*instance, {}, 0), Result(1));
     EXPECT_EQ(opt_table->limits.min, 2);
     ASSERT_TRUE(opt_table->limits.max.has_value());
     EXPECT_EQ(opt_table->limits.max, 20);
@@ -242,7 +242,7 @@ TEST(api, find_exported_table)
         "0061736d010000000104016000000211010474657374057461626c650170010214030302000005030100000606"
         "017f0041000b071604037461620100016600000267310300036d656d02000a09020300010b0300010b");
 
-    table_elements table = {1, 0};
+    table_elements table(2);
     auto instance_reexported_table =
         instantiate(parse(wasm_reexported_table), {}, {ExternalTable{&table, {2, 20}}});
 

--- a/test/unittests/execute_call_test.cpp
+++ b/test/unittests/execute_call_test.cpp
@@ -343,6 +343,49 @@ TEST(execute_call, imported_function_from_another_module)
     EXPECT_RESULT(execute(*instance2, 1, {44, 2}), 42);
 }
 
+TEST(execute_call, imported_table_from_another_module)
+{
+    /* wat2wasm
+    (module
+      (func $sub (param $lhs i32) (param $rhs i32) (result i32)
+        get_local $lhs
+        get_local $rhs
+        i32.sub)
+      (table (export "tab") 1 funcref)
+      (elem (i32.const 0) $sub)
+    )
+    */
+    const auto bin1 = from_hex(
+        "0061736d0100000001070160027f7f017f030201000404017000010707010374616201000907010041000b0100"
+        "0a09010700200020016b0b");
+    const auto module1 = parse(bin1);
+    auto instance1 = instantiate(module1);
+
+    /* wat2wasm
+    (module
+      (type $t1 (func (param $lhs i32) (param $rhs i32) (result i32)))
+      (import "m1" "tab" (table 1 funcref))
+
+      (func $main (param i32) (param i32) (result i32)
+        get_local 0
+        get_local 1
+        (call_indirect (type $t1) (i32.const 0))
+      )
+    )
+    */
+    const auto bin2 = from_hex(
+        "0061736d0100000001070160027f7f017f020c01026d310374616201700001030201000a0d010b002000200141"
+        "001100000b");
+    const auto module2 = parse(bin2);
+
+    const auto table = fizzy::find_exported_table(*instance1, "tab");
+    ASSERT_TRUE(table.has_value());
+
+    auto instance2 = instantiate(module2, {}, {*table});
+
+    EXPECT_THAT(execute(*instance2, 0, {44, 2}), Result(42));
+}
+
 TEST(execute_call, call_infinite_recursion)
 {
     /* wat2wasm

--- a/test/unittests/execute_call_test.cpp
+++ b/test/unittests/execute_call_test.cpp
@@ -388,6 +388,51 @@ TEST(execute_call, imported_table_from_another_module)
     EXPECT_THAT(execute(*instance2, 0, {44, 2}), Result(42));
 }
 
+TEST(execute_call, imported_table_modified_by_uninstantiable_module)
+{
+    /* wat2wasm
+    (module
+      (type $t1 (func (param $lhs i32) (param $rhs i32) (result i32)))
+      (func (param i32) (param i32) (result i32)
+        get_local 0
+        get_local 1
+        (call_indirect (type $t1) (i32.const 0))
+      )
+      (table (export "tab") 1 funcref)
+    )
+    */
+    const auto bin1 = from_hex(
+        "0061736d0100000001070160027f7f017f030201000404017000010707010374616201000a0d010b0020002001"
+        "41001100000b");
+    const auto module1 = parse(bin1);
+    auto instance1 = instantiate(module1);
+
+    /* wat2wasm
+    (module
+      (import "m1" "tab" (table 1 funcref))
+      (func $sub (param $lhs i32) (param $rhs i32) (result i32)
+        get_local $lhs
+        get_local $rhs
+        i32.sub)
+      (elem (i32.const 0) $sub)
+      (func $main (unreachable))
+      (start $main)
+    )
+    */
+    const auto bin2 = from_hex(
+        "0061736d01000000010a0260027f7f017f600000020c01026d3103746162017000010303020001080101090701"
+        "0041000b01000a0d020700200020016b0b0300000b");
+    const auto module2 = parse(bin2);
+
+    const auto table = fizzy::find_exported_table(*instance1, "tab");
+    ASSERT_TRUE(table.has_value());
+
+    EXPECT_THROW_MESSAGE(
+        instantiate(module2, {}, {*table}), instantiate_error, "Start function failed to execute");
+
+    EXPECT_THAT(execute(*instance1, 0, {44, 2}), Result(42));
+}
+
 TEST(execute_call, call_infinite_recursion)
 {
     /* wat2wasm

--- a/test/unittests/execute_call_test.cpp
+++ b/test/unittests/execute_call_test.cpp
@@ -134,44 +134,46 @@ TEST(execute_call, call_indirect_imported_table)
       (type $out_i32 (func (result i32)))
       (import "m" "t" (table 5 20 anyfunc))
 
-      (func $f1 (result i32) i32.const 1)
-      (func $f2 (result i32) i32.const 2)
-      (func $f3 (result i32) i32.const 3)
-      (func $f4 (result i64) i64.const 4)
-      (func $f5 (result i32) unreachable)
-
       (func (param i32) (result i32)
         (call_indirect (type $out_i32) (get_local 0))
       )
     )
     */
     const auto bin = from_hex(
-        "0061736d01000000010e036000017f6000017e60017f017f020a01016d01740170010514030706000000010002"
-        "0a2106040041010b040041020b040041030b040042040b0300000b070020001100000b");
+        "0061736d01000000010a026000017f60017f017f020a01016d01740170010514030201010a0901070020001100"
+        "000b");
 
     const Module module = parse(bin);
 
-    table_elements table{2, 1, 0, 3, 4};
+    auto f1 = [](Instance&, std::vector<uint64_t>, int) { return execution_result{false, {1}}; };
+    auto f2 = [](Instance&, std::vector<uint64_t>, int) { return execution_result{false, {2}}; };
+    auto f3 = [](Instance&, std::vector<uint64_t>, int) { return execution_result{false, {3}}; };
+    auto f4 = [](Instance&, std::vector<uint64_t>, int) { return execution_result{false, {4}}; };
+    auto f5 = [](Instance&, std::vector<uint64_t>, int) { return execution_result{true, {}}; };
+
+    auto out_i32 = FuncType{{}, {ValType::i32}};
+    auto out_i64 = FuncType{{}, {ValType::i64}};
+
+    table_elements table{
+        {{f3, out_i32}}, {{f2, out_i32}}, {{f1, out_i32}}, {{f4, out_i64}}, {{f5, out_i32}}};
+
     auto instance = instantiate(module, {}, {{&table, {5, 20}}});
 
     for (const auto param : {0u, 1u, 2u})
     {
         constexpr uint64_t expected_results[]{3, 2, 1};
 
-        const auto [trap, ret] = execute(*instance, 5, {param});
-        ASSERT_FALSE(trap);
-        ASSERT_EQ(ret.size(), 1);
-        EXPECT_EQ(ret[0], expected_results[param]);
+        EXPECT_THAT(execute(*instance, 0, {param}), Result(expected_results[param]));
     }
 
     // immediate is incorrect type
-    EXPECT_TRUE(execute(*instance, 5, {3}).trapped);
+    EXPECT_THAT(execute(*instance, 0, {3}), Traps());
 
     // called function traps
-    EXPECT_TRUE(execute(*instance, 5, {4}).trapped);
+    EXPECT_THAT(execute(*instance, 0, {4}), Traps());
 
     // argument out of table bounds
-    EXPECT_TRUE(execute(*instance, 5, {5}).trapped);
+    EXPECT_THAT(execute(*instance, 0, {5}), Traps());
 }
 
 TEST(execute_call, call_indirect_uninited_table)

--- a/test/unittests/execute_call_test.cpp
+++ b/test/unittests/execute_call_test.cpp
@@ -373,7 +373,7 @@ TEST(execute_call, call_indirect_infinite_recursion)
     EXPECT_TRUE(execute(module, 0, {}).trapped);
 }
 
-TEST(execute, call_max_depth)
+TEST(execute_call, call_max_depth)
 {
     /* wat2wasm
     (func (result i32) (i32.const 42))
@@ -390,7 +390,7 @@ TEST(execute, call_max_depth)
 }
 
 // A regression test for incorrect number of arguments passed to a call.
-TEST(execute, call_nonempty_stack)
+TEST(execute_call, call_nonempty_stack)
 {
     /* wat2wasm
     (func (param i32) (result i32)
@@ -412,7 +412,7 @@ TEST(execute, call_nonempty_stack)
     EXPECT_RESULT(execute(*instance, 1, {}), 3);
 }
 
-TEST(execute, call_imported_infinite_recursion)
+TEST(execute_call, call_imported_infinite_recursion)
 {
     /* wat2wasm
     (import "mod" "foo" (func (result i32)))

--- a/test/unittests/execute_call_test.cpp
+++ b/test/unittests/execute_call_test.cpp
@@ -214,7 +214,7 @@ TEST(execute_call, imported_function_call)
 
     const auto module = parse(wasm);
 
-    constexpr auto host_foo = [](Instance&, std::vector<uint64_t>) -> execution_result {
+    constexpr auto host_foo = [](Instance&, std::vector<uint64_t>, int) -> execution_result {
         return {false, {42}};
     };
     const auto host_foo_type = module.typesec[0];
@@ -241,7 +241,7 @@ TEST(execute_call, imported_function_call_with_arguments)
 
     const auto module = parse(wasm);
 
-    auto host_foo = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    auto host_foo = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args[0] * 2}};
     };
     const auto host_foo_type = module.typesec[0];
@@ -285,10 +285,10 @@ TEST(execute_call, imported_functions_call_indirect)
     ASSERT_EQ(module.importsec.size(), 2);
     ASSERT_EQ(module.codesec.size(), 2);
 
-    constexpr auto sqr = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto sqr = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args[0] * args[0]}};
     };
-    constexpr auto isqrt = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto isqrt = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {(11 + args[0] / 11) / 2}};
     };
 
@@ -333,7 +333,8 @@ TEST(execute_call, imported_function_from_another_module)
     const auto func_idx = fizzy::find_exported_function(module1, "sub");
     ASSERT_TRUE(func_idx.has_value());
 
-    auto sub = [&instance1, func_idx](Instance&, std::vector<uint64_t> args) -> execution_result {
+    auto sub = [&instance1, func_idx](
+                   Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return fizzy::execute(*instance1, *func_idx, std::move(args));
     };
 
@@ -423,8 +424,8 @@ TEST(execute, call_imported_infinite_recursion)
         "0061736d010000000105016000017f020b01036d6f6403666f6f0000030201000a0601040010000b");
 
     const auto module = parse(wasm);
-    auto host_foo = [](Instance& instance, std::vector<uint64_t>) -> execution_result {
-        return execute(instance, 0, {});
+    auto host_foo = [](Instance& instance, std::vector<uint64_t>, int depth) -> execution_result {
+        return execute(instance, 0, {}, depth + 1);
     };
     const auto host_foo_type = module.typesec[0];
 

--- a/test/unittests/execute_control_test.cpp
+++ b/test/unittests/execute_control_test.cpp
@@ -658,8 +658,8 @@ TEST(execute_control, br_1_out_of_function_and_imported_function)
         "0061736d010000000108026000006000017f02150108696d706f727465640866756e6374696f6e000003020101"
         "0a0d010b00034041010c010b41000b");
 
-    constexpr auto fake_imported_function =
-        [](Instance&, std::vector<uint64_t>) noexcept -> execution_result { return {}; };
+    constexpr auto fake_imported_function = [](Instance&, std::vector<uint64_t>,
+                                                int) noexcept -> execution_result { return {}; };
 
     const auto module = parse(bin);
     auto instance = instantiate(module, {{fake_imported_function, module.typesec[0]}});

--- a/test/unittests/execute_test.cpp
+++ b/test/unittests/execute_test.cpp
@@ -602,7 +602,7 @@ TEST(execute, imported_function)
     const auto module = parse(wasm);
     ASSERT_EQ(module.typesec.size(), 1);
 
-    constexpr auto host_foo = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto host_foo = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args[0] + args[1]}};
     };
 
@@ -622,10 +622,10 @@ TEST(execute, imported_two_functions)
     const auto module = parse(wasm);
     ASSERT_EQ(module.typesec.size(), 1);
 
-    constexpr auto host_foo1 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto host_foo1 = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args[0] + args[1]}};
     };
-    constexpr auto host_foo2 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto host_foo2 = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args[0] * args[1]}};
     };
 
@@ -649,10 +649,10 @@ TEST(execute, imported_functions_and_regular_one)
         "0061736d0100000001070160027f7f017f021702036d6f6404666f6f310000036d6f6404666f6f320000030201"
         "000a0901070041aa80a8010b");
 
-    constexpr auto host_foo1 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto host_foo1 = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args[0] + args[1]}};
     };
-    constexpr auto host_foo2 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto host_foo2 = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args[0] * args[0]}};
     };
 
@@ -664,7 +664,7 @@ TEST(execute, imported_functions_and_regular_one)
     EXPECT_THAT(execute(*instance, 1, {20}), Result(400));
 
     // check correct number of arguments is passed to host
-    constexpr auto count_args = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto count_args = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args.size()}};
     };
 
@@ -689,10 +689,10 @@ TEST(execute, imported_two_functions_different_type)
         "0061736d01000000010c0260027f7f017f60017e017e021702036d6f6404666f6f310000036d6f6404666f6f32"
         "0001030201010a0901070042aa80a8010b");
 
-    constexpr auto host_foo1 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto host_foo1 = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args[0] + args[1]}};
     };
-    constexpr auto host_foo2 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto host_foo2 = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args[0] * args[0]}};
     };
 
@@ -713,7 +713,7 @@ TEST(execute, imported_function_traps)
     */
     const auto wasm = from_hex("0061736d0100000001070160027f7f017f020b01036d6f6403666f6f0000");
 
-    constexpr auto host_foo = [](Instance&, std::vector<uint64_t>) -> execution_result {
+    constexpr auto host_foo = [](Instance&, std::vector<uint64_t>, int) -> execution_result {
         return {true, {}};
     };
 

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -7,6 +7,15 @@
 
 using namespace fizzy;
 
+namespace
+{
+uint64_t call_table_func(Instance& instance, size_t idx)
+{
+    const auto& elem = (*instance.table)[idx];
+    const auto res = elem->function(instance, {}, 0);
+    return res.stack.front();
+}
+}  // namespace
 
 TEST(instantiate, imported_functions)
 {
@@ -169,7 +178,7 @@ TEST(instantiate, imported_table_invalid)
         "Provided imported table doesn't fit provided limits");
 
     // Allocated more than max
-    table_elements table_big(40, 0);
+    table_elements table_big(40);
     EXPECT_THROW_MESSAGE(instantiate(module, {}, {{&table_big, {10, 30}}}), instantiate_error,
         "Provided imported table doesn't fit provided limits");
 }
@@ -429,39 +438,51 @@ TEST(instantiate, memory_single_large_maximum)
 
 TEST(instantiate, element_section)
 {
-    Module module;
-    module.tablesec.emplace_back(Table{{4, std::nullopt}});
-    // Table contents: 0, 0xaa, 0xff, 0, ...
-    module.elementsec.emplace_back(
-        Element{{ConstantExpression::Kind::Constant, {1}}, {0xaa, 0xff}});
-    // Table contents: 0, 0xaa, 0x55, 0x55, 0, ...
-    module.elementsec.emplace_back(
-        Element{{ConstantExpression::Kind::Constant, {2}}, {0x55, 0x55}});
+    /* wat2wasm
+    (module
+      (table (export "tab") 4 funcref)
+      (elem (i32.const 1) $f1 $f2) ;; Table contents: uninit, f1, f2, uninit
+      (elem (i32.const 2) $f3 $f3) ;; Table contents: uninit, f1, f3, f3
+      (func $f1 (result i32) (i32.const 1))
+      (func $f2 (result i32) (i32.const 2))
+      (func $f3 (result i32) (i32.const 3))
+    )
+    */
+    const auto bin = from_hex(
+        "0061736d010000000105016000017f030403000000040401700004070701037461620100090f020041010b0200"
+        "010041020b0202020a1003040041010b040041020b040041030b");
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(parse(bin));
 
     ASSERT_EQ(instance->table->size(), 4);
     EXPECT_FALSE((*instance->table)[0].has_value());
-    EXPECT_EQ((*instance->table)[1], 0xaa);
-    EXPECT_EQ((*instance->table)[2], 0x55);
-    EXPECT_EQ((*instance->table)[3], 0x55);
+    EXPECT_EQ(call_table_func(*instance, 1), 1);
+    EXPECT_EQ(call_table_func(*instance, 2), 3);
+    EXPECT_EQ(call_table_func(*instance, 3), 3);
 }
 
 TEST(instantiate, element_section_offset_from_global)
 {
-    Module module;
-    module.tablesec.emplace_back(Table{{4, std::nullopt}});
-    module.globalsec.emplace_back(Global{false, {ConstantExpression::Kind::Constant, {1}}});
-    // Table contents: 0, 0xaa, 0xff, 0, ...
-    module.elementsec.emplace_back(
-        Element{{ConstantExpression::Kind::GlobalGet, {0}}, {0xaa, 0xff}});
-
-    auto instance = instantiate(module);
+    // Manually generated binary,
+    // because wabt doesn't support offset initied from non-imported global
+    /*
+    (module
+      (global $offset i32 (i32.const 1))
+      (table (export "tab") 4 funcref)
+      (elem (global.get $offset) $f1 $f2) ;; Table contents: uninit, f1, f2, uninit
+      (func $f1 (result i32) (i32.const 1))
+      (func $f2 (result i32) (i32.const 2))
+    )
+    */
+    const auto bin = from_hex(
+        "0061736d010000000105016000017f03030200000404017000040606017f0041010b0707010374616201"
+        "000908010023000b0200010a0b02040041010b040041020b");
+    auto instance = instantiate(parse(bin));
 
     ASSERT_EQ(instance->table->size(), 4);
     EXPECT_FALSE((*instance->table)[0].has_value());
-    EXPECT_EQ((*instance->table)[1], 0xaa);
-    EXPECT_EQ((*instance->table)[2], 0xff);
+    EXPECT_EQ(call_table_func(*instance, 1), 1);
+    EXPECT_EQ(call_table_func(*instance, 2), 2);
     EXPECT_FALSE((*instance->table)[3].has_value());
 }
 
@@ -482,12 +503,12 @@ TEST(instantiate, element_section_offset_from_imported_global)
     uint64_t global_value = 1;
     ExternalGlobal g{&global_value, false};
 
-    auto instance = instantiate(module, {}, {}, {}, {g});
+    auto instance = instantiate(parse(bin), {}, {}, {}, {g});
 
     ASSERT_EQ(instance->table->size(), 4);
     EXPECT_FALSE((*instance->table)[0].has_value());
-    EXPECT_EQ((*instance->table)[1], 0);
-    EXPECT_EQ((*instance->table)[2], 1);
+    EXPECT_EQ(call_table_func(*instance, 1), 1);
+    EXPECT_EQ(call_table_func(*instance, 2), 2);
     EXPECT_FALSE((*instance->table)[3].has_value());
 }
 
@@ -520,28 +541,31 @@ TEST(instantiate, element_section_offset_too_large)
 TEST(instantiate, element_section_fills_imported_table)
 {
     /* wat2wasm
-      (table (import "mod" "t") 4 funcref)
-      (elem (i32.const 1) 0 1) ;; Table contents: uninit, 0, 1, uninit
-      (elem (i32.const 2) 2 3) ;; Table contents: uninit, 0, 2, 3
-      (func (result i32) (i32.const 1))
-      (func (result i32) (i32.const 2))
-      (func (result i32) (i32.const 3))
-      (func (result i32) (i32.const 4))
+    (module
+      (table (import "m" "tab") 4 funcref)
+      (elem (i32.const 1) $f1 $f2) ;; Table contents: uninit, f1, f2, uninit
+      (elem (i32.const 2) $f3 $f4) ;; Table contents: uninit, f1, f3, f4
+      (func $f1 (result i32) (i32.const 1))
+      (func $f2 (result i32) (i32.const 2))
+      (func $f3 (result i32) (i32.const 3))
+      (func $f4 (result i32) (i32.const 4))
+    )
     */
     const auto bin = from_hex(
-        "0061736d010000000105016000017f020b01036d6f6401740170000403050400000000090f020041010b020001"
+        "0061736d010000000105016000017f020b01016d037461620170000403050400000000090f020041010b020001"
         "0041020b0202030a1504040041010b040041020b040041030b040041040b");
-    const auto module = parse(bin);
+
+    auto f0 = [](Instance&, std::vector<uint64_t>, int) { return execution_result{false, {0}}; };
 
     table_elements table(4);
-    table[0] = 0xbb;
-    auto instance = instantiate(module, {}, {{&table, {4, std::nullopt}}});
+    table[0] = ExternalFunction{f0, FuncType{{}, {ValType::i32}}};
+    auto instance = instantiate(parse(bin), {}, {{&table, {4, std::nullopt}}});
 
     ASSERT_EQ(instance->table->size(), 4);
-    EXPECT_EQ((*instance->table)[0], 0xbb);
-    EXPECT_EQ((*instance->table)[1], 0);
-    EXPECT_EQ((*instance->table)[2], 2);
-    EXPECT_EQ((*instance->table)[3], 3);
+    EXPECT_EQ(call_table_func(*instance, 0), 0);
+    EXPECT_EQ(call_table_func(*instance, 1), 1);
+    EXPECT_EQ(call_table_func(*instance, 2), 3);
+    EXPECT_EQ(call_table_func(*instance, 3), 4);
 }
 
 TEST(instantiate, element_section_out_of_bounds_doesnt_change_imported_table)
@@ -559,14 +583,16 @@ TEST(instantiate, element_section_out_of_bounds_doesnt_change_imported_table)
         "0b0200000a0601040041010b");
     Module module = parse(bin);
 
+    auto f0 = [](Instance&, std::vector<uint64_t>, int) { return execution_result{false, {0}}; };
+
     table_elements table(3);
-    table[0] = 0xbb;
+    table[0] = ExternalFunction{f0, FuncType{{}, {ValType::i32}}};
 
     EXPECT_THROW_MESSAGE(instantiate(module, {}, {{&table, {3, std::nullopt}}}), instantiate_error,
         "Element segment is out of table bounds");
 
     ASSERT_EQ(table.size(), 3);
-    EXPECT_EQ(table[0], 0xbb);
+    EXPECT_EQ(*table[0]->function.target<decltype(f0)>(), f0);
     EXPECT_FALSE(table[1].has_value());
     EXPECT_FALSE(table[2].has_value());
 }

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -16,7 +16,9 @@ TEST(instantiate, imported_functions)
     const auto bin = from_hex("0061736d0100000001060160017f017f020b01036d6f6403666f6f0000");
     const auto module = parse(bin);
 
-    auto host_foo = [](Instance&, std::vector<uint64_t>) -> execution_result { return {true, {}}; };
+    auto host_foo = [](Instance&, std::vector<uint64_t>, int) -> execution_result {
+        return {true, {}};
+    };
     auto instance = instantiate(module, {{host_foo, module.typesec[0]}});
 
     ASSERT_EQ(instance->imported_functions.size(), 1);
@@ -37,10 +39,10 @@ TEST(instantiate, imported_functions_multiple)
         "0061736d0100000001090260017f017f600000021702036d6f6404666f6f310000036d6f6404666f6f320001");
     const auto module = parse(bin);
 
-    auto host_foo1 = [](Instance&, std::vector<uint64_t>) -> execution_result {
+    auto host_foo1 = [](Instance&, std::vector<uint64_t>, int) -> execution_result {
         return {true, {0}};
     };
-    auto host_foo2 = [](Instance&, std::vector<uint64_t>) -> execution_result {
+    auto host_foo2 = [](Instance&, std::vector<uint64_t>, int) -> execution_result {
         return {true, {}};
     };
     auto instance =
@@ -77,7 +79,9 @@ TEST(instantiate, imported_function_wrong_type)
     const auto bin = from_hex("0061736d0100000001060160017f017f020b01036d6f6403666f6f0000");
     const auto module = parse(bin);
 
-    auto host_foo = [](Instance&, std::vector<uint64_t>) -> execution_result { return {true, {}}; };
+    auto host_foo = [](Instance&, std::vector<uint64_t>, int) -> execution_result {
+        return {true, {}};
+    };
     const auto host_foo_type = FuncType{{}, {}};
 
     EXPECT_THROW_MESSAGE(instantiate(module, {{host_foo, host_foo_type}}), instantiate_error,


### PR DESCRIPTION
This fixes remaining failures in `elem.wast` and `linking.wast`. 

There are two scenarios:

1.
- module A has exported table
- module A adds via element section some of its functions into the table.
- module B imports this table
- `call_indirect` executed with this table in the instance of B will call a function in A.

Unit test demonstrating it: https://github.com/wasmx/fizzy/blob/0a51bc1ec4db349249113ed99a0c8371c1368c65/test/unittests/execute_call_test.cpp#L353

2. 
- module A has exported table
- module B imports this table and adds via element section some of its functions into this shared table.
- module B's start function traps, so it can't be instantiated.
- After this the change to shared table can't be rolled back, and so the table still must contain the functions of module B. They can be called from module A with `call_indirect`.
(Related discussion about this scenario:
https://github.com/WebAssembly/spec/issues/993
https://github.com/WebAssembly/spec/pull/994)

Unit test demonstrating it: https://github.com/wasmx/fizzy/blob/b5d12edf384710c0bb48f730cf0efedca2180c2a/test/unittests/execute_call_test.cpp#L396


Two problems are fixed in the same PR, because fixing only 1 leads to UB in the spectest for scenario 2 (calling a function from deleted instance)
https://github.com/WebAssembly/spec/blob/9f7b0ae427e5f078cf4951d1c974aa3bcda72bc2/test/core/linking.wast#L388