### PR TITLE
Stack optimization

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -378,26 +378,25 @@ inline bool store_into_memory(bytes& memory, OperandStack& stack, const uint8_t*
 template <typename Op>
 inline void unary_op(OperandStack& stack, Op op) noexcept
 {
-    using T = decltype(op(stack.pop()));
-    const auto a = static_cast<T>(stack.pop());
-    stack.push(op(a));
+    using T = decltype(op(stack.top()));
+    stack.top() = op(static_cast<T>(stack.top()));
 }
 
 template <typename Op>
 inline void binary_op(OperandStack& stack, Op op) noexcept
 {
-    using T = decltype(op(stack.pop(), stack.pop()));
+    using T = decltype(op(stack.top(), stack.top()));
     const auto val2 = static_cast<T>(stack.pop());
-    const auto val1 = static_cast<T>(stack.pop());
-    stack.push(static_cast<std::make_unsigned_t<T>>(op(val1, val2)));
+    const auto val1 = static_cast<T>(stack.top());
+    stack.top() = static_cast<std::make_unsigned_t<T>>(op(val1, val2));
 }
 
 template <typename T, template <typename> class Op>
 inline void comparison_op(OperandStack& stack, Op<T> op) noexcept
 {
     const auto val2 = static_cast<T>(stack.pop());
-    const auto val1 = static_cast<T>(stack.pop());
-    stack.push(uint32_t{op(val1, val2)});
+    const auto val1 = static_cast<T>(stack.top());
+    stack.top() = uint32_t{op(val1, val2)};
 }
 
 template <typename T>

--- a/lib/fizzy/stack.hpp
+++ b/lib/fizzy/stack.hpp
@@ -6,6 +6,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 namespace fizzy
@@ -47,5 +48,80 @@ public:
         assert(new_size <= size());
         resize(new_size);
     }
+};
+
+class OperandStack
+{
+    /// The pointer to the top item, or below the stack bottom if stack is empty.
+    ///
+    /// This pointer always alias m_storage, but it is kept as the first field
+    /// because it is accessed the most. Therefore, it must be initialized
+    /// in the constructor after the m_storage.
+    uint64_t* m_top;
+
+    /// The storage for items.
+    std::unique_ptr<uint64_t[]> m_storage;
+
+public:
+    /// Default constructor. Sets the top item pointer to below the stack bottom.
+    explicit OperandStack(size_t max_stack_height)
+      : m_storage{std::make_unique<uint64_t[]>(max_stack_height)}
+    {
+        m_top = m_storage.get() - 1;
+    }
+
+    OperandStack(const OperandStack&) = delete;
+    OperandStack& operator=(const OperandStack&) = delete;
+
+    /// The current number of items on the stack (aka stack height).
+    [[nodiscard]] size_t size() const noexcept
+    {
+        return static_cast<size_t>(m_top + 1 - m_storage.get());
+    }
+
+    /// Returns the reference to the top item.
+    /// Requires non-empty stack.
+    [[nodiscard]] auto& top() noexcept
+    {
+        assert(size() != 0);
+        return *m_top;
+    }
+
+    /// Returns the reference to the stack item on given position from the stack top.
+    /// Requires index < size().
+    [[nodiscard]] auto& operator[](size_t index) noexcept
+    {
+        assert(index < size());
+        return *(m_top - index);
+    }
+
+    /// Pushes an item on the stack.
+    /// The stack max height limit is not checked.
+    void push(uint64_t item) noexcept { *++m_top = item; }
+
+    /// Returns an item popped from the top of the stack.
+    /// Requires non-empty stack.
+    auto pop() noexcept
+    {
+        assert(size() != 0);
+        return *m_top--;
+    }
+
+    /// Shrinks the stack to the given new size by dropping items from the top.
+    ///
+    /// Requires new_size <= size().
+    /// shrink(0) clears entire stack and moves the top pointer below the stack base.
+    void shrink(size_t new_size) noexcept
+    {
+        assert(new_size <= size());
+        // For new_size == 0, the m_top will point below the storage.
+        m_top = m_storage.get() + new_size - 1;
+    }
+
+    /// Returns iterator to the bottom of the stack.
+    [[nodiscard]] const uint64_t* rbegin() const noexcept { return m_storage.get(); }
+
+    /// Returns end iterator counting from the bottom of the stack.
+    [[nodiscard]] const uint64_t* rend() const noexcept { return m_top + 1; }
 };
 }  // namespace fizzy

