### PR TITLE
More stack height validation

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -137,6 +137,7 @@ commands:
             set +e
             expected="  PASSED <<parameters.expected_passed>>, FAILED <<parameters.expected_failed>>, SKIPPED <<parameters.expected_skipped>>."
             result=$(bin/fizzy-spectests <<#parameters.skip_validation>>--skip-validation<</parameters.skip_validation>> wasm-spec/test/core/json | tail -1)
+            echo $result
             if [ "$expected" != "$result" ]; then exit 1; fi
 
 jobs:
@@ -262,8 +263,8 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 4783
-          expected_failed: 649
+          expected_passed: 4807
+          expected_failed: 625
           expected_skipped: 6381
 
   benchmark:
@@ -358,8 +359,8 @@ jobs:
           expected_failed: 8
           expected_skipped: 7323
       - spectest:
-          expected_passed: 4783
-          expected_failed: 649
+          expected_passed: 4807
+          expected_failed: 625
           expected_skipped: 6381
 
 workflows:

--- a/lib/fizzy/parser_expr.cpp
+++ b/lib/fizzy/parser_expr.cpp
@@ -42,6 +42,10 @@ struct ControlFrame
     /// Whether the remainder of the block is unreachable (used to handle stack-polymorphic typing
     /// after branches).
     bool unreachable{false};
+
+    ControlFrame(Instr _instruction, size_t _immediates_offset = 0) noexcept
+      : instruction{_instruction}, immediates_offset{_immediates_offset}
+    {}
 };
 
 /// Parses blocktype.

--- a/test/unittests/parser_expr_test.cpp
+++ b/test/unittests/parser_expr_test.cpp
@@ -21,24 +21,30 @@ inline auto parse_expr(const bytes& input, const Module& module = {})
 
 TEST(parser_expr, instr_loop)
 {
-    const auto loop_void_empty = "03400b0b"_bytes;
-    const auto [code1, pos1] = parse_expr(loop_void_empty);
+    const auto loop_void = "03400b0b"_bytes;
+    const auto [code1, pos1] = parse_expr(loop_void);
     EXPECT_EQ(code1.instructions, (std::vector{Instr::loop, Instr::end, Instr::end}));
     EXPECT_EQ(code1.immediates.size(), 0);
 
-    const auto loop_i32_empty = "037f0b0b"_bytes;
-    const auto [code2, pos2] = parse_expr(loop_i32_empty);
-    EXPECT_EQ(code2.instructions, (std::vector{Instr::loop, Instr::end, Instr::end}));
-    EXPECT_EQ(code2.immediates.size(), 0);
+    // EXPECT_EQ(code1.max_stack_height, 0);
 
-    const auto loop_f32_empty = "037d0b0b"_bytes;
-    const auto [code3, pos3] = parse_expr(loop_f32_empty);
-    EXPECT_EQ(code3.instructions, (std::vector{Instr::loop, Instr::end, Instr::end}));
+    const auto loop_i32 = "037f41000b0b"_bytes;
+    const auto [code2, pos2] = parse_expr(loop_i32);
+    EXPECT_EQ(
+        code2.instructions, (std::vector{Instr::loop, Instr::i32_const, Instr::end, Instr::end}));
+    EXPECT_EQ(code2.immediates.size(), 4);
+    // EXPECT_EQ(code2.max_stack_height, 1);
+
+    const auto loop_f32 = "037d43000000000b0b"_bytes;
+    const auto [code3, pos3] = parse_expr(loop_f32);
+    EXPECT_EQ(
+        code3.instructions, (std::vector{Instr::loop, Instr::f32_const, Instr::end, Instr::end}));
     EXPECT_EQ(code3.immediates.size(), 0);
 
-    const auto loop_f64_empty = "037d0b0b"_bytes;
-    const auto [code4, pos4] = parse_expr(loop_f64_empty);
-    EXPECT_EQ(code4.instructions, (std::vector{Instr::loop, Instr::end, Instr::end}));
+    const auto loop_f64 = "037d4400000000000000000b0b"_bytes;
+    const auto [code4, pos4] = parse_expr(loop_f64);
+    EXPECT_EQ(
+        code4.instructions, (std::vector{Instr::loop, Instr::f64_const, Instr::end, Instr::end}));
     EXPECT_EQ(code4.immediates.size(), 0);
 }
 
@@ -63,20 +69,23 @@ TEST(parser_expr, instr_block)
         "04000000"
         "09000000"_bytes);
 
-    const auto block_i64 = "027e0b0b"_bytes;
+    const auto block_i64 = "027e42000b0b"_bytes;
     const auto [code2, pos2] = parse_expr(block_i64);
-    EXPECT_EQ(code2.instructions, (std::vector{Instr::block, Instr::end, Instr::end}));
+    EXPECT_EQ(
+        code2.instructions, (std::vector{Instr::block, Instr::i64_const, Instr::end, Instr::end}));
     EXPECT_EQ(code2.immediates,
         "01"
-        "02000000"
-        "09000000"_bytes);
+        "03000000"
+        "11000000"
+        "0000000000000000"_bytes);
 
-    const auto block_f64 = "027c0b0b"_bytes;
+    const auto block_f64 = "027c4400000000000000000b0b"_bytes;
     const auto [code3, pos3] = parse_expr(block_f64);
-    EXPECT_EQ(code3.instructions, (std::vector{Instr::block, Instr::end, Instr::end}));
+    EXPECT_EQ(
+        code3.instructions, (std::vector{Instr::block, Instr::f64_const, Instr::end, Instr::end}));
     EXPECT_EQ(code3.immediates,
         "01"
-        "02000000"
+        "03000000"
         "09000000"_bytes);
 }
 


### PR DESCRIPTION
This validates if frames leave enough results they promised, however this check is missing for function frames (function type information is missing, but this is fixed in #312 - see a TODO comment). The situation where there is more results left is also not reported, but is easy to add - see TODO comment. This cannot be applied now because a lot of false positives when function result arity is so far assumed 0.

The frame `stack_height` now uses absolute values what will be useful for jump resolving in #312 and makes computing code's max stack height straight forward (as it is max value of any `frame.stack_height`).