### PR TITLE
test: also test instantiate with parser errors in wasm_engine_test

### DIFF
--- a/test/unittests/wasm_engine_test.cpp
+++ b/test/unittests/wasm_engine_test.cpp
@@ -21,6 +21,8 @@ TEST(wasm_engine, parse_error)
     {
         auto engine = engine_create_fn();
         ASSERT_FALSE(engine->parse(wasm));
+        // Instantiate also performs parsing first.
+        ASSERT_FALSE(engine->instantiate(wasm));
     }
 }
 


### PR DESCRIPTION
This was missed in 287e51c.