### PR TITLE
refactor: move the loop splitting imports from instantiate to parser

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -248,8 +248,8 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 4732
-          expected_failed: 700
+          expected_passed: 4734
+          expected_failed: 698
           expected_skipped: 6381
 
   benchmark:
@@ -344,8 +344,8 @@ jobs:
           expected_failed: 21
           expected_skipped: 7323
       - spectest:
-          expected_passed: 4732
-          expected_failed: 700
+          expected_passed: 4734
+          expected_failed: 698
           expected_skipped: 6381
 
 workflows:

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -157,43 +157,6 @@ void match_imported_globals(const std::vector<bool>& module_imports_mutability,
     }
 }
 
-void match_imports(const Module& module, const std::vector<ExternalFunction>& imported_functions,
-    const std::vector<ExternalTable>& imported_tables,
-    const std::vector<ExternalMemory>& imported_memories,
-    const std::vector<ExternalGlobal>& imported_globals)
-{
-    std::vector<FuncType> imported_function_types;
-    std::vector<Table> imported_table_types;
-    std::vector<Memory> imported_memory_types;
-    std::vector<bool> imported_globals_mutability;
-    for (auto const& import : module.importsec)
-    {
-        switch (import.kind)
-        {
-        case ExternalKind::Function:
-            assert(import.desc.function_type_index < module.typesec.size());
-            imported_function_types.emplace_back(module.typesec[import.desc.function_type_index]);
-            break;
-        case ExternalKind::Table:
-            imported_table_types.emplace_back(import.desc.table);
-            break;
-        case ExternalKind::Memory:
-            imported_memory_types.emplace_back(import.desc.memory);
-            break;
-        case ExternalKind::Global:
-            imported_globals_mutability.emplace_back(import.desc.global_mutable);
-            break;
-        default:
-            assert(false);
-        }
-    }
-
-    match_imported_functions(imported_function_types, imported_functions);
-    match_imported_tables(imported_table_types, imported_tables);
-    match_imported_memories(imported_memory_types, imported_memories);
-    match_imported_globals(imported_globals_mutability, imported_globals);
-}
-
 table_ptr allocate_table(
     const std::vector<Table>& module_tables, const std::vector<ExternalTable>& imported_tables)
 {
@@ -535,7 +498,10 @@ std::unique_ptr<Instance> instantiate(Module module,
 {
     assert(module.funcsec.size() == module.codesec.size());
 
-    match_imports(module, imported_functions, imported_tables, imported_memories, imported_globals);
+    match_imported_functions(module.imported_function_types, imported_functions);
+    match_imported_tables(module.imported_table_types, imported_tables);
+    match_imported_memories(module.imported_memory_types, imported_memories);
+    match_imported_globals(module.imported_globals_mutability, imported_globals);
 
     // Init globals
     std::vector<uint64_t> globals;

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -489,6 +489,8 @@ Module parse(bytes_view input)
         switch (import.kind)
         {
         case ExternalKind::Function:
+            if (import.desc.function_type_index >= module.typesec.size())
+                throw validation_error{"invalid type index of an imported function"};
             module.imported_function_types.emplace_back(
                 module.typesec[import.desc.function_type_index]);
             break;

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -3,6 +3,7 @@
 #include "types.hpp"
 #include "utf8.hpp"
 #include <algorithm>
+#include <cassert>
 
 namespace fizzy
 {
@@ -482,6 +483,30 @@ Module parse(bytes_view input)
     }
 
     // Validation checks
+
+    // Split imports by kind
+    for (const auto& import : module.importsec)
+    {
+        switch (import.kind)
+        {
+        case ExternalKind::Function:
+            module.imported_function_types.emplace_back(
+                module.typesec[import.desc.function_type_index]);
+            break;
+        case ExternalKind::Table:
+            module.imported_table_types.emplace_back(import.desc.table);
+            break;
+        case ExternalKind::Memory:
+            module.imported_memory_types.emplace_back(import.desc.memory);
+            break;
+        case ExternalKind::Global:
+            module.imported_globals_mutability.emplace_back(import.desc.global_mutable);
+            break;
+        default:
+            assert(false);
+        }
+    }
+
     if (module.tablesec.size() > 1)
         throw validation_error{"too many table sections (at most one is allowed)"};
 

--- a/lib/fizzy/types.hpp
+++ b/lib/fizzy/types.hpp
@@ -395,6 +395,15 @@ struct Module
     std::vector<Code> codesec;
     // https://webassembly.github.io/spec/core/binary/modules.html#data-section
     std::vector<Data> datasec;
+
+    // Types of functions defined in import section
+    std::vector<FuncType> imported_function_types;
+    // Types of tables defined in import section
+    std::vector<Table> imported_table_types;
+    // Types of memories defined in import section
+    std::vector<Memory> imported_memory_types;
+    // Mutability of globals defined in import section
+    std::vector<bool> imported_globals_mutability;
 };
 
 }  // namespace fizzy

--- a/test/unittests/validation_test.cpp
+++ b/test/unittests/validation_test.cpp
@@ -9,6 +9,17 @@
 using namespace fizzy;
 using namespace fizzy::test;
 
+TEST(validation, imported_function_unknown_type)
+{
+    /* wat2wasm --no-check
+    (type (func (result i32)))
+    (func (import "m" "f") (type 1))
+    */
+    const auto wasm = from_hex("0061736d010000000105016000017f020701016d01660001");
+    EXPECT_THROW_MESSAGE(
+        parse(wasm), validation_error, "invalid type index of an imported function");
+}
+
 TEST(validation, import_memories_multiple)
 {
     const auto section_contents =


### PR DESCRIPTION
Also add validation of imported function type index.

Required for #267