### PR TITLE
validation: table and memory number

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -248,8 +248,8 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 4724
-          expected_failed: 708
+          expected_passed: 4732
+          expected_failed: 700
           expected_skipped: 6381
 
   benchmark:
@@ -344,8 +344,8 @@ jobs:
           expected_failed: 21
           expected_skipped: 7323
       - spectest:
-          expected_passed: 4724
-          expected_failed: 708
+          expected_passed: 4732
+          expected_failed: 700
           expected_skipped: 6381
 
 workflows:

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -200,13 +200,9 @@ table_ptr allocate_table(
     static const auto table_delete = [](table_elements* t) noexcept { delete t; };
     static const auto null_delete = [](table_elements*) noexcept {};
 
-    if (module_tables.size() + imported_tables.size() > 1)
-    {
-        // FIXME: turn this into an assert if instantiate is not exposed externally and it only
-        // takes validated modules
-        throw instantiate_error("Cannot support more than 1 table section.");
-    }
-    else if (module_tables.size() == 1)
+    assert(module_tables.size() + imported_tables.size() <= 1);
+
+    if (module_tables.size() == 1)
         return {new table_elements(module_tables[0].limits.min), table_delete};
     else if (imported_tables.size() == 1)
         return {imported_tables[0].table, null_delete};
@@ -220,13 +216,9 @@ std::tuple<bytes_ptr, size_t> allocate_memory(const std::vector<Memory>& module_
     static const auto bytes_delete = [](bytes* b) noexcept { delete b; };
     static const auto null_delete = [](bytes*) noexcept {};
 
-    if (module_memories.size() + imported_memories.size() > 1)
-    {
-        // FIXME: turn this into an assert if instantiate is not exposed externally and it only
-        // takes validated modules
-        throw instantiate_error("Cannot support more than 1 memory section.");
-    }
-    else if (module_memories.size() == 1)
+    assert(module_memories.size() + imported_memories.size() <= 1);
+
+    if (module_memories.size() == 1)
     {
         const size_t memory_min = module_memories[0].limits.min;
         const size_t memory_max =

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -483,20 +483,20 @@ Module parse(bytes_view input)
 
     // Validation checks
     if (module.tablesec.size() > 1)
-        throw parser_error{"too many table sections (at most one is allowed)"};
+        throw validation_error{"too many table sections (at most one is allowed)"};
 
     if (module.memorysec.size() > 1)
-        throw parser_error{"too many memory sections (at most one is allowed)"};
+        throw validation_error{"too many memory sections (at most one is allowed)"};
 
     const auto imported_mem_count = std::count_if(module.importsec.begin(), module.importsec.end(),
         [](const auto& import) noexcept { return import.kind == ExternalKind::Memory; });
 
     if (imported_mem_count > 1)
-        throw parser_error{"too many imported memories (at most one is allowed)"};
+        throw validation_error{"too many imported memories (at most one is allowed)"};
 
     if (!module.memorysec.empty() && imported_mem_count > 0)
     {
-        throw parser_error{
+        throw validation_error{
             "both module memory and imported memory are defined (at most one of them is allowed)"};
     }
 
@@ -504,11 +504,11 @@ Module parse(bytes_view input)
         [](const auto& import) noexcept { return import.kind == ExternalKind::Table; });
 
     if (imported_tbl_count > 1)
-        throw parser_error{"too many imported tables (at most one is allowed)"};
+        throw validation_error{"too many imported tables (at most one is allowed)"};
 
     if (!module.tablesec.empty() && imported_tbl_count > 0)
     {
-        throw parser_error{
+        throw validation_error{
             "both module table and imported table are defined (at most one of them is allowed)"};
     }
 

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -152,13 +152,6 @@ TEST(instantiate, imported_table_invalid)
     table_elements table_big(40, 0);
     EXPECT_THROW_MESSAGE(instantiate(module, {}, {{&table_big, {10, 30}}}), instantiate_error,
         "Provided imported table doesn't fit provided limits");
-
-    // Imported table and regular table
-    Module module_with_two_tables;
-    module_with_two_tables.tablesec.emplace_back(Table{{10, 10}});
-    module_with_two_tables.importsec.emplace_back(imp);
-    EXPECT_THROW_MESSAGE(instantiate(module_with_two_tables, {}, {{&table, {10, 30}}}),
-        instantiate_error, "Cannot support more than 1 table section.");
 }
 
 TEST(instantiate, imported_memory)
@@ -267,13 +260,6 @@ TEST(instantiate, imported_memory_invalid)
         instantiate(module_without_max, {}, {}, {{&memory, {1, MemoryPagesLimit + 1}}}),
         instantiate_error,
         "Imported memory limits cannot exceed hard memory limit of 268435456 bytes.");
-
-    // Imported memory and regular memory
-    Module module_with_two_memories;
-    module_with_two_memories.memorysec.emplace_back(Memory{{1, 1}});
-    module_with_two_memories.importsec.emplace_back(imp);
-    EXPECT_THROW_MESSAGE(instantiate(module_with_two_memories, {}, {}, {{&memory, {1, 3}}}),
-        instantiate_error, "Cannot support more than 1 memory section.");
 }
 
 TEST(instantiate, imported_globals)
@@ -395,16 +381,6 @@ TEST(instantiate, memory_single_large_maximum)
 
     EXPECT_THROW_MESSAGE(instantiate(module), instantiate_error,
         "Cannot exceed hard memory limit of 268435456 bytes.");
-}
-
-TEST(instantiate, memory_multiple)
-{
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.memorysec.emplace_back(Memory{{1, 1}});
-
-    EXPECT_THROW_MESSAGE(
-        instantiate(module), instantiate_error, "Cannot support more than 1 memory section.");
 }
 
 TEST(instantiate, element_section)

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -367,7 +367,7 @@ TEST(parser, import_memories_multiple)
     const auto bin = bytes{wasm_prefix} + make_section(2, section_contents);
 
     EXPECT_THROW_MESSAGE(
-        parse(bin), parser_error, "too many imported memories (at most one is allowed)");
+        parse(bin), validation_error, "too many imported memories (at most one is allowed)");
 }
 
 TEST(parser, import_invalid_kind)
