### PR TITLE
Compute functions' max stack height

### DIFF
--- a/lib/fizzy/parser_expr.cpp
+++ b/lib/fizzy/parser_expr.cpp
@@ -142,6 +142,9 @@ parser_result<Code> parse_expr(const uint8_t* pos, const uint8_t* end, const Mod
 
         frame.stack_height += metrics.stack_height_change;
 
+        if (!frame.unreachable)
+            code.max_stack_height = std::max(code.max_stack_height, frame.stack_height);
+
         const auto instr = static_cast<Instr>(opcode);
         switch (instr)
         {

--- a/lib/fizzy/types.hpp
+++ b/lib/fizzy/types.hpp
@@ -332,6 +332,8 @@ struct Element
 /// https://webassembly.github.io/spec/core/binary/modules.html#code-section
 struct Code
 {
+    int max_stack_height = 0;
+
     uint32_t local_count = 0;
 
     // The instructions bytecode without immediate values.

--- a/test/unittests/execute_numeric_test.cpp
+++ b/test/unittests/execute_numeric_test.cpp
@@ -18,7 +18,7 @@ execution_result execute_unary_operation(Instr instr, uint64_t arg)
     // type is currently needed only to get arity of function, so exact value types don't matter
     module.typesec.emplace_back(FuncType{{ValType::i32}, {ValType::i32}});
     module.funcsec.emplace_back(TypeIdx{0});
-    module.codesec.emplace_back(Code{0, {Instr::local_get, instr, Instr::end}, {0, 0, 0, 0}});
+    module.codesec.emplace_back(Code{1, 0, {Instr::local_get, instr, Instr::end}, {0, 0, 0, 0}});
 
     return execute(module, 0, {arg});
 }
@@ -29,8 +29,8 @@ execution_result execute_binary_operation(Instr instr, uint64_t lhs, uint64_t rh
     // type is currently needed only to get arity of function, so exact value types don't matter
     module.typesec.emplace_back(FuncType{{ValType::i32, ValType::i32}, {ValType::i32}});
     module.funcsec.emplace_back(TypeIdx{0});
-    module.codesec.emplace_back(
-        Code{0, {Instr::local_get, Instr::local_get, instr, Instr::end}, {0, 0, 0, 0, 1, 0, 0, 0}});
+    module.codesec.emplace_back(Code{
+        2, 0, {Instr::local_get, Instr::local_get, instr, Instr::end}, {0, 0, 0, 0, 1, 0, 0, 0}});
 
     return execute(module, 0, {lhs, rhs});
 }

--- a/test/unittests/parser_expr_test.cpp
+++ b/test/unittests/parser_expr_test.cpp
@@ -212,10 +212,9 @@ TEST(parser_expr, instr_br_table_as_return)
     */
 
     const auto code_bin = "41000e00000b"_bytes;
-
-    const auto [code, pos] = parse_expr(code_bin);
-
+    const auto [code, _] = parse_expr(code_bin);
     EXPECT_EQ(code.instructions, (std::vector{Instr::i32_const, Instr::br_table, Instr::end}));
+    EXPECT_EQ(code.max_stack_height, 1);
 }
 
 TEST(parser_expr, instr_br_table_missing_arg)
@@ -340,6 +339,8 @@ TEST(parser_expr, call_0args_1result)
 
     const auto module = parse(wasm);
     ASSERT_EQ(module.codesec.size(), 2);
+    EXPECT_EQ(module.codesec[0].max_stack_height, 1);
+    EXPECT_EQ(module.codesec[1].max_stack_height, 1);
 }
 
 TEST(parser_expr, call_1arg_1result)
@@ -353,4 +354,6 @@ TEST(parser_expr, call_1arg_1result)
 
     const auto module = parse(wasm);
     ASSERT_EQ(module.codesec.size(), 2);
+    EXPECT_EQ(module.codesec[0].max_stack_height, 1);
+    EXPECT_EQ(module.codesec[1].max_stack_height, 1);
 }

--- a/test/unittests/parser_expr_test.cpp
+++ b/test/unittests/parser_expr_test.cpp
@@ -25,27 +25,28 @@ TEST(parser_expr, instr_loop)
     const auto [code1, pos1] = parse_expr(loop_void);
     EXPECT_EQ(code1.instructions, (std::vector{Instr::loop, Instr::end, Instr::end}));
     EXPECT_EQ(code1.immediates.size(), 0);
-
-    // EXPECT_EQ(code1.max_stack_height, 0);
+    EXPECT_EQ(code1.max_stack_height, 0);
 
     const auto loop_i32 = "037f41000b0b"_bytes;
     const auto [code2, pos2] = parse_expr(loop_i32);
     EXPECT_EQ(
         code2.instructions, (std::vector{Instr::loop, Instr::i32_const, Instr::end, Instr::end}));
     EXPECT_EQ(code2.immediates.size(), 4);
-    // EXPECT_EQ(code2.max_stack_height, 1);
+    EXPECT_EQ(code2.max_stack_height, 1);
 
     const auto loop_f32 = "037d43000000000b0b"_bytes;
     const auto [code3, pos3] = parse_expr(loop_f32);
     EXPECT_EQ(
         code3.instructions, (std::vector{Instr::loop, Instr::f32_const, Instr::end, Instr::end}));
     EXPECT_EQ(code3.immediates.size(), 0);
+    EXPECT_EQ(code3.max_stack_height, 1);
 
     const auto loop_f64 = "037d4400000000000000000b0b"_bytes;
     const auto [code4, pos4] = parse_expr(loop_f64);
     EXPECT_EQ(
         code4.instructions, (std::vector{Instr::loop, Instr::f64_const, Instr::end, Instr::end}));
     EXPECT_EQ(code4.immediates.size(), 0);
