### PR TITLE
benchmarks: Remove execute/ecparing/empty

### DIFF
--- a/test/benchmarks/ecpairing.inputs
+++ b/test/benchmarks/ecpairing.inputs
@@ -1,9 +1,3 @@
-empty
-ecpairing_empty
-
-
-
-
 onepoint
 ecpairing_onepoint
 


### PR DESCRIPTION
It does not do anything.