### PR TITLE
validation: use correct function arity in stack height validation

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -269,8 +269,8 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 4807
-          expected_failed: 625
+          expected_passed: 4852
+          expected_failed: 580
           expected_skipped: 6381
 
   sanitizers-macos:
@@ -287,8 +287,8 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 4807
-          expected_failed: 625
+          expected_passed: 4852
+          expected_failed: 580
           expected_skipped: 6381
 
   benchmark:
@@ -398,8 +398,8 @@ jobs:
           expected_failed: 8
           expected_skipped: 7323
       - spectest:
-          expected_passed: 4807
-          expected_failed: 625
+          expected_passed: 4852
+          expected_failed: 580
           expected_skipped: 6381
 
 workflows:

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -339,13 +339,13 @@ inline parser_result<code_view> parse(const uint8_t* pos, const uint8_t* end)
     return {{code_begin, code_size}, code_end};
 }
 
-inline Code parse_code(code_view code_binary, const Module& module)
+inline Code parse_code(code_view code_binary, FuncIdx func_idx, const Module& module)
 {
     const auto begin = code_binary.begin();
     const auto end = code_binary.end();
     const auto [locals_vec, pos1] = parse_vec<Locals>(begin, end);
 
-    auto [code, pos2] = parse_expr(pos1, end, module);
+    auto [code, pos2] = parse_expr(pos1, end, func_idx, module);
 
     // Size is the total bytes of locals and expressions.
     if (pos2 != end)
@@ -538,10 +538,7 @@ Module parse(bytes_view input)
     // Process code. TODO: This can be done lazily.
     module.codesec.reserve(code_binaries.size());
     for (size_t i = 0; i < code_binaries.size(); ++i)
-    {
-        assert(module.funcsec[i] < module.typesec.size());
-        module.codesec.emplace_back(parse_code(code_binaries[i], module));
-    }
+        module.codesec.emplace_back(parse_code(code_binaries[i], static_cast<FuncIdx>(i), module));
 
     return module;
 }

--- a/lib/fizzy/parser.hpp
+++ b/lib/fizzy/parser.hpp
@@ -40,8 +40,10 @@ inline parser_result<uint8_t> parse_byte(const uint8_t* pos, const uint8_t* end)
 ///
 /// @param input    The beginning of the expr binary input.
 /// @param end      The end of the binary input.
+/// @param func_idx Index of the function being parsed.
 /// @param module   Module that this code is part of.
-parser_result<Code> parse_expr(const uint8_t* input, const uint8_t* end, const Module& module);
+parser_result<Code> parse_expr(
+    const uint8_t* input, const uint8_t* end, FuncIdx func_idx, const Module& module);
 
 parser_result<std::string> parse_string(const uint8_t* pos, const uint8_t* end);
 


### PR DESCRIPTION
Required for #312 

Resolves one TODO in `parse_expr` and 45 validation spec tests (must be the tests checking if function stack has enough results at the end of execution)