### PR TITLE
Resolve br/br_if/br_table in parser

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -738,11 +738,15 @@ execution_result execute(
         {
             // We reach else only at the end of if block.
             assert(!labels.empty());
-            const auto label = labels.top();
             labels.pop();
 
-            pc = label.pc;
-            immediates = label.immediate;
+            // We reach else only after executing if block ("then" part),
+            // so we need to skip else block now.
+            const auto target_pc = read<uint32_t>(immediates);
+            const auto target_imm = read<uint32_t>(immediates);
+
+            pc = code.instructions.data() + target_pc;
+            immediates = code.immediates.data() + target_imm;
 
             break;
         }

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -655,38 +655,20 @@ execution_result execute(
             trap = true;
             goto end;
         case Instr::nop:
-            break;
         case Instr::block:
-        {
-            immediates += sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t);
-            break;
-        }
         case Instr::loop:
             break;
         case Instr::if_:
         {
-            const auto arity = read<uint8_t>(immediates);
-            const auto target_pc = read<uint32_t>(immediates);
-            const auto target_imm = read<uint32_t>(immediates);
-
             if (static_cast<uint32_t>(stack.pop()) != 0)
                 immediates += 2 * sizeof(uint32_t);  // Skip the immediates for else instruction.
             else
             {
-                const auto target_else_pc = read<uint32_t>(immediates);
-                const auto target_else_imm = read<uint32_t>(immediates);
+                const auto target_pc = read<uint32_t>(immediates);
+                const auto target_imm = read<uint32_t>(immediates);
 
-                if (target_else_pc != 0)  // If else block defined.
-                {
-                    pc = code.instructions.data() + target_else_pc;
-                    immediates = code.immediates.data() + target_else_imm;
-                }
-                else  // If else block not defined go to end of if.
-                {
-                    assert(arity == 0);  // if without else cannot have type signature.
-                    pc = code.instructions.data() + target_pc;
-                    immediates = code.immediates.data() + target_imm;
-                }
+                pc = code.instructions.data() + target_pc;
+                immediates = code.immediates.data() + target_imm;
             }
             break;
         }

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -271,41 +271,27 @@ void branch(const Code& code, LabelStack& labels, OperandStack& stack, const Ins
     assert(labels.size() > label_idx);
     while (label_idx-- > 0)
         labels.pop();  // Drop skipped labels (does nothing for labelidx == 0).
-    const auto label = labels.top();
     labels.pop();
 
     const auto code_offset = read<uint32_t>(immediates);
     const auto imm_offset = read<uint32_t>(immediates);
-    // TODO: these will be const when blocks other than loop use them
-    size_t stack_height = static_cast<uint32_t>(read<int>(immediates));
-    auto arity = read<uint8_t>(immediates);
+    const auto stack_height = static_cast<size_t>(read<int>(immediates));
+    const auto arity = read<uint8_t>(immediates);
 
-    if (label.pc == nullptr)
-    {
-        // Labels refers to loop, use jump destination resolved in parser
-        pc = code.instructions.data() + code_offset;
-        immediates = code.immediates.data() + imm_offset;
-    }
-    else
-    {
-        // Label refers to block other than loop, use jump destination saved in label
-        pc = label.pc;
-        immediates = label.immediate;
-        stack_height = label.stack_height;
-        arity = static_cast<uint8_t>(label.arity);
-    }
+    pc = code.instructions.data() + code_offset;
+    immediates = code.immediates.data() + imm_offset;
 
     // When branch is taken, additional stack items must be dropped.
     assert(stack.size() >= stack_height + arity);
     if (arity != 0)
     {
-        assert(label.arity == 1);
+        assert(arity == 1);
         const auto result = stack.top();
-        stack.shrink(label.stack_height);
+        stack.shrink(stack_height);
         stack.push(result);
     }
     else
-        stack.shrink(label.stack_height);
+        stack.shrink(stack_height);
 }
 
 template <class F>

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -16,8 +16,8 @@ namespace fizzy
 {
 namespace
 {
-// label_idx + code_offset + imm_offset + stack_height + arity
-constexpr auto BranchImmediateSize = 4 * sizeof(uint32_t) + sizeof(uint8_t);
+// code_offset + imm_offset + stack_height + arity
+constexpr auto BranchImmediateSize = 3 * sizeof(uint32_t) + sizeof(uint8_t);
 
 inline bool operator==(const FuncType& lhs, const FuncType& rhs)
 {
@@ -256,9 +256,6 @@ inline T read(const uint8_t*& input) noexcept
 void branch(
     const Code& code, OperandStack& stack, const Instr*& pc, const uint8_t*& immediates) noexcept
 {
-    // skip label_idx
-    immediates += sizeof(uint32_t);
-
     const auto code_offset = read<uint32_t>(immediates);
     const auto imm_offset = read<uint32_t>(immediates);
     const auto stack_height = static_cast<size_t>(read<int>(immediates));

--- a/lib/fizzy/parser_expr.cpp
+++ b/lib/fizzy/parser_expr.cpp
@@ -339,16 +339,10 @@ parser_result<Code> parse_expr(
         {
             uint8_t arity;
             std::tie(arity, pos) = parse_blocktype(pos, end);
-            code.immediates.push_back(arity);
 
             // Push label with immediates offset after arity.
             control_stack.emplace(Instr::block, arity, frame.stack_height, code.instructions.size(),
                 code.immediates.size());
-
-            // TODO: these will not be needed when br out of block is resolved in parser
-            // Placeholders for immediate values, filled at the matching end instruction.
-            push(code.immediates, uint32_t{0});  // Diff to the end instruction.
-            push(code.immediates, uint32_t{0});  // Diff for the immediates.
             break;
         }
 
@@ -367,16 +361,11 @@ parser_result<Code> parse_expr(
         {
             uint8_t arity;
             std::tie(arity, pos) = parse_blocktype(pos, end);
-            code.immediates.push_back(arity);
 
             control_stack.emplace(Instr::if_, arity, frame.stack_height, code.instructions.size(),
                 code.immediates.size());
 
-            // TODO: these will not be needed when br out of if is resolved in parser
-            // Placeholders for immediate values, filled at the matching end and else instructions.
-            push(code.immediates, uint32_t{0});  // Diff to the end instruction.
-            push(code.immediates, uint32_t{0});  // Diff for the immediates
-
+            // Placeholders for immediate values, filled at the matching end or else instructions.
             push(code.immediates, uint32_t{0});  // Diff to the else instruction
             push(code.immediates, uint32_t{0});  // Diff for the immediates.
 
@@ -405,8 +394,7 @@ parser_result<Code> parse_expr(
             const auto target_imm = static_cast<uint32_t>(code.immediates.size());
 
             // Set the imm values for else instruction.
-            auto* if_imm =
-                code.immediates.data() + if_imm_offset + sizeof(target_pc) + sizeof(target_imm);
+            auto* if_imm = code.immediates.data() + if_imm_offset;
             store(if_imm, target_pc);
             if_imm += sizeof(target_pc);
             store(if_imm, target_imm);

--- a/lib/fizzy/parser_expr.cpp
+++ b/lib/fizzy/parser_expr.cpp
@@ -40,7 +40,8 @@ struct ControlFrame
     const size_t code_offset{0};
 
     /// The immediates offset for block instructions.
-    const size_t immediates_offset{0};
+    /// Non-const because else block changes it (to resolve jumping over else block).
+    size_t immediates_offset{0};
 
     /// The frame stack height of the parent frame.
     /// TODO: Storing this is not strictly required, as the parent frame is available
@@ -392,16 +393,23 @@ parser_result<Code> parse_expr(
             // Reset frame after if. The if result type validation not implemented yet.
             frame.stack_height = frame.parent_stack_height;
             frame.unreachable = false;
+            const auto if_imm_offset = frame.immediates_offset;
+            frame.immediates_offset = code.immediates.size();
 
+            // Placeholders for immediate values, filled at the matching end instructions.
+            push(code.immediates, uint32_t{0});  // Diff to the end instruction.
+            push(code.immediates, uint32_t{0});  // Diff for the immediates
+
+            // Fill in if's immediates with offsets of first instruction in else block.
             const auto target_pc = static_cast<uint32_t>(code.instructions.size() + 1);
             const auto target_imm = static_cast<uint32_t>(code.immediates.size());
 
             // Set the imm values for else instruction.
-            auto* block_imm = code.immediates.data() + frame.immediates_offset + sizeof(target_pc) +
-                              sizeof(target_imm);
-            store(block_imm, target_pc);
-            block_imm += sizeof(target_pc);
-            store(block_imm, target_imm);
+            auto* if_imm =
+                code.immediates.data() + if_imm_offset + sizeof(target_pc) + sizeof(target_imm);
+            store(if_imm, target_pc);
+            if_imm += sizeof(target_pc);
+            store(if_imm, target_imm);
 
             break;
         }
@@ -422,8 +430,9 @@ parser_result<Code> parse_expr(
 
                 if (frame.instruction == Instr::if_)
                 {
-                    // We're at the end instruction of the if block without else.
-                    // Fill in if's immediates with offsets right after if block.
+                    // We're at the end instruction of the if block without else or at the end of
+                    // else block. Fill in if/else's immediates with offsets of first instruction
+                    // after if/else block.
                     auto* if_imm = code.immediates.data() + frame.immediates_offset;
                     store(if_imm, target_pc);
                     if_imm += sizeof(target_pc);

--- a/test/unittests/execute_control_test.cpp
+++ b/test/unittests/execute_control_test.cpp
@@ -648,6 +648,25 @@ TEST(execute_control, br_1_out_of_function_and_imported_function)
     EXPECT_THAT(execute(*instance, 1, {}), Result(1));
 }
 
+TEST(execute_control, br_inner_nonempty_stack)
+{
+    /* wat2wasm
+      (func (result i32)
+        (i32.const 0x1)
+        (block (result i32)
+          (block (br 0))
+          (i32.const 0x2)
+        )
+        i32.add
+      )
+     */
+    const auto bin =
+        from_hex("0061736d010000000105016000017f030201000a11010f004101027f02400c000b41020b6a0b");
+
+    auto instance = instantiate(parse(bin));
+    EXPECT_THAT(execute(*instance, 0, {}), Result(0x3));
+}
+
 TEST(execute_control, br_table)
 {
     /* wat2wasm

--- a/test/unittests/parser_expr_test.cpp
+++ b/test/unittests/parser_expr_test.cpp
@@ -69,29 +69,19 @@ TEST(parser_expr, instr_block)
     const auto [code1, pos1] = parse_expr(empty);
     EXPECT_EQ(code1.instructions,
         (std::vector{Instr::nop, Instr::nop, Instr::block, Instr::end, Instr::end}));
-    EXPECT_EQ(code1.immediates,
-        "00"
-        "04000000"
-        "09000000"_bytes);
+    EXPECT_TRUE(code1.immediates.empty());
 
     const auto block_i64 = "027e42000b1a0b"_bytes;
     const auto [code2, pos2] = parse_expr(block_i64);
     EXPECT_EQ(code2.instructions,
         (std::vector{Instr::block, Instr::i64_const, Instr::end, Instr::drop, Instr::end}));
-    EXPECT_EQ(code2.immediates,
-        "01"
-        "03000000"
-        "11000000"
-        "0000000000000000"_bytes);
+    EXPECT_EQ(code2.immediates, "0000000000000000"_bytes);
 
     const auto block_f64 = "027c4400000000000000000b1a0b"_bytes;
     const auto [code3, pos3] = parse_expr(block_f64);
     EXPECT_EQ(code3.instructions,
         (std::vector{Instr::block, Instr::f64_const, Instr::end, Instr::drop, Instr::end}));
-    EXPECT_EQ(code3.immediates,
-        "01"
-        "03000000"
-        "09000000"_bytes);
+    EXPECT_TRUE(code3.immediates.empty());
 }
 
 TEST(parser_expr, instr_block_input_buffer_overflow)
@@ -122,14 +112,11 @@ TEST(parser_expr, block_br)
                                Instr::local_set, Instr::br, Instr::i32_const, Instr::local_set,
                                Instr::end, Instr::local_get, Instr::drop, Instr::end}));
     EXPECT_EQ(code.immediates,
-        "00"
-        "08000000"
-        "2a000000"
         "0a000000"
         "01000000"
         "00000000"  // label_idx
-        "01000000"  // code_offset
-        "01000000"  // imm_offset
+        "08000000"  // code_offset
+        "21000000"  // imm_offset
         "00000000"  // stack_height
         "00"        // arity
         "0b000000"
@@ -138,7 +125,7 @@ TEST(parser_expr, block_br)
     EXPECT_EQ(code.max_stack_height, 1);
 }
 
-TEST(parser_expr, DISABLED_instr_br_table)
+TEST(parser_expr, instr_br_table)
 {
     /* wat2wasm
     (func (param i32) (result i32)
@@ -176,40 +163,47 @@ TEST(parser_expr, DISABLED_instr_br_table)
             Instr::end, Instr::i32_const, Instr::return_, Instr::end, Instr::i32_const,
             Instr::return_, Instr::end, Instr::i32_const, Instr::end}));
 
-    // 5 blocks + 1 local_get before br_table
-    const auto br_table_imm_offset = 5 * (1 + 2 * 4) + 4;
+    // 1 local_get before br_table
+    const auto br_table_imm_offset = 4;
+    // br_imm_size = 17
+    // br_0_offset = br_table_imm_offset + br_imm_size * 5 + 4 + br_imm_size = 114 = 0x72
+    // br_1_offset = br_0_offset + 21 = 0x87
+    // br_2_offset = br_1_offset + 21 = 0x9c
+    // br_3_offset = br_2_offset + 21 = 0xb1
+    // br_4_offset = br_3_offset + 21 = 0xc6
     const auto expected_br_imm =
-        "04000000"
+        "04000000"  // label_count
 
-        "03000000"          // label_idx
-        "0100000000000000"  // code_offset
-        "0900000000000000"  // imm_offset
-        "00000000"          // stack_height
-        "00"                // arity
+        "03000000"  // label_idx
+        "13000000"  // code_offset
+        "b1000000"  // imm_offset
+        "00000000"  // stack_height
+        "00"        // arity
 
-        "02000000"
-        "0100000000000000"
-        "0900000000000000"
-        "00000000"
-        "00"
+        "02000000"  // label_idx
+        "10000000"  // code_offset
+        "9c000000"  // imm_offset
+        "00000000"  // stack_height
+        "00"        // arity
 
-        "0100000000000000"
-        "0900000000000000"
-        "00000000"
-        "00"
-        "01000000"
+        "01000000"  // label_idx
+        "0d000000"  // code_offset
+        "87000000"  // imm_offset
+        "00000000"  // stack_height
+        "00"        // arity
 
-        "00000000"
-        "0100000000000000"
-        "0900000000000000"
-        "00000000"
-        "00"
+        "00000000"  // label_idx
+        "0a000000"  // code_offset
+        "72000000"  // imm_offset
+        "00000000"  // stack_height
+        "00"        // arity
 
-        "04000000"
-        "0100000000000000"
-        "0900000000000000"
-        "00000000"
-        "00"_bytes;
+        "04000000"   // label_idx
+        "16000000"   // code_offset
+        "c6000000"   // imm_offset
+        "00000000"   // stack_height
+        "00"_bytes;  // arity
+
     EXPECT_EQ(code.immediates.substr(br_table_imm_offset, expected_br_imm.size()), expected_br_imm);
     EXPECT_EQ(code.max_stack_height, 1);
 }
@@ -236,11 +230,15 @@ TEST(parser_expr, instr_br_table_empty_vector)
         (std::vector{Instr::block, Instr::local_get, Instr::br_table, Instr::i32_const,
             Instr::return_, Instr::end, Instr::i32_const, Instr::end}));
 
-    // blocks + local_get before br_table
-    const auto br_table_imm_offset = 1 + 2 * 4 + 4;
+    // local_get before br_table
+    const auto br_table_imm_offset = 4;
     const auto expected_br_imm =
-        "00000000"
-        "00000000"_bytes;
+        "00000000"   // label_count
+        "00000000"   // label_idx
+        "06000000"   // code_offset
+        "2e000000"   // imm_offset
+        "00000000"   // stack_height
+        "00"_bytes;  // arity
     EXPECT_EQ(code.immediates.substr(br_table_imm_offset, expected_br_imm.size()), expected_br_imm);
     EXPECT_EQ(code.max_stack_height, 1);
 }

--- a/test/unittests/parser_expr_test.cpp
+++ b/test/unittests/parser_expr_test.cpp
@@ -124,17 +124,21 @@ TEST(parser_expr, block_br)
     EXPECT_EQ(code.immediates,
         "00"
         "08000000"
-        "1d000000"
+        "2a000000"
         "0a000000"
         "01000000"
-        "00000000"
+        "00000000"  // label_idx
+        "01000000"  // code_offset
+        "01000000"  // imm_offset
+        "00000000"  // stack_height
+        "00"        // arity
         "0b000000"
         "01000000"
         "01000000"_bytes);
     EXPECT_EQ(code.max_stack_height, 1);
 }
 
-TEST(parser_expr, instr_br_table)
+TEST(parser_expr, DISABLED_instr_br_table)
 {
     /* wat2wasm
     (func (param i32) (result i32)
@@ -176,11 +180,36 @@ TEST(parser_expr, instr_br_table)
     const auto br_table_imm_offset = 5 * (1 + 2 * 4) + 4;
     const auto expected_br_imm =
         "04000000"
-        "03000000"
+
+        "03000000"          // label_idx
+        "0100000000000000"  // code_offset
+        "0900000000000000"  // imm_offset
+        "00000000"          // stack_height
+        "00"                // arity
+
         "02000000"
-        "01000000"
+        "0100000000000000"
+        "0900000000000000"
         "00000000"
-        "04000000"_bytes;
+        "00"
+
+        "0100000000000000"
+        "0900000000000000"
+        "00000000"
+        "00"
+        "01000000"
+
+        "00000000"
+        "0100000000000000"
+        "0900000000000000"
+        "00000000"
+        "00"
+
+        "04000000"
+        "0100000000000000"
+        "0900000000000000"
+        "00000000"
+        "00"_bytes;
     EXPECT_EQ(code.immediates.substr(br_table_imm_offset, expected_br_imm.size()), expected_br_imm);
     EXPECT_EQ(code.max_stack_height, 1);
 }

--- a/test/unittests/parser_expr_test.cpp
+++ b/test/unittests/parser_expr_test.cpp
@@ -114,9 +114,8 @@ TEST(parser_expr, block_br)
     EXPECT_EQ(code.immediates,
         "0a000000"
         "01000000"
-        "00000000"  // label_idx
         "08000000"  // code_offset
-        "21000000"  // imm_offset
+        "1d000000"  // imm_offset
         "00000000"  // stack_height
         "00"        // arity
         "0b000000"
@@ -165,42 +164,37 @@ TEST(parser_expr, instr_br_table)
 
     // 1 local_get before br_table
     const auto br_table_imm_offset = 4;
-    // br_imm_size = 17
-    // br_0_offset = br_table_imm_offset + br_imm_size * 5 + 4 + br_imm_size = 114 = 0x72
-    // br_1_offset = br_0_offset + 21 = 0x87
-    // br_2_offset = br_1_offset + 21 = 0x9c
-    // br_3_offset = br_2_offset + 21 = 0xb1
-    // br_4_offset = br_3_offset + 21 = 0xc6
+    // br_imm_size = 13
+    // br_0_offset = br_table_imm_offset + 4 + br_imm_size * 5 + 4 + br_imm_size = 86 = 0x5a
+    // br_1_offset = br_0_offset + 4 + br_imm_size = 0x6b
+    // br_2_offset = br_1_offset + 4 + br_imm_size = 0x7c
+    // br_3_offset = br_2_offset + 4 + br_imm_size = 0x8d
+    // br_4_offset = br_3_offset + 4 + br_imm_size = 0x9e
     const auto expected_br_imm =
         "04000000"  // label_count
 
-        "03000000"  // label_idx
         "13000000"  // code_offset
-        "b1000000"  // imm_offset
+        "8d000000"  // imm_offset
         "00000000"  // stack_height
         "00"        // arity
 
-        "02000000"  // label_idx
         "10000000"  // code_offset
-        "9c000000"  // imm_offset
+        "7c000000"  // imm_offset
         "00000000"  // stack_height
         "00"        // arity
 
-        "01000000"  // label_idx
         "0d000000"  // code_offset
-        "87000000"  // imm_offset
+        "6b000000"  // imm_offset
         "00000000"  // stack_height
         "00"        // arity
 
-        "00000000"  // label_idx
         "0a000000"  // code_offset
-        "72000000"  // imm_offset
+        "5a000000"  // imm_offset
         "00000000"  // stack_height
         "00"        // arity
 
-        "04000000"   // label_idx
         "16000000"   // code_offset
-        "c6000000"   // imm_offset
+        "9e000000"   // imm_offset
         "00000000"   // stack_height
         "00"_bytes;  // arity
 
@@ -234,9 +228,8 @@ TEST(parser_expr, instr_br_table_empty_vector)
     const auto br_table_imm_offset = 4;
     const auto expected_br_imm =
         "00000000"   // label_count
-        "00000000"   // label_idx
         "06000000"   // code_offset
-        "2e000000"   // imm_offset
+        "26000000"   // imm_offset
         "00000000"   // stack_height
         "00"_bytes;  // arity
     EXPECT_EQ(code.immediates.substr(br_table_imm_offset, expected_br_imm.size()), expected_br_imm);


### PR DESCRIPTION
Replaces #297 

I tried to make the change history to gradually introduce resolving in parser, at first keeping control stack in execute and old instruction immediates, then deleting it in the very end. So this can be reviewed by commit.

For `br_table` it currently puts arity into immedaites for each label. This should be further optimized to have one arity immediate for entire `br_table` instruction.