### PR TITLE
test: fix execution_result printer

### DIFF
--- a/test/utils/asserts.cpp
+++ b/test/utils/asserts.cpp
@@ -16,7 +16,7 @@ std::ostream& operator<<(std::ostream& os, execution_result result)
     std::string_view separator;
     for (const auto& x : result.stack)
     {
-        os << x << separator;
+        os << separator << x;
         separator = ", ";
     }
     os << ")";


### PR DESCRIPTION
It was outputting `(ab, )` instead of `(a, b)`