### PR TITLE
Fix disabled tests around reexports of imported table/memory

### DIFF
--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -66,17 +66,20 @@ struct Instance
     // Table is either allocated and owned by the instance or imported and owned externally.
     // For these cases unique_ptr would either have a normal deleter or noop deleter respectively.
     table_ptr table = {nullptr, [](table_elements*) {}};
+    Limits table_limits;
     std::vector<uint64_t> globals;
     std::vector<ExternalFunction> imported_functions;
     std::vector<ExternalGlobal> imported_globals;
 
     Instance(Module _module, bytes_ptr _memory, size_t _memory_max_pages, table_ptr _table,
-        std::vector<uint64_t> _globals, std::vector<ExternalFunction> _imported_functions,
+        Limits _table_limits, std::vector<uint64_t> _globals,
+        std::vector<ExternalFunction> _imported_functions,
         std::vector<ExternalGlobal> _imported_globals)
       : module(std::move(_module)),
         memory(std::move(_memory)),
         memory_max_pages(_memory_max_pages),
         table(std::move(_table)),
+        table_limits(_table_limits),
         globals(std::move(_globals)),
         imported_functions(std::move(_imported_functions)),
         imported_globals(std::move(_imported_globals))

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -62,7 +62,7 @@ struct Instance
     // and owned externally.
     // For these cases unique_ptr would either have a normal deleter or noop deleter respectively
     bytes_ptr memory = {nullptr, [](bytes*) {}};
-    size_t memory_max_pages = 0;
+    Limits memory_limits;
     // Table is either allocated and owned by the instance or imported and owned externally.
     // For these cases unique_ptr would either have a normal deleter or noop deleter respectively.
     table_ptr table = {nullptr, [](table_elements*) {}};
@@ -71,13 +71,13 @@ struct Instance
     std::vector<ExternalFunction> imported_functions;
     std::vector<ExternalGlobal> imported_globals;
 
-    Instance(Module _module, bytes_ptr _memory, size_t _memory_max_pages, table_ptr _table,
+    Instance(Module _module, bytes_ptr _memory, Limits _memory_limits, table_ptr _table,
         Limits _table_limits, std::vector<uint64_t> _globals,
         std::vector<ExternalFunction> _imported_functions,
         std::vector<ExternalGlobal> _imported_globals)
       : module(std::move(_module)),
         memory(std::move(_memory)),
-        memory_max_pages(_memory_max_pages),
+        memory_limits(_memory_limits),
         table(std::move(_table)),
         table_limits(_table_limits),
         globals(std::move(_globals)),

--- a/lib/fizzy/types.hpp
+++ b/lib/fizzy/types.hpp
@@ -35,7 +35,7 @@ struct FuncType
 // https://webassembly.github.io/spec/core/binary/types.html#binary-limits
 struct Limits
 {
-    uint32_t min;
+    uint32_t min = 0;
     std::optional<uint32_t> max;
 };
 

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -377,7 +377,7 @@ TEST(api, find_exported_memory)
     EXPECT_FALSE(find_exported_table(*instance_no_memory, "mem").has_value());
 }
 
-TEST(api, DISABLED_find_exported_memory_reimport)
+TEST(api, find_exported_memory_reimport)
 {
     /* wat2wasm
     (module

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -275,7 +275,7 @@ TEST(api, find_exported_table)
     EXPECT_FALSE(find_exported_table(*instance_no_table, "tab").has_value());
 }
 
-TEST(api, DISABLED_find_exported_table_reimport)
+TEST(api, find_exported_table_reimport)
 {
     /* wat2wasm
     (module

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -201,7 +201,9 @@ TEST(instantiate, imported_memory)
     ASSERT_TRUE(instance->memory);
     EXPECT_EQ(instance->memory->size(), PageSize);
     EXPECT_EQ(instance->memory->data(), memory.data());
-    EXPECT_EQ(instance->memory_max_pages, 3);
+    EXPECT_EQ(instance->memory_limits.min, 1);
+    ASSERT_TRUE(instance->memory_limits.max.has_value());
+    EXPECT_EQ(instance->memory_limits.max, 3);
 }
 
 TEST(instantiate, imported_memory_unlimited)
@@ -218,7 +220,8 @@ TEST(instantiate, imported_memory_unlimited)
     ASSERT_TRUE(instance->memory);
     EXPECT_EQ(instance->memory->size(), PageSize);
     EXPECT_EQ(instance->memory->data(), memory.data());
-    EXPECT_EQ(instance->memory_max_pages, MemoryPagesLimit);
+    EXPECT_EQ(instance->memory_limits.min, 1);
+    EXPECT_FALSE(instance->memory_limits.max.has_value());
 }
 
 TEST(instantiate, imported_memory_stricter_limits)
@@ -235,7 +238,9 @@ TEST(instantiate, imported_memory_stricter_limits)
     ASSERT_TRUE(instance->memory);
     EXPECT_EQ(instance->memory->size(), PageSize * 2);
     EXPECT_EQ(instance->memory->data(), memory.data());
-    EXPECT_EQ(instance->memory_max_pages, 2);
+    EXPECT_EQ(instance->memory_limits.min, 2);
+    ASSERT_TRUE(instance->memory_limits.max.has_value());
+    EXPECT_EQ(instance->memory_limits.max, 2);
 }
 
 TEST(instantiate, imported_memory_invalid)
@@ -408,7 +413,9 @@ TEST(instantiate, memory_single)
     auto instance = instantiate(module);
 
     ASSERT_EQ(instance->memory->size(), PageSize);
-    EXPECT_EQ(instance->memory_max_pages, 1);
+    EXPECT_EQ(instance->memory_limits.min, 1);
+    ASSERT_TRUE(instance->memory_limits.max.has_value());
+    EXPECT_EQ(instance->memory_limits.max, 1);
 }
 
 TEST(instantiate, memory_single_unspecified_maximum)
@@ -419,7 +426,8 @@ TEST(instantiate, memory_single_unspecified_maximum)
     auto instance = instantiate(module);
 
     ASSERT_EQ(instance->memory->size(), PageSize);
-    EXPECT_EQ(instance->memory_max_pages * PageSize, 256 * 1024 * 1024);
+    EXPECT_EQ(instance->memory_limits.min, 1);
+    EXPECT_FALSE(instance->memory_limits.max.has_value());
 }
 
 TEST(instantiate, memory_single_large_minimum)


### PR DESCRIPTION
Imported table and memory are allowed to have narrower limits than the ones defined in the module. If it is then reexported, the limits must be original (narrower) ones, otherwise it might not fit as an import to another module. The disabled tests demonstrate it https://github.com/wasmx/fizzy/blob/7dabb5255a2f1b9fe7fb253a617851184951e696/test/unittests/api_test.cpp#L278

PR adds new members to `Instance` to save the limits of either local or imported table/memory. These limits are then returned from `find_exported_table`/`find_exported_memory`.

I also tried to use `std::variant` to refactor table in https://github.com/wasmx/fizzy/pull/302 but the approach in this PR seems now much simpler.