### PR TITLE
Add call depth parameter to ExternalFunction

### DIFF
--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -22,7 +22,7 @@ struct Instance;
 
 struct ExternalFunction
 {
-    std::function<execution_result(Instance&, std::vector<uint64_t>)> function;
+    std::function<execution_result(Instance&, std::vector<uint64_t>, int depth)> function;
     FuncType type;
 };
 

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -58,7 +58,7 @@ TEST(api, find_exported_function)
 
     auto opt_function = find_exported_function(*instance, "foo");
     ASSERT_TRUE(opt_function);
-    EXPECT_RESULT(opt_function->function(*instance, {}), 42);
+    EXPECT_RESULT(opt_function->function(*instance, {}, 0), 42);
     EXPECT_TRUE(opt_function->type.inputs.empty());
     ASSERT_EQ(opt_function->type.outputs.size(), 1);
     EXPECT_EQ(opt_function->type.outputs[0], ValType::i32);
@@ -77,7 +77,7 @@ TEST(api, find_exported_function)
         "0061736d010000000105016000017f021001087370656374657374036261720000040401700000050401010102"
         "0606017f0041000b07170403666f6f000001670300037461620100036d656d0200");
 
-    auto bar = [](Instance&, std::vector<uint64_t>) { return execution_result{false, {42}}; };
+    auto bar = [](Instance&, std::vector<uint64_t>, int) { return execution_result{false, {42}}; };
     const auto bar_type = FuncType{{}, {ValType::i32}};
 
     auto instance_reexported_function =
@@ -85,7 +85,7 @@ TEST(api, find_exported_function)
 
     opt_function = find_exported_function(*instance_reexported_function, "foo");
     ASSERT_TRUE(opt_function);
-    EXPECT_RESULT(opt_function->function(*instance, {}), 42);
+    EXPECT_THAT(opt_function->function(*instance, {}, 0), Result(42));
     EXPECT_TRUE(opt_function->type.inputs.empty());
     ASSERT_EQ(opt_function->type.outputs.size(), 1);
     EXPECT_EQ(opt_function->type.outputs[0], ValType::i32);

--- a/test/unittests/execute_call_test.cpp
+++ b/test/unittests/execute_call_test.cpp
@@ -373,7 +373,7 @@ TEST(execute_call, call_indirect_infinite_recursion)
     EXPECT_TRUE(execute(module, 0, {}).trapped);
 }
 
