### PR TITLE
wasm3: add patch for better start function support

### DIFF
--- a/cmake/wasm3_03_startfunc.patch
+++ b/cmake/wasm3_03_startfunc.patch
@@ -1,0 +1,20 @@
+diff --git a/source/m3_env.c b/source/m3_env.c
+index 9292006..73628f4 100644
+--- a/source/m3_env.c
++++ b/source/m3_env.c
+@@ -638,7 +638,14 @@ M3Result  InitStartFunc  (IM3Module io_module)
+ _           (Compile_Function (function));
+         }
+ 
+-_       (m3_Call(function));
++        IM3FuncType ftype = function->funcType;
++        if (ftype->numArgs != 0 || ftype->returnType != c_m3Type_none)
++            _throw (m3Err_argumentCountMismatch);
++
++        IM3Module module = function->module;
++        IM3Runtime runtime = module->runtime;
++
++_       ((M3Result) Call (function->compiled, runtime->stack, runtime->memory.mallocated, d_m3OpDefaultArgs));
+     }
+ 
+     _catch: return result;


### PR DESCRIPTION
Includes https://github.com/wasm3/wasm3/pull/145 in our patchset.

The main benefit is we don't get hundreds of lines of `Result: <Empty Stack>` displayed by fizzy-bench.

We have a test case for this, `wasm_engine/start_func`, which seems to work.