### PR TITLE
refactor: pass Module to parse_expr

### DIFF
--- a/lib/fizzy/module.hpp
+++ b/lib/fizzy/module.hpp
@@ -57,5 +57,10 @@ struct Module
 
         return typesec[type_idx];
     }
+
+    bool has_memory() const noexcept
+    {
+        return !memorysec.empty() || !imported_memory_types.empty();
+    }
 };
 }  // namespace fizzy

--- a/lib/fizzy/parser.hpp
+++ b/lib/fizzy/parser.hpp
@@ -38,10 +38,10 @@ inline parser_result<uint8_t> parse_byte(const uint8_t* pos, const uint8_t* end)
 /// Parse `expr`, i.e. a function's instructions residing in the code section.
 /// https://webassembly.github.io/spec/core/binary/instructions.html#binary-expr
 ///
-/// @param input        The beginning of the expr binary input.
-/// @param end          The end of the binary input.
-/// @param have_memory  If the module (the context) contains imported or defined memory.
-parser_result<Code> parse_expr(const uint8_t* input, const uint8_t* end, bool have_memory);
+/// @param input    The beginning of the expr binary input.
+/// @param end      The end of the binary input.
+/// @param module   Module that this code is part of.
+parser_result<Code> parse_expr(const uint8_t* input, const uint8_t* end, const Module& module);
 
 parser_result<std::string> parse_string(const uint8_t* pos, const uint8_t* end);
 

--- a/lib/fizzy/parser_expr.cpp
+++ b/lib/fizzy/parser_expr.cpp
@@ -64,7 +64,7 @@ parser_result<uint8_t> parse_blocktype(const uint8_t* pos, const uint8_t* end)
 }
 }  // namespace
 
-parser_result<Code> parse_expr(const uint8_t* pos, const uint8_t* end, bool have_memory)
+parser_result<Code> parse_expr(const uint8_t* pos, const uint8_t* end, const Module& module)
 {
     Code code;
 
@@ -102,7 +102,7 @@ parser_result<Code> parse_expr(const uint8_t* pos, const uint8_t* end, bool have
         case Instr::f64_load:
         case Instr::f32_store:
         case Instr::f64_store:
-            if (!have_memory)
+            if (!module.has_memory())
                 throw validation_error{"memory instructions require imported or defined memory"};
             // alignment
             std::tie(std::ignore, pos) = leb128u_decode<uint32_t>(pos, end);
@@ -459,7 +459,7 @@ parser_result<Code> parse_expr(const uint8_t* pos, const uint8_t* end, bool have
             std::tie(imm, pos) = leb128u_decode<uint32_t>(pos, end);
             push(code.immediates, imm);
 
-            if (!have_memory)
+            if (!module.has_memory())
                 throw validation_error{"memory instructions require imported or defined memory"};
             break;
         }
@@ -473,7 +473,7 @@ parser_result<Code> parse_expr(const uint8_t* pos, const uint8_t* end, bool have
             if (memory_idx != 0)
                 throw parser_error{"invalid memory index encountered"};
 
-            if (!have_memory)
+            if (!module.has_memory())
                 throw validation_error{"memory instructions require imported or defined memory"};
             break;
         }

--- a/test/unittests/parser_expr_test.cpp
+++ b/test/unittests/parser_expr_test.cpp
@@ -15,7 +15,8 @@ namespace
 {
 inline auto parse_expr(const bytes& input)
 {
-    return fizzy::parse_expr(input.data(), input.data() + input.size(), false);
+    // TODO: may need to expose Module for some validation cases
+    return fizzy::parse_expr(input.data(), input.data() + input.size(), Module{});
 }
 }  // namespace
 


### PR DESCRIPTION
And add has_memory() helper on Module

Pulled out of #267. Needed for a lot of validation steps.