--- a/lib/fizzy/types.hpp
+++ b/lib/fizzy/types.hpp
@@ -332,6 +332,8 @@ struct Element
 /// https://webassembly.github.io/spec/core/binary/modules.html#code-section
 struct Code
 {
+    int max_stack_height = 0;
+
     uint32_t local_count = 0;
 
     // The instructions bytecode without immediate values.

--- a/test/unittests/execute_numeric_test.cpp
+++ b/test/unittests/execute_numeric_test.cpp
@@ -18,7 +18,7 @@ execution_result execute_unary_operation(Instr instr, uint64_t arg)
     // type is currently needed only to get arity of function, so exact value types don't matter
     module.typesec.emplace_back(FuncType{{ValType::i32}, {ValType::i32}});
     module.funcsec.emplace_back(TypeIdx{0});
-    module.codesec.emplace_back(Code{0, {Instr::local_get, instr, Instr::end}, {0, 0, 0, 0}});
+    module.codesec.emplace_back(Code{1, 0, {Instr::local_get, instr, Instr::end}, {0, 0, 0, 0}});
 
     return execute(module, 0, {arg});
 }
@@ -29,8 +29,8 @@ execution_result execute_binary_operation(Instr instr, uint64_t lhs, uint64_t rh
     // type is currently needed only to get arity of function, so exact value types don't matter
     module.typesec.emplace_back(FuncType{{ValType::i32, ValType::i32}, {ValType::i32}});
     module.funcsec.emplace_back(TypeIdx{0});
-    module.codesec.emplace_back(
-        Code{0, {Instr::local_get, Instr::local_get, instr, Instr::end}, {0, 0, 0, 0, 1, 0, 0, 0}});
+    module.codesec.emplace_back(Code{
+        2, 0, {Instr::local_get, Instr::local_get, instr, Instr::end}, {0, 0, 0, 0, 1, 0, 0, 0}});
 
     return execute(module, 0, {lhs, rhs});
 }

--- a/test/unittests/parser_expr_test.cpp
+++ b/test/unittests/parser_expr_test.cpp
@@ -25,27 +25,28 @@ TEST(parser_expr, instr_loop)
     const auto [code1, pos1] = parse_expr(loop_void);
     EXPECT_EQ(code1.instructions, (std::vector{Instr::loop, Instr::end, Instr::end}));
     EXPECT_EQ(code1.immediates.size(), 0);
-
-    // EXPECT_EQ(code1.max_stack_height, 0);
+    EXPECT_EQ(code1.max_stack_height, 0);
 
     const auto loop_i32 = "037f41000b0b"_bytes;
     const auto [code2, pos2] = parse_expr(loop_i32);
     EXPECT_EQ(
         code2.instructions, (std::vector{Instr::loop, Instr::i32_const, Instr::end, Instr::end}));
     EXPECT_EQ(code2.immediates.size(), 4);
-    // EXPECT_EQ(code2.max_stack_height, 1);
+    EXPECT_EQ(code2.max_stack_height, 1);
 
     const auto loop_f32 = "037d43000000000b0b"_bytes;
     const auto [code3, pos3] = parse_expr(loop_f32);
     EXPECT_EQ(
         code3.instructions, (std::vector{Instr::loop, Instr::f32_const, Instr::end, Instr::end}));
     EXPECT_EQ(code3.immediates.size(), 0);
