### PR TITLE
Small stack optimization

### DIFF
--- a/test/unittests/execute_test.cpp
+++ b/test/unittests/execute_test.cpp
@@ -1008,3 +1008,49 @@ TEST(execute, reuse_args)
 
     EXPECT_THAT(execute(parse(wasm), 1, {}), Result(23 % (23 / 5)));
 }
+
+TEST(execute, stack_abuse)
+{
+    /* wat2wasm
+    (func (param i32) (result i32)
+      local.get 0
+      i32.const 1
+      i32.const 2
+      i32.const 3
+      i32.const 4
+      i32.const 5
+      i32.const 6
+      i32.const 7
+      i32.const 8
+      i32.const 9
+      i32.const 10
+      i32.const 11
+      i32.const 12
+      i32.const 13
+      i32.const 14
+      i32.const 15
+      i32.const 16
+      i32.add
+      i32.add
+      i32.add
+      i32.add
+      i32.add
+      i32.add
+      i32.add
+      i32.add
+      i32.add
+      i32.add
+      i32.add
+      i32.add
+      i32.add
+      i32.add
+      i32.add
+      i32.add
+    )
+    */
+    const auto wasm = from_hex(
+        "0061736d0100000001060160017f017f030201000a360134002000410141024103410441054106410741084109"
+        "410a410b410c410d410e410f41106a6a6a6a6a6a6a6a6a6a6a6a6a6a6a6a0b");
+
+    EXPECT_THAT(execute(parse(wasm), 0, {1000}), Result(1136));
+}


### PR DESCRIPTION
Requires #247 

This implements "small vector" / "small string" optimization to `OperandStack`. When the max stack height is smaller than static limit we omit dynamic allocation and use static storage within `OperandStack`.

The max stack height is usually very small. E.g. for LLVM generated code it is usually 3 except calls (as they naturally requires the stack to have all call args).

```
fizzy/execute/blake2b/rounds_1_mean                      -0.1445         -0.1445        265267        226946        265240        226922
fizzy/execute/blake2b/rounds_16_mean                     -0.1447         -0.1447       3975578       3400162       3975531       3400087
fizzy/execute/ecpairing/multipoint_mean                  -0.1318         -0.1318    2871590597    2493111309    2871538432    2493063825
fizzy/execute/memset/256_bytes_mean                      -0.1257         -0.1258         24064         21039         24029         21006
fizzy/execute/memset/60000_bytes_mean                    -0.1379         -0.1379       5059587       4361997       5059539       4361958
fizzy/execute/mul256_opt0/input0_mean                    -0.0618         -0.0619         75348         70693         75314         70656
fizzy/execute/mul256_opt0/input1_mean                    -0.0676         -0.0672         75570         70461         75502         70425
fizzy/execute/sha1/rounds_1_mean                         -0.1733         -0.1733        276025        228194        275996        228169
fizzy/execute/sha1/rounds_16_mean                        -0.1726         -0.1726       3808532       3151106       3808477       3151040
fizzy/execute/micro/factorial/10_mean                    -0.1620         -0.1644          2887          2420          2893          2418
fizzy/execute/micro/factorial/20_mean                    -0.1897         -0.1921          4858          3936          4873          3937
fizzy/execute/micro/fibonacci/24_mean                    -0.1509         -0.1509      34522229      29313074      34521804      29312302
fizzy/execute/micro/spinner/1_mean                       -0.0545         -0.0571           882           834           881           830
fizzy/execute/micro/spinner/1000_mean                    -0.0711         -0.0712         39449         36644         39455         36646
```