### PR TITLE
Resolve jumps

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -652,8 +652,6 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         }
         case Instr::loop:
         {
-            LabelContext label{pc - 1, immediates, 0, stack.size()};  // Target this instruction.
-            labels.push_back(label);
             break;
         }
         case Instr::if_:
@@ -714,7 +712,9 @@ execution_result execute(Instance& instance, FuncIdx func_idx, std::vector<uint6
         case Instr::br:
         case Instr::br_if:
         {
-            const auto label_idx = read<uint32_t>(immediates);
+            const auto code_offset = read<uint32_t>(immediates);
+            const auto imm_offset = read<uint32_t>(immediates);
+            const auto carries_result = read<uint8_t>(immediates) != 0;
 
             // Check condition for br_if.
             if (instruction == Instr::br_if && static_cast<uint32_t>(stack.pop()) == 0)

--- a/lib/fizzy/parser_expr.cpp
+++ b/lib/fizzy/parser_expr.cpp
@@ -315,7 +315,21 @@ parser_result<Code> parse_expr(const uint8_t* pos, const uint8_t* end, bool have
             if (label_idx > label_positions.size())
                 throw validation_error{"invalid label index"};
 
-            push(code.immediates, label_idx);
+            // FIXME: Add support for "return"
+
+            // TODO: Do not return by value.
+            const auto label = label_positions.peek(label_idx);
+
+            if (label.instruction == Instr::loop)
+            {
+                push(code.immediates, label.code_offset);
+                push(code.immediates, label.immediates_offset);
+
+                // TODO: Should be named differently, for loop this is always 0.
+                push(code.immediates, uint8_t{label.has_result});
+            }
+            // FIXME: Add support for block.
+
             break;
         }
 


### PR DESCRIPTION
Goal is to move label stack for `block` and `loop` opcodes from execution to parser and result jumps targets there. Finally, for every `br`, `br_if`, `br_table`, `return`, `if` and `else` we will have the destination (as relative or absolute code offset) available as an immediate value during execution.

Resolving `loop` is simple. For every `br` inside `loop` the destination is the `loop` offset (available as the top of the label stack).

Resolving `block` is not simple because `br` destination is at the `end` after the `br` itself. So in the `block` label we need an array of `br` to be resolved when `end` is reached.