+    EXPECT_EQ(code3.max_stack_height, 1);
 
     const auto loop_f64 = "037d4400000000000000000b0b"_bytes;
     const auto [code4, pos4] = parse_expr(loop_f64);
     EXPECT_EQ(
         code4.instructions, (std::vector{Instr::loop, Instr::f64_const, Instr::end, Instr::end}));
     EXPECT_EQ(code4.immediates.size(), 0);
+    EXPECT_EQ(code4.max_stack_height, 1);
 }
 
 TEST(parser_expr, instr_loop_input_buffer_overflow)
@@ -124,6 +125,7 @@ TEST(parser_expr, block_br)
         "0b000000"
         "01000000"
         "01000000"_bytes);
+    EXPECT_EQ(code.max_stack_height, 1);
 }
 
 TEST(parser_expr, instr_br_table)
@@ -172,6 +174,7 @@ TEST(parser_expr, instr_br_table)
         "00000000"
         "04000000"_bytes;
     EXPECT_EQ(code.immediates.substr(br_table_imm_offset, expected_br_imm.size()), expected_br_imm);
+    EXPECT_EQ(code.max_stack_height, 1);
 }
 
 TEST(parser_expr, instr_br_table_empty_vector)
@@ -198,6 +201,7 @@ TEST(parser_expr, instr_br_table_empty_vector)
         "00000000"
         "00000000"_bytes;
     EXPECT_EQ(code.immediates.substr(br_table_imm_offset, expected_br_imm.size()), expected_br_imm);
+    EXPECT_EQ(code.max_stack_height, 1);
 }
 
 TEST(parser_expr, instr_br_table_as_return)
@@ -208,10 +212,9 @@ TEST(parser_expr, instr_br_table_as_return)
     */
 
     const auto code_bin = "41000e00000b"_bytes;
-
-    const auto [code, pos] = parse_expr(code_bin);
-
+    const auto [code, _] = parse_expr(code_bin);
     EXPECT_EQ(code.instructions, (std::vector{Instr::i32_const, Instr::br_table, Instr::end}));
+    EXPECT_EQ(code.max_stack_height, 1);
 }
 
 TEST(parser_expr, instr_br_table_missing_arg)
@@ -336,6 +339,8 @@ TEST(parser_expr, call_0args_1result)
 
     const auto module = parse(wasm);
     ASSERT_EQ(module.codesec.size(), 2);
+    EXPECT_EQ(module.codesec[0].max_stack_height, 1);
+    EXPECT_EQ(module.codesec[1].max_stack_height, 1);
 }
 
 TEST(parser_expr, call_1arg_1result)
@@ -349,8 +354,9 @@ TEST(parser_expr, call_1arg_1result)
 
     const auto module = parse(wasm);
     ASSERT_EQ(module.codesec.size(), 2);
+    EXPECT_EQ(module.codesec[0].max_stack_height, 1);
+    EXPECT_EQ(module.codesec[1].max_stack_height, 1);
 }