@@ -406,7 +406,7 @@ TEST(parser, memory_and_imported_memory)
     const auto memory_section = "05030100010008046e616d65020100"_bytes;
     const auto bin = bytes{wasm_prefix} + import_section + memory_section;
 
-    EXPECT_THROW_MESSAGE(parse(bin), parser_error,
+    EXPECT_THROW_MESSAGE(parse(bin), validation_error,
         "both module memory and imported memory are defined (at most one of them is allowed)");
 }
 
@@ -418,7 +418,7 @@ TEST(parser, import_tables_multiple)
     const auto bin = bytes{wasm_prefix} + make_section(2, section_contents);
 
     EXPECT_THROW_MESSAGE(
-        parse(bin), parser_error, "too many imported tables (at most one is allowed)");
+        parse(bin), validation_error, "too many imported tables (at most one is allowed)");
 }
 
 TEST(parser, table_and_imported_table)
@@ -429,7 +429,7 @@ TEST(parser, table_and_imported_table)
     const auto table_section = "0404017000020008046e616d65020100"_bytes;
     const auto bin = bytes{wasm_prefix} + import_section + table_section;
 
-    EXPECT_THROW_MESSAGE(parse(bin), parser_error,
+    EXPECT_THROW_MESSAGE(parse(bin), validation_error,
         "both module table and imported table are defined (at most one of them is allowed)");
 }
 
@@ -558,7 +558,7 @@ TEST(parser, table_multi_min_limit)
     const auto bin = bytes{wasm_prefix} + make_section(4, section_contents);
 
     EXPECT_THROW_MESSAGE(
-        parse(bin), parser_error, "too many table sections (at most one is allowed)");
+        parse(bin), validation_error, "too many table sections (at most one is allowed)");
 }
 
 TEST(parser, table_invalid_elemtype)
@@ -617,7 +617,7 @@ TEST(parser, memory_multi_min_limit)
     const auto bin = bytes{wasm_prefix} + make_section(5, section_contents);
 
     EXPECT_THROW_MESSAGE(
-        parse(bin), parser_error, "too many memory sections (at most one is allowed)");
+        parse(bin), validation_error, "too many memory sections (at most one is allowed)");
 }
 
 TEST(parser, memory_limits_kind_out_of_bounds)

--- a/test/unittests/validation_test.cpp
+++ b/test/unittests/validation_test.cpp
@@ -4,8 +4,74 @@
 #include <gtest/gtest.h>
 #include <test/utils/asserts.hpp>
 #include <test/utils/hex.hpp>
+#include <test/utils/wasm_binary.hpp>
 
 using namespace fizzy;