-TEST(execute, call_max_depth)
+TEST(execute_call, call_max_depth)
 {
     /* wat2wasm
     (func (result i32) (i32.const 42))
@@ -390,7 +390,7 @@ TEST(execute, call_max_depth)
 }
 
 // A regression test for incorrect number of arguments passed to a call.
-TEST(execute, call_nonempty_stack)
+TEST(execute_call, call_nonempty_stack)
 {
     /* wat2wasm
     (func (param i32) (result i32)
@@ -412,7 +412,7 @@ TEST(execute, call_nonempty_stack)
     EXPECT_RESULT(execute(*instance, 1, {}), 3);
 }
 
-TEST(execute, call_imported_infinite_recursion)
+TEST(execute_call, call_imported_infinite_recursion)
 {
     /* wat2wasm
     (import "mod" "foo" (func (result i32)))

--- a/test/unittests/execute_call_test.cpp
+++ b/test/unittests/execute_call_test.cpp
@@ -214,7 +214,7 @@ TEST(execute_call, imported_function_call)
 
     const auto module = parse(wasm);
 
-    constexpr auto host_foo = [](Instance&, std::vector<uint64_t>) -> execution_result {
+    constexpr auto host_foo = [](Instance&, std::vector<uint64_t>, int) -> execution_result {
         return {false, {42}};
     };
     const auto host_foo_type = module.typesec[0];
@@ -241,7 +241,7 @@ TEST(execute_call, imported_function_call_with_arguments)
 
     const auto module = parse(wasm);
 
-    auto host_foo = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    auto host_foo = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args[0] * 2}};
     };
     const auto host_foo_type = module.typesec[0];
@@ -285,10 +285,10 @@ TEST(execute_call, imported_functions_call_indirect)
     ASSERT_EQ(module.importsec.size(), 2);
     ASSERT_EQ(module.codesec.size(), 2);
 
-    constexpr auto sqr = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto sqr = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args[0] * args[0]}};
     };
-    constexpr auto isqrt = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto isqrt = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {(11 + args[0] / 11) / 2}};
     };
 
@@ -333,7 +333,8 @@ TEST(execute_call, imported_function_from_another_module)
     const auto func_idx = fizzy::find_exported_function(module1, "sub");
     ASSERT_TRUE(func_idx.has_value());
 
-    auto sub = [&instance1, func_idx](Instance&, std::vector<uint64_t> args) -> execution_result {
+    auto sub = [&instance1, func_idx](
+                   Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return fizzy::execute(*instance1, *func_idx, std::move(args));
     };
 
@@ -423,8 +424,8 @@ TEST(execute, call_imported_infinite_recursion)
         "0061736d010000000105016000017f020b01036d6f6403666f6f0000030201000a0601040010000b");
 
     const auto module = parse(wasm);
-    auto host_foo = [](Instance& instance, std::vector<uint64_t>) -> execution_result {
-        return execute(instance, 0, {});
+    auto host_foo = [](Instance& instance, std::vector<uint64_t>, int depth) -> execution_result {
+        return execute(instance, 0, {}, depth + 1);
     };
     const auto host_foo_type = module.typesec[0];
 

--- a/test/unittests/execute_control_test.cpp
+++ b/test/unittests/execute_control_test.cpp
@@ -658,8 +658,8 @@ TEST(execute_control, br_1_out_of_function_and_imported_function)
         "0061736d010000000108026000006000017f02150108696d706f727465640866756e6374696f6e000003020101"
         "0a0d010b00034041010c010b41000b");
 
-    constexpr auto fake_imported_function =
-        [](Instance&, std::vector<uint64_t>) noexcept -> execution_result { return {}; };
+    constexpr auto fake_imported_function = [](Instance&, std::vector<uint64_t>,
+                                                int) noexcept -> execution_result { return {}; };
 
     const auto module = parse(bin);
     auto instance = instantiate(module, {{fake_imported_function, module.typesec[0]}});

--- a/test/unittests/execute_test.cpp
+++ b/test/unittests/execute_test.cpp
@@ -602,7 +602,7 @@ TEST(execute, imported_function)
     const auto module = parse(wasm);
     ASSERT_EQ(module.typesec.size(), 1);
 
-    constexpr auto host_foo = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto host_foo = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args[0] + args[1]}};
     };
 
@@ -622,10 +622,10 @@ TEST(execute, imported_two_functions)
     const auto module = parse(wasm);
     ASSERT_EQ(module.typesec.size(), 1);
 
-    constexpr auto host_foo1 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto host_foo1 = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args[0] + args[1]}};
     };
-    constexpr auto host_foo2 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto host_foo2 = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args[0] * args[1]}};
     };
 
@@ -649,10 +649,10 @@ TEST(execute, imported_functions_and_regular_one)
         "0061736d0100000001070160027f7f017f021702036d6f6404666f6f310000036d6f6404666f6f320000030201"
         "000a0901070041aa80a8010b");
 
-    constexpr auto host_foo1 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto host_foo1 = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args[0] + args[1]}};
     };
-    constexpr auto host_foo2 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto host_foo2 = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args[0] * args[0]}};
     };
 
@@ -664,7 +664,7 @@ TEST(execute, imported_functions_and_regular_one)
     EXPECT_THAT(execute(*instance, 1, {20}), Result(400));
 
     // check correct number of arguments is passed to host
-    constexpr auto count_args = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto count_args = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args.size()}};
     };
 
@@ -689,10 +689,10 @@ TEST(execute, imported_two_functions_different_type)
         "0061736d01000000010c0260027f7f017f60017e017e021702036d6f6404666f6f310000036d6f6404666f6f32"
         "0001030201010a0901070042aa80a8010b");
 
-    constexpr auto host_foo1 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto host_foo1 = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args[0] + args[1]}};
     };
-    constexpr auto host_foo2 = [](Instance&, std::vector<uint64_t> args) -> execution_result {
+    constexpr auto host_foo2 = [](Instance&, std::vector<uint64_t> args, int) -> execution_result {
         return {false, {args[0] * args[0]}};
     };
 
@@ -713,7 +713,7 @@ TEST(execute, imported_function_traps)
     */
     const auto wasm = from_hex("0061736d0100000001070160027f7f017f020b01036d6f6403666f6f0000");
 
-    constexpr auto host_foo = [](Instance&, std::vector<uint64_t>) -> execution_result {
+    constexpr auto host_foo = [](Instance&, std::vector<uint64_t>, int) -> execution_result {
         return {true, {}};
     };
 

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -16,7 +16,9 @@ TEST(instantiate, imported_functions)
     const auto bin = from_hex("0061736d0100000001060160017f017f020b01036d6f6403666f6f0000");
     const auto module = parse(bin);
 
-    auto host_foo = [](Instance&, std::vector<uint64_t>) -> execution_result { return {true, {}}; };
+    auto host_foo = [](Instance&, std::vector<uint64_t>, int) -> execution_result {
+        return {true, {}};
+    };
     auto instance = instantiate(module, {{host_foo, module.typesec[0]}});
 
     ASSERT_EQ(instance->imported_functions.size(), 1);
@@ -37,10 +39,10 @@ TEST(instantiate, imported_functions_multiple)
         "0061736d0100000001090260017f017f600000021702036d6f6404666f6f310000036d6f6404666f6f320001");
     const auto module = parse(bin);
 
-    auto host_foo1 = [](Instance&, std::vector<uint64_t>) -> execution_result {
+    auto host_foo1 = [](Instance&, std::vector<uint64_t>, int) -> execution_result {
         return {true, {0}};
     };
-    auto host_foo2 = [](Instance&, std::vector<uint64_t>) -> execution_result {
+    auto host_foo2 = [](Instance&, std::vector<uint64_t>, int) -> execution_result {
         return {true, {}};
     };
     auto instance =
@@ -77,7 +79,9 @@ TEST(instantiate, imported_function_wrong_type)
     const auto bin = from_hex("0061736d0100000001060160017f017f020b01036d6f6403666f6f0000");
     const auto module = parse(bin);
 
-    auto host_foo = [](Instance&, std::vector<uint64_t>) -> execution_result { return {true, {}}; };
+    auto host_foo = [](Instance&, std::vector<uint64_t>, int) -> execution_result {
+        return {true, {}};
+    };
     const auto host_foo_type = FuncType{{}, {}};
 
     EXPECT_THROW_MESSAGE(instantiate(module, {{host_foo, host_foo_type}}), instantiate_error,


### PR DESCRIPTION
This is required for `call_indirect` in #246 to check the call depth limit.
But also allows calls to functions imported from another module to start not from 0 depth, but from current value.