### PR TITLE
Split args and locals

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -489,6 +489,12 @@ std::optional<uint32_t> find_export(const Module& module, ExternalKind kind, std
     return (it != module.exportsec.end() ? std::make_optional(it->index) : std::nullopt);
 }
 
+inline uint64_t& get_local(std::vector<uint64_t>& locals, uint32_t idx) noexcept
+{
+    assert(idx <= locals.size());
+    return locals[idx];
+}
+
 }  // namespace
 
 std::unique_ptr<Instance> instantiate(Module module,
@@ -842,23 +848,17 @@ execution_result execute(
         }
         case Instr::local_get:
         {
-            const auto idx = read<uint32_t>(immediates);
-            assert(idx <= locals.size());
-            stack.push(locals[idx]);
+            stack.push(get_local(locals, read<uint32_t>(immediates)));
             break;
         }
         case Instr::local_set:
         {
-            const auto idx = read<uint32_t>(immediates);
-            assert(idx <= locals.size());
-            locals[idx] = stack.pop();
+            get_local(locals, read<uint32_t>(immediates)) = stack.pop();
             break;
         }
         case Instr::local_tee:
         {
-            const auto idx = read<uint32_t>(immediates);
-            assert(idx <= locals.size());
-            locals[idx] = stack.top();
+            get_local(locals, read<uint32_t>(immediates)) = stack.top();
             break;
         }
         case Instr::global_get:


### PR DESCRIPTION
This is preliminary step for opening two optimization directions:
1. Optimizing "calling convention" by not copying calls' args around.
2. Combining allocation for stack and locals + small stack optimization.

This change is a big execution time regression.
```
fizzy/execute/blake2b/512_bytes_rounds_1_mean                     +0.0803         +0.0802            85            92            85            92                       
fizzy/execute/blake2b/512_bytes_rounds_16_mean                    +0.0979         +0.0979          1263          1387          1264          1387                       
fizzy/execute/ecpairing/onepoint_mean                             +0.0804         +0.0804        484863        523864        484865        523866                       
fizzy/execute/keccak256/512_bytes_rounds_1_mean                   -0.0504         -0.0504           107           102           107           102                       
fizzy/execute/keccak256/512_bytes_rounds_16_mean                  -0.0290         -0.0290          1540          1496          1540          1496                       
fizzy/execute/memset/256_bytes_mean                               +0.1068         +0.1067             8             9             8             9                       
fizzy/execute/memset/60000_bytes_mean                             +0.1202         +0.1202          1587          1778          1587          1778                       
fizzy/execute/mul256_opt0/input0_mean                             +0.1167         +0.1165            28            32            28            32                       
fizzy/execute/mul256_opt0/input1_mean                             +0.1173         +0.1171            28            32            28            32                       
fizzy/execute/sha1/512_bytes_rounds_1_mean                        +0.1152         +0.1151            89            99            89            99                       
fizzy/execute/sha1/512_bytes_rounds_16_mean                       +0.1332         +0.1332          1223          1385          1223          1385                       
fizzy/execute/sha256/512_bytes_rounds_1_mean                      +0.0330         +0.0330            86            88            86            88                       
fizzy/execute/sha256/512_bytes_rounds_16_mean                     +0.0382         +0.0382          1153          1198          1153          1198                       
fizzy/execute/micro/factorial/10_mean                             +0.0075         +0.0069             1             1             1             1                       
fizzy/execute/micro/factorial/20_mean                             +0.0029         +0.0019             2             2             2             2                       
fizzy/execute/micro/fibonacci/24_mean                             -0.0017         -0.0017         14541         14517         14542         14517                       
fizzy/execute/micro/host_adler32/1_mean                           -0.0084         -0.0094             1             1             1             1                       
fizzy/execute/micro/host_adler32/100_mean                         -0.0083         -0.0085             7             7             7             7                       
fizzy/execute/micro/host_adler32/1000_mean                        -0.0083         -0.0084            66            65            66            65                       
fizzy/execute/micro/spinner/1_mean                                -0.0027         -0.0036             0             0             0             0                       
fizzy/execute/micro/spinner/1000_mean                             +0.0595         +0.0598            11            12            11            12
```