### PR TITLE
ci: fix shebang in ci-benchmark.sh

### DIFF
--- a/test/ci-benchmark.sh
+++ b/test/ci-benchmark.sh
@@ -1,8 +1,8 @@
+#!/usr/bin/env sh
+
 # Fizzy: A fast WebAssembly interpreter
 # Copyright 2019-2020 The Fizzy Authors.
 # SPDX-License-Identifier: Apache-2.0
-
-#!/usr/bin/env sh
 
 if [ -z "$CIRCLECI_TOKEN" ]; then
   echo "CIRCLECI_TOKEN env var is required"


### PR DESCRIPTION
My shell (fish) requires shebang to be the first bytes in the file.

Fixes #280.