### PR TITLE
parser: Control stack refactor

### DIFF
--- a/lib/fizzy/parser_expr.cpp
+++ b/lib/fizzy/parser_expr.cpp
@@ -71,6 +71,8 @@ parser_result<Code> parse_expr(const uint8_t* pos, const uint8_t* end, bool have
         if (pos == end)
             throw parser_error{"Unexpected EOF"};
 
+        const auto& frame = control_stack.top();
+
         const auto instr = static_cast<Instr>(*pos++);
         switch (instr)
         {
@@ -230,7 +232,6 @@ parser_result<Code> parse_expr(const uint8_t* pos, const uint8_t* end, bool have
         {
             if (control_stack.size() > 1)
             {
-                const auto& frame = control_stack.top();
                 if (frame.instruction != Instr::loop)  // If end of block/if/else instruction.
                 {
                     const auto target_pc = static_cast<uint32_t>(code.instructions.size() + 1);
@@ -291,7 +292,6 @@ parser_result<Code> parse_expr(const uint8_t* pos, const uint8_t* end, bool have
 
         case Instr::else_:
         {
-            const auto& frame = control_stack.top();
             if (frame.instruction != Instr::if_)
                 throw parser_error{"unexpected else instruction (if instruction missing)"};
             const auto target_pc = static_cast<uint32_t>(code.instructions.size() + 1);

--- a/test/unittests/parser_expr_test.cpp
+++ b/test/unittests/parser_expr_test.cpp
@@ -189,7 +189,8 @@ TEST(parser, unexpected_else)
 {
     // (else)
     const auto code1_bin = "050b0b"_bytes;
-    EXPECT_THROW_MESSAGE(parse_expr(code1_bin), parser_error, "unexpected else instruction");
+    EXPECT_THROW_MESSAGE(parse_expr(code1_bin), parser_error,
+        "unexpected else instruction (if instruction missing)");
 
     // (block (else))
     const auto code2_bin = "0240050b0b0b"_bytes;


### PR DESCRIPTION
Cleanups and refactoring to control stack as preliminary work for #244.

1. Use `std::stack` instead of `Stack` to help with #247 where `Stack` is replaced and is not generic any more.
2. Renames to match Wasm Validation Algorithm https://webassembly.github.io/spec/core/appendix/algorithm.html.
3. Add the implicit function's block to control stack. This guarantees that there is always a control frame.