-
 TEST(parser_expr, call_nonexisting_typeidx)
 {
     // This creates a wasm module where code[0] has a call instruction calling function[1] which

--- a/test/unittests/stack_test.cpp
+++ b/test/unittests/stack_test.cpp
@@ -3,9 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "stack.hpp"
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 using namespace fizzy;
+using namespace testing;
 
 TEST(stack, push_and_pop)
 {
@@ -144,4 +145,120 @@ TEST(stack, clear_on_empty)
 {
     Stack<char> stack;
     stack.clear();
+}
+
+TEST(operand_stack, construct)
+{
+    OperandStack stack(0);
+    EXPECT_EQ(stack.size(), 0);
+    stack.shrink(0);
+    EXPECT_EQ(stack.size(), 0);
+}
+
+TEST(operand_stack, top)
+{
+    OperandStack stack(1);
+    EXPECT_EQ(stack.size(), 0);
+
+    stack.push(1);
+    EXPECT_EQ(stack.size(), 1);
+    EXPECT_EQ(stack.top(), 1);
+    EXPECT_EQ(stack[0], 1);
+
+    stack.top() = 101;
+    EXPECT_EQ(stack.size(), 1);
+    EXPECT_EQ(stack.top(), 101);
+    EXPECT_EQ(stack[0], 101);
+
+    stack.shrink(0);
+    EXPECT_EQ(stack.size(), 0);
+
+    stack.push(2);
+    EXPECT_EQ(stack.size(), 1);
+    EXPECT_EQ(stack.top(), 2);
+    EXPECT_EQ(stack[0], 2);
+}
+
+TEST(operand_stack, small)
+{
+    OperandStack stack(3);
+    EXPECT_EQ(stack.size(), 0);
+
+    stack.push(1);
+    stack.push(2);
+    stack.push(3);
+    EXPECT_EQ(stack.size(), 3);
+    EXPECT_EQ(stack.top(), 3);
+    EXPECT_EQ(stack[0], 3);
+    EXPECT_EQ(stack[1], 2);
+    EXPECT_EQ(stack[2], 1);
+
+    stack[0] = 13;
+    stack[1] = 12;
+    stack[2] = 11;
+    EXPECT_EQ(stack.size(), 3);
+    EXPECT_EQ(stack.top(), 13);
+    EXPECT_EQ(stack[0], 13);
+    EXPECT_EQ(stack[1], 12);
+    EXPECT_EQ(stack[2], 11);
+
+    EXPECT_EQ(stack.pop(), 13);
+    EXPECT_EQ(stack.size(), 2);
+    EXPECT_EQ(stack.top(), 12);
+}
+
+TEST(operand_stack, large)
+{
+    constexpr auto max_height = 33;
+    OperandStack stack(max_height);
+
+    for (unsigned i = 0; i < max_height; ++i)
+        stack.push(i);
+
+    EXPECT_EQ(stack.size(), max_height);
+    for (int expected = max_height - 1; expected >= 0; --expected)
+        EXPECT_EQ(stack.pop(), expected);
+    EXPECT_EQ(stack.size(), 0);
+}
+
+TEST(operand_stack, shrink)
+{
+    constexpr auto max_height = 60;
+    OperandStack stack(max_height);
+
+    for (unsigned i = 0; i < max_height; ++i)
+        stack.push(i);
+
+    EXPECT_EQ(stack.size(), max_height);
+    constexpr auto new_height = max_height / 3;
+    stack.shrink(new_height);
+    EXPECT_EQ(stack.size(), new_height);
+    EXPECT_EQ(stack.top(), new_height - 1);
+    EXPECT_EQ(stack[0], new_height - 1);
+    EXPECT_EQ(stack[new_height - 1], 0);
+}
+
+TEST(operand_stack, rbegin_rend)
+{
+    OperandStack stack(3);
+    EXPECT_EQ(stack.rbegin(), stack.rend());
+
+    stack.push(1);
+    stack.push(2);
+    stack.push(3);
+    EXPECT_LT(stack.rbegin(), stack.rend());
+    EXPECT_EQ(*stack.rbegin(), 1);
+    EXPECT_EQ(*(stack.rend() - 1), 3);
+}
+
+TEST(operand_stack, to_vector)
+{
+    OperandStack stack(3);
+    EXPECT_THAT(std::vector(stack.rbegin(), stack.rend()), IsEmpty());
+
+    stack.push(1);
+    stack.push(2);
+    stack.push(3);
+
+    EXPECT_THAT(std::vector(stack.rbegin(), stack.rend()), ElementsAre(1, 2, 3));
 }

--- a/test/unittests/validation_stack_test.cpp
+++ b/test/unittests/validation_stack_test.cpp
@@ -59,8 +59,8 @@ TEST(validation_stack, block_with_result)
     )
     */
     const auto wasm = from_hex("0061736d01000000010401600000030201000a0a010800027f417f0b1a0b");
-    parse(wasm);
-    // TODO: Add max stack height check.
+    const auto module = parse(wasm);
+    EXPECT_EQ(module.codesec[0].max_stack_height, 1);
 }
 
 TEST(validation_stack, block_missing_result)
@@ -116,8 +116,8 @@ TEST(validation_stack, loop_with_result)
     )
     */
     const auto wasm = from_hex("0061736d01000000010401600000030201000a0a010800037f417f0b1a0b");
-    parse(wasm);
-    // TODO: Add max stack height check.
+    const auto module = parse(wasm);
+    EXPECT_EQ(module.codesec[0].max_stack_height, 1);
 }
 
 TEST(validation_stack, loop_missing_result)
@@ -382,8 +382,8 @@ TEST(validation_stack, unreachable)
     )
     */
     const auto wasm = from_hex("0061736d010000000105016000017f030201000a0601040000450b");
-    parse(wasm);
-    // TODO: Add max stack height check.
+    const auto module = parse(wasm);
+    EXPECT_THAT(module.codesec[0].max_stack_height, 0);
 }
 
 TEST(validation_stack, unreachable_2)
@@ -398,8 +398,8 @@ TEST(validation_stack, unreachable_2)
     )
     */
     const auto wasm = from_hex("0061736d01000000010401600000030201000a09010700006a6a6a1a0b");
-    parse(wasm);
-    // TODO: Add max stack height check.
+    const auto module = parse(wasm);
+    EXPECT_THAT(module.codesec[0].max_stack_height, 0);
 }
 
 TEST(validation_stack, unreachable_call)
@@ -451,8 +451,8 @@ TEST(validation_stack, br)
     )
     */
     const auto wasm = from_hex("0061736d01000000010401600000030201000a0b01090002400c00451a0b0b");
-    parse(wasm);
-    // TODO: Add max stack height check.
+    const auto module = parse(wasm);
+    EXPECT_THAT(module.codesec[0].max_stack_height, 0);
 }
 
 TEST(validation_stack, br_table)
@@ -472,8 +472,8 @@ TEST(validation_stack, br_table)
     */
     const auto wasm = from_hex(
         "0061736d0100000001050160017f00030201000a14011200024041e90720000e0100016c6c6c1a0b0b");
-    parse(wasm);
-    // TODO: Add max stack height check.
+    const auto module = parse(wasm);
+    EXPECT_THAT(module.codesec[0].max_stack_height, 2);
 }
 
 TEST(validation_stack, return_)
@@ -486,8 +486,8 @@ TEST(validation_stack, return_)
     )
     */
     const auto wasm = from_hex("0061736d01000000010401600000030201000a070105000f451a0b");
-    parse(wasm);
-    // TODO: Add max stack height check.
+    const auto module = parse(wasm);
+    EXPECT_THAT(module.codesec[0].max_stack_height, 0);
 }
 
 TEST(validation_stack, if_stack_underflow)
@@ -698,7 +698,7 @@ TEST(validation_stack, if_else_stack_height)
     const auto wasm =
         from_hex("0061736d01000000010401600000030201000a1201100042014102047e42010542030b1a1a0b");
     const auto module = parse(wasm);
-    // TODO: Add max stack height check.
+    EXPECT_EQ(module.codesec[0].max_stack_height, 2);
 }
 
 TEST(validation_stack, if_invalid_end_stack_height)
@@ -724,8 +724,8 @@ TEST(validation_stack, if_invalid_end_stack_height)
     */
     const auto wasm = from_hex(
         "0061736d01000000010401600000030201000a1701150042014102047e4201420205420342041a0b1a1a0b");
-    parse(wasm);
-    // TODO: Add max stack height check.
+    const auto module = parse(wasm);
+    EXPECT_EQ(module.codesec[0].max_stack_height, 3);
 }
 
 TEST(validation_stack, if_with_unreachable)


### PR DESCRIPTION
Execution comparison
```
Comparing master-exec to opt-exec                                                                                                                                       
Benchmark                                                            Time             CPU      Time Old      Time New       CPU Old       CPU New                       
-------------------------------------------------------------------------------------------------------------------------------------------------
fizzy/execute/blake2b/512_bytes_rounds_1_mean                     -0.1219         -0.1218            98            86            98            86
fizzy/execute/blake2b/512_bytes_rounds_16_mean                    -0.1459         -0.1459          1472          1257          1472          1257
fizzy/execute/ecpairing/onepoint_mean                             -0.2044         -0.2044        606879        482851        606880        482854
fizzy/execute/keccak256/512_bytes_rounds_1_mean                   -0.0619         -0.0619           104            97           104            97
fizzy/execute/keccak256/512_bytes_rounds_16_mean                  -0.0729         -0.0729          1495          1386          1495          1386
fizzy/execute/memset/256_bytes_mean                               -0.1190         -0.1189             9             8             9             8
fizzy/execute/memset/60000_bytes_mean                             -0.1218         -0.1218          1809          1589          1809          1589
fizzy/execute/mul256_opt0/input0_mean                             -0.0909         -0.0909            30            27            30            27
fizzy/execute/mul256_opt0/input1_mean                             -0.0909         -0.0909            30            27            30            27
fizzy/execute/sha1/512_bytes_rounds_1_mean                        -0.1538         -0.1538           105            89           105            89
fizzy/execute/sha1/512_bytes_rounds_16_mean                       -0.1598         -0.1598          1456          1224          1456          1224
fizzy/execute/sha256/512_bytes_rounds_1_mean                      -0.1101         -0.1101            96            85            96            85
fizzy/execute/sha256/512_bytes_rounds_16_mean                     -0.1178         -0.1178          1301          1148          1301          1148
fizzy/execute/micro/factorial/10_mean                             -0.0329         -0.0321             2             2             2             2
fizzy/execute/micro/factorial/20_mean                             -0.0284         -0.0276             3             3             3             3
fizzy/execute/micro/fibonacci/24_mean                             -0.0893         -0.0893         16020         14588         16020         14589
fizzy/execute/micro/host_adler32/1_mean                           -0.0360         -0.0359             1             1             1             1
fizzy/execute/micro/host_adler32/100_mean                         -0.0509         -0.0504             7             7             7             7
fizzy/execute/micro/host_adler32/1000_mean                        -0.0462         -0.0462            68            65            68            65
fizzy/execute/micro/spinner/1_mean                                -0.0280         -0.0296             1             0             1             0
fizzy/execute/micro/spinner/1000_mean                             -0.1301         -0.1302            13            11            13            11
```

Parsing comparison

```
Comparing master-parse to opt-parse                                                                                                                                     
Benchmark                                               Time             CPU      Time Old      Time New       CPU Old       CPU New                                    
------------------------------------------------------------------------------------------------------------------------------------
fizzy/parse/blake2b_mean                             +0.0439         +0.0439            12            13            12            13
fizzy/parse/ecpairing_mean                           +0.0320         +0.0320           678           699           678           699
fizzy/parse/keccak256_mean                           +0.0297         +0.0297            20            21            20            21
fizzy/parse/memset_mean                              +0.0112         +0.0112             3             3             3             3
fizzy/parse/mul256_opt0_mean                         +0.0276         +0.0276             4             4             4             4
fizzy/parse/sha1_mean                                +0.0240         +0.0240            19            20            19            20
fizzy/parse/sha256_mean                              +0.0090         +0.0090            33            34            33            34
fizzy/parse/micro/factorial_mean                     +0.0057         +0.0057             1             1             1             1
fizzy/parse/micro/fibonacci_mean                     +0.0065         +0.0065             1             1             1             1
fizzy/parse/micro/host_adler32_mean                  -0.0044         -0.0044             1             1             1             1
fizzy/parse/micro/spinner_mean                       -0.0209         -0.0209             1             1             1             1
```