+using namespace fizzy::test;
+
+TEST(validation, import_memories_multiple)
+{
+    const auto section_contents =
+        make_vec({bytes{0x02, 'm', '1', 0x03, 'a', 'b', 'c', 0x02, 0x00, 0x7f},
+            bytes{0x02, 'm', '2', 0x03, 'd', 'e', 'f', 0x02, 0x00, 0x7f}});
+    const auto bin = bytes{wasm_prefix} + make_section(2, section_contents);
+
+    EXPECT_THROW_MESSAGE(
+        parse(bin), validation_error, "too many imported memories (at most one is allowed)");
+}
+
+TEST(validation, memory_and_imported_memory)
+{
+    // (import "js" "mem"(memory 1))
+    const auto import_section = "020b01026a73036d656d0200010008046e616d65020100"_bytes;
+    // (memory 1)
+    const auto memory_section = "05030100010008046e616d65020100"_bytes;
+    const auto bin = bytes{wasm_prefix} + import_section + memory_section;
+
+    EXPECT_THROW_MESSAGE(parse(bin), validation_error,
+        "both module memory and imported memory are defined (at most one of them is allowed)");
+}
+
+TEST(validation, memory_multi_min_limit)
+{
+    const auto section_contents = "02007f007f"_bytes;
+    const auto bin = bytes{wasm_prefix} + make_section(5, section_contents);
+
+    EXPECT_THROW_MESSAGE(
+        parse(bin), validation_error, "too many memory sections (at most one is allowed)");
+}
+
+TEST(validation, import_tables_multiple)
+{
+    const auto section_contents =
+        make_vec({bytes{0x02, 'm', '1', 0x03, 'a', 'b', 'c', 0x01, 0x70, 0x00, 0x01},
+            bytes{0x02, 'm', '2', 0x03, 'd', 'e', 'f', 0x01, 0x70, 0x01, 0x01, 0x03}});
+    const auto bin = bytes{wasm_prefix} + make_section(2, section_contents);
+
+    EXPECT_THROW_MESSAGE(
+        parse(bin), validation_error, "too many imported tables (at most one is allowed)");
+}
+
+TEST(validation, table_and_imported_table)
+{
+    // (import "js" "t" (table 1 anyfunc))
+    const auto import_section = "020a01026a730174017000010008046e616d65020100"_bytes;
+    // (table 2 anyfunc)
+    const auto table_section = "0404017000020008046e616d65020100"_bytes;
+    const auto bin = bytes{wasm_prefix} + import_section + table_section;
+
+    EXPECT_THROW_MESSAGE(parse(bin), validation_error,
+        "both module table and imported table are defined (at most one of them is allowed)");
+}
+
+TEST(validation, table_multi_min_limit)
+{
+    const auto section_contents = "0270007f70007f"_bytes;
+    const auto bin = bytes{wasm_prefix} + make_section(4, section_contents);
+
+    EXPECT_THROW_MESSAGE(
+        parse(bin), validation_error, "too many table sections (at most one is allowed)");
+}
 
 TEST(validation, i32_store_no_memory)
 {

--- a/test/utils/wasm_binary.hpp
+++ b/test/utils/wasm_binary.hpp
@@ -5,6 +5,24 @@
 
 namespace fizzy::test
 {
+inline bytes add_size_prefix(const bytes& content)
+{
+    return leb128u_encode(content.size()) + content;
+}
+
+inline bytes make_vec(std::initializer_list<bytes_view> contents)
+{
+    bytes ret = leb128u_encode(contents.size());
+    for (const auto& content : contents)
+        ret.append(content);
+    return ret;
+}
+
+inline bytes make_section(uint8_t id, const bytes& content)
+{
+    return bytes{id} + add_size_prefix(content);
+}
+
 /// Creates wasm binary representing i32.const instruction with following encoded immediate value.
 inline bytes i32_const(uint32_t c)
 {


### PR DESCRIPTION
1. Throw `validation_error` instead of `parser_error` in table/memory number checks.
2. Move related tests to validation_test.cpp
3. assert in `instantiate` for the same checks instead of throwing `instantiate_error`
3.1 remove related cases from instantiation tests

3.1 is required for converting instantiation tests to wat2wasm https://github.com/wasmx/fizzy/blob/a534d42636da97700db634e2640b8947f44a4735/test/unittests/instantiate_test.cpp#L172-L184