### PR TITLE
ci: Run sanitizers job on macos / ugrade to XCode 11.5.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ executors:
       - image: ethereum/cpp-build-env:14-clang-10
   macos:
     macos:
-      xcode: 11.3.0
+      xcode: 11.5.0
 
 commands:
   description: "Install macOS system dependencies"

--- a/circle.yml
+++ b/circle.yml
@@ -20,6 +20,13 @@ executors:
       xcode: 11.3.0
 
 commands:
+  description: "Install macOS system dependencies"
+  install_macos_deps:
+    steps:
+      - run:
+          name: "Install system dependencies"
+          command: HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install cmake ninja
+
   build:
     description: "Build"
     parameters:
@@ -197,9 +204,7 @@ jobs:
     environment:
       BUILD_TYPE: Release
     steps:
-      - run:
-          name: "Install System Dependencies"
-          command: HOMEBREW_NO_AUTO_UPDATE=1 brew install cmake ninja
+      - install_macos_deps
       - checkout
       - build
       - test
@@ -257,6 +262,24 @@ jobs:
       CMAKE_OPTIONS: -DENABLE_ASSERTIONS=ON -DSANITIZE=address,undefined,nullability,implicit-unsigned-integer-truncation,implicit-signed-integer-truncation
       UBSAN_OPTIONS: halt_on_error=1
     steps:
+      - checkout
+      - build
+      - test
+      - benchmark:
+          min_time: "0.01"
+      - spectest:
+          expected_passed: 4807
+          expected_failed: 625
+          expected_skipped: 6381
+
+  sanitizers-macos:
+    executor: macos
+    environment:
+      BUILD_TYPE: RelWithDebInfo
+      CMAKE_OPTIONS: -DENABLE_ASSERTIONS=ON -DSANITIZE=address,undefined,nullability,implicit-unsigned-integer-truncation,implicit-signed-integer-truncation
+      UBSAN_OPTIONS: halt_on_error=1
+    steps:
+      - install_macos_deps
       - checkout
       - build
       - test
@@ -374,6 +397,7 @@ workflows:
       - release-macos
       - coverage-tidy
       - sanitizers
+      - sanitizers-macos
       - fuzzing
       - spectest:
           requires:


### PR DESCRIPTION
This is valuable because this tests usage of `libc++` standard library.