+    EXPECT_EQ(code4.max_stack_height, 1);
 }
 
 TEST(parser_expr, instr_loop_input_buffer_overflow)
@@ -124,6 +125,7 @@ TEST(parser_expr, block_br)
         "0b000000"
         "01000000"
         "01000000"_bytes);
+    EXPECT_EQ(code.max_stack_height, 1);
 }
 
 TEST(parser_expr, instr_br_table)
@@ -172,6 +174,7 @@ TEST(parser_expr, instr_br_table)
         "00000000"
         "04000000"_bytes;
     EXPECT_EQ(code.immediates.substr(br_table_imm_offset, expected_br_imm.size()), expected_br_imm);
+    EXPECT_EQ(code.max_stack_height, 1);
 }
 
 TEST(parser_expr, instr_br_table_empty_vector)
@@ -198,6 +201,7 @@ TEST(parser_expr, instr_br_table_empty_vector)
         "00000000"
         "00000000"_bytes;
     EXPECT_EQ(code.immediates.substr(br_table_imm_offset, expected_br_imm.size()), expected_br_imm);
+    EXPECT_EQ(code.max_stack_height, 1);
 }
 
 TEST(parser_expr, instr_br_table_as_return)

--- a/test/unittests/validation_stack_test.cpp
+++ b/test/unittests/validation_stack_test.cpp
@@ -59,8 +59,8 @@ TEST(validation_stack, block_with_result)
     )
     */
     const auto wasm = from_hex("0061736d01000000010401600000030201000a0a010800027f417f0b1a0b");
-    parse(wasm);
-    // TODO: Add max stack height check.
+    const auto module = parse(wasm);
+    EXPECT_EQ(module.codesec[0].max_stack_height, 1);
 }
 
 TEST(validation_stack, block_missing_result)
@@ -116,8 +116,8 @@ TEST(validation_stack, loop_with_result)
     )
     */
     const auto wasm = from_hex("0061736d01000000010401600000030201000a0a010800037f417f0b1a0b");
-    parse(wasm);
-    // TODO: Add max stack height check.
+    const auto module = parse(wasm);
+    EXPECT_EQ(module.codesec[0].max_stack_height, 1);
 }
 
 TEST(validation_stack, loop_missing_result)
@@ -206,8 +206,8 @@ TEST(validation_stack, unreachable)
     )
     */
     const auto wasm = from_hex("0061736d010000000105016000017f030201000a0601040000450b");
-    parse(wasm);
-    // TODO: Add max stack height check.
+    const auto module = parse(wasm);
+    EXPECT_THAT(module.codesec[0].max_stack_height, 0);
 }
 
 TEST(validation_stack, unreachable_2)
@@ -222,8 +222,8 @@ TEST(validation_stack, unreachable_2)
     )
     */
     const auto wasm = from_hex("0061736d01000000010401600000030201000a09010700006a6a6a1a0b");
-    parse(wasm);
-    // TODO: Add max stack height check.
+    const auto module = parse(wasm);
+    EXPECT_THAT(module.codesec[0].max_stack_height, 0);
 }
 
 TEST(validation_stack, unreachable_call)
@@ -275,8 +275,8 @@ TEST(validation_stack, br)
     )
     */
     const auto wasm = from_hex("0061736d01000000010401600000030201000a0b01090002400c00451a0b0b");
-    parse(wasm);
-    // TODO: Add max stack height check.
+    const auto module = parse(wasm);
+    EXPECT_THAT(module.codesec[0].max_stack_height, 0);
 }
 
 TEST(validation_stack, br_table)
@@ -296,8 +296,8 @@ TEST(validation_stack, br_table)
     */
     const auto wasm = from_hex(
         "0061736d0100000001050160017f00030201000a14011200024041e90720000e0100016c6c6c1a0b0b");
-    parse(wasm);
-    // TODO: Add max stack height check.
+    const auto module = parse(wasm);
+    EXPECT_THAT(module.codesec[0].max_stack_height, 2);
 }
 
 TEST(validation_stack, return_)
@@ -310,8 +310,8 @@ TEST(validation_stack, return_)
     )
     */
     const auto wasm = from_hex("0061736d01000000010401600000030201000a070105000f451a0b");
-    parse(wasm);
-    // TODO: Add max stack height check.
+    const auto module = parse(wasm);
+    EXPECT_THAT(module.codesec[0].max_stack_height, 0);
 }
 
 TEST(validation_stack, if_stack_underflow)
@@ -522,7 +522,7 @@ TEST(validation_stack, if_else_stack_height)
     const auto wasm =
         from_hex("0061736d01000000010401600000030201000a1201100042014102047e42010542030b1a1a0b");
     const auto module = parse(wasm);
-    // TODO: Add max stack height check.
+    EXPECT_EQ(module.codesec[0].max_stack_height, 2);
 }
 
 TEST(validation_stack, if_invalid_end_stack_height)
@@ -548,8 +548,8 @@ TEST(validation_stack, if_invalid_end_stack_height)
     */
     const auto wasm = from_hex(
         "0061736d01000000010401600000030201000a1701150042014102047e4201420205420342041a0b1a1a0b");
-    parse(wasm);
-    // TODO: Add max stack height check.
+    const auto module = parse(wasm);
+    EXPECT_EQ(module.codesec[0].max_stack_height, 3);
 }
 
 TEST(validation_stack, if_with_unreachable)


### PR DESCRIPTION
This aggregates the information about stack height in each frame in a function to compute the max function's stack height. This value will be used to preallocate storage for operand stack for execution.