### PR TITLE
Single arity immediate per br_table instruction

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -241,7 +241,7 @@ inline T read(const uint8_t*& input) noexcept
 }
 
 void branch(const Code& code, OperandStack& stack, const Instr*& pc, const uint8_t*& immediates,
-    uint8_t arity) noexcept
+    uint32_t arity) noexcept
 {
     const auto code_offset = read<uint32_t>(immediates);
     const auto imm_offset = read<uint32_t>(immediates);
@@ -669,7 +669,7 @@ ExecutionResult execute(Instance& instance, FuncIdx func_idx, span<const uint64_
         case Instr::br_if:
         case Instr::return_:
         {
-            const auto arity = read<uint8_t>(immediates);
+            const auto arity = read<uint32_t>(immediates);
 
             // Check condition for br_if.
             if (instruction == Instr::br_if && static_cast<uint32_t>(stack.pop()) == 0)
@@ -684,7 +684,7 @@ ExecutionResult execute(Instance& instance, FuncIdx func_idx, span<const uint64_
         case Instr::br_table:
         {
             const auto br_table_size = read<uint32_t>(immediates);
-            const auto arity = read<uint8_t>(immediates);
+            const auto arity = read<uint32_t>(immediates);
 
             const auto br_table_idx = stack.pop();
 

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -243,10 +243,10 @@ inline T read(const uint8_t*& input) noexcept
 void branch(
     const Code& code, OperandStack& stack, const Instr*& pc, const uint8_t*& immediates) noexcept
 {
+    const auto arity = read<uint8_t>(immediates);
     const auto code_offset = read<uint32_t>(immediates);
     const auto imm_offset = read<uint32_t>(immediates);
     const auto stack_drop = read<uint32_t>(immediates);
-    const auto arity = read<uint8_t>(immediates);
 
     pc = code.instructions.data() + code_offset;
     immediates = code.immediates.data() + imm_offset;

--- a/lib/fizzy/parser_expr.cpp
+++ b/lib/fizzy/parser_expr.cpp
@@ -204,6 +204,8 @@ inline void update_branch_stack(const ControlFrame& current_frame, const Control
 
 void push_branch_immediates(const ControlFrame& branch_frame, int stack_height, bytes& immediates)
 {
+    push(immediates, get_branch_arity(branch_frame));  // arity is uint8_t
+
     // How many stack items to drop when taking the branch.
     const auto stack_drop = stack_height - branch_frame.parent_stack_height;
 
@@ -212,7 +214,6 @@ void push_branch_immediates(const ControlFrame& branch_frame, int stack_height, 
     push(immediates, static_cast<uint32_t>(branch_frame.code_offset));
     push(immediates, static_cast<uint32_t>(branch_frame.immediates_offset));
     push(immediates, static_cast<uint32_t>(stack_drop));
-    push(immediates, get_branch_arity(branch_frame));  // arity is uint8_t
 }
 
 inline void mark_frame_unreachable(
@@ -569,7 +570,7 @@ parser_result<Code> parse_expr(const uint8_t* pos, const uint8_t* end, FuncIdx f
                 // Fill in immediates all br/br_table instructions jumping out of this block.
                 for (const auto br_imm_offset : frame.br_immediate_offsets)
                 {
-                    auto* br_imm = code.immediates.data() + br_imm_offset;
+                    auto* br_imm = code.immediates.data() + br_imm_offset + sizeof(uint8_t);
                     store(br_imm, static_cast<uint32_t>(target_pc));
                     br_imm += sizeof(uint32_t);
                     store(br_imm, static_cast<uint32_t>(target_imm));

--- a/lib/fizzy/parser_expr.cpp
+++ b/lib/fizzy/parser_expr.cpp
@@ -187,7 +187,7 @@ inline std::optional<ValType> get_branch_frame_type(const ControlFrame& frame) n
     return frame.instruction == Instr::loop ? std::nullopt : frame.type;
 }
 
-inline uint8_t get_branch_arity(const ControlFrame& frame) noexcept
+inline uint32_t get_branch_arity(const ControlFrame& frame) noexcept
 {
     return get_branch_frame_type(frame).has_value() ? 1 : 0;
 }

--- a/test/unittests/parser_expr_test.cpp
+++ b/test/unittests/parser_expr_test.cpp
@@ -351,38 +351,35 @@ TEST(parser_expr, instr_br_table)
 
     // 1 local_get before br_table
     const auto br_table_imm_offset = 4;
-    // br_imm_size = 13
-    // br_0_offset = br_table_imm_offset + 4 + br_imm_size * 5 + 4 + br_imm_size = 86 = 0x5a
-    // br_1_offset = br_0_offset + 4 + br_imm_size = 0x6b
-    // br_2_offset = br_1_offset + 4 + br_imm_size = 0x7c
-    // br_3_offset = br_2_offset + 4 + br_imm_size = 0x8d
-    // br_4_offset = br_3_offset + 4 + br_imm_size = 0x9e
+    // br_imm_size = 12
+    // return_imm_size = br_imm_size + arity_size = 13
+    // br_0_offset = br_table_imm_offset + 4 + 1 + br_imm_size * 5 + 4 + return_imm_size = 86 = 0x56
+    // br_1_offset = br_0_offset + 4 + return_imm_size = 0x67
+    // br_2_offset = br_1_offset + 4 + return_imm_size = 0x78
+    // br_3_offset = br_2_offset + 4 + return_imm_size = 0x89
+    // br_4_offset = br_3_offset + 4 + return_imm_size = 0x9a
     const auto expected_br_imm =
         "04000000"  // label_count
-
         "00"        // arity
+
         "13000000"  // code_offset
-        "8d000000"  // imm_offset
+        "89000000"  // imm_offset
         "00000000"  // stack_drop
 
-        "00"        // arity
         "10000000"  // code_offset
-        "7c000000"  // imm_offset
+        "78000000"  // imm_offset
         "00000000"  // stack_drop
 
-        "00"        // arity
         "0d000000"  // code_offset
-        "6b000000"  // imm_offset
+        "67000000"  // imm_offset
         "00000000"  // stack_drop
 
-        "00"        // arity
         "0a000000"  // code_offset
-        "5a000000"  // imm_offset
+        "56000000"  // imm_offset
         "00000000"  // stack_drop
 
-        "00"               // arity
         "16000000"         // code_offset
-        "9e000000"         // imm_offset
+        "9a000000"         // imm_offset
         "00000000"_bytes;  // stack_drop
 
     EXPECT_EQ(code.immediates.substr(br_table_imm_offset, expected_br_imm.size()), expected_br_imm);

--- a/test/unittests/parser_expr_test.cpp
+++ b/test/unittests/parser_expr_test.cpp
@@ -122,11 +122,11 @@ TEST(parser_expr, loop_br)
         (std::vector{
             Instr::i32_const, Instr::loop, Instr::br, Instr::end, Instr::drop, Instr::end}));
     EXPECT_EQ(module_parent_stack.codesec[0].immediates,
-        "00000000"    // i32.const
-        "01000000"    // code_offset
-        "04000000"    // imm_offset
-        "00000000"    // stack_drop
-        "00"_bytes);  // arity
+        "00000000"          // i32.const
+        "00"                // arity
+        "01000000"          // code_offset
+        "04000000"          // imm_offset
+        "00000000"_bytes);  // stack_drop
 
     /* wat2wasm
     (func
@@ -145,11 +145,11 @@ TEST(parser_expr, loop_br)
         module_arity.codesec[0].instructions, (std::vector{Instr::loop, Instr::i32_const, Instr::br,
                                                   Instr::end, Instr::drop, Instr::end}));
     EXPECT_EQ(module_arity.codesec[0].immediates,
-        "00000000"    // i32.const
-        "00000000"    // code_offset
-        "00000000"    // imm_offset
-        "01000000"    // stack_drop
-        "00"_bytes);  // arity - always 0 for loop
+        "00000000"          // i32.const
+        "00"                // arity - always 0 for loop
+        "00000000"          // code_offset
+        "00000000"          // imm_offset
+        "01000000"_bytes);  // stack_drop
 }
 
 TEST(parser_expr, loop_return)
@@ -163,10 +163,10 @@ TEST(parser_expr, loop_return)
     EXPECT_EQ(module.codesec[0].instructions,
         (std::vector{Instr::loop, Instr::return_, Instr::end, Instr::end}));
     EXPECT_EQ(module.codesec[0].immediates,
-        "03000000"    // code_offset
-        "0d000000"    // imm_offset
-        "00000000"    // stack_drop
-        "00"_bytes);  // arity
+        "00"                // arity
+        "03000000"          // code_offset
+        "0d000000"          // imm_offset
+        "00000000"_bytes);  // stack_drop
 }
 
 TEST(parser_expr, block_br)
@@ -192,10 +192,10 @@ TEST(parser_expr, block_br)
     EXPECT_EQ(code.immediates,
         "0a000000"
         "01000000"
+        "00"        // arity
         "08000000"  // code_offset
         "1d000000"  // imm_offset
         "00000000"  // stack_drop
-        "00"        // arity
         "0b000000"
         "01000000"
         "01000000"_bytes);
@@ -216,11 +216,11 @@ TEST(parser_expr, block_br)
         (std::vector{
             Instr::i32_const, Instr::block, Instr::br, Instr::end, Instr::drop, Instr::end}));
     EXPECT_EQ(module_parent_stack.codesec[0].immediates,
-        "00000000"    // i32.const
-        "04000000"    // code_offset
-        "11000000"    // imm_offset
-        "00000000"    // stack_drop
-        "00"_bytes);  // arity
+        "00000000"          // i32.const
+        "00"                // arity
+        "04000000"          // code_offset
+        "11000000"          // imm_offset
+        "00000000"_bytes);  // stack_drop
 
     /* wat2wasm
     (func
@@ -239,11 +239,11 @@ TEST(parser_expr, block_br)
         module_arity.codesec[0].instructions, (std::vector{Instr::block, Instr::i32_const,
                                                   Instr::br, Instr::end, Instr::drop, Instr::end}));
     EXPECT_EQ(module_arity.codesec[0].immediates,
-        "00000000"  // i32.const
-        "04000000"  // code_offset
-        "11000000"  // imm_offset
-        "00000000"  // stack_drop
-        "01"_bytes);
+        "00000000"          // i32.const
+        "01"                // arity
+        "04000000"          // code_offset
+        "11000000"          // imm_offset
+        "00000000"_bytes);  // stack_drop
 }
 
 TEST(parser_expr, block_return)
@@ -257,10 +257,10 @@ TEST(parser_expr, block_return)
     EXPECT_EQ(module.codesec[0].instructions,
         (std::vector{Instr::block, Instr::return_, Instr::end, Instr::end}));
     EXPECT_EQ(module.codesec[0].immediates,
-        "03000000"    // code_offset
-        "0d000000"    // imm_offset
-        "00000000"    // stack_drop
-        "00"_bytes);  // arity
+        "00"                // arity
+        "03000000"          // code_offset
+        "0d000000"          // imm_offset
+        "00000000"_bytes);  // stack_drop
 }
 
 TEST(parser_expr, if_br)
@@ -277,13 +277,13 @@ TEST(parser_expr, if_br)
     EXPECT_EQ(module.codesec[0].instructions,
         (std::vector{Instr::i32_const, Instr::if_, Instr::br, Instr::end, Instr::end}));
     EXPECT_EQ(module.codesec[0].immediates,
-        "00000000"    // i32.const
-        "04000000"    // else code offset
-        "19000000"    // else imm offset
-        "04000000"    // code_offset
-        "19000000"    // imm_offset
-        "00000000"    // stack_drop
-        "00"_bytes);  // arity
+        "00000000"          // i32.const
+        "04000000"          // else code offset
+        "19000000"          // else imm offset
+        "00"                // arity
+        "04000000"          // code_offset
+        "19000000"          // imm_offset
+        "00000000"_bytes);  // stack_drop
 
     /* wat2wasm
     (func
@@ -301,14 +301,14 @@ TEST(parser_expr, if_br)
         (std::vector{Instr::i32_const, Instr::i32_const, Instr::if_, Instr::br, Instr::end,
             Instr::drop, Instr::end}));
     EXPECT_EQ(module_parent_stack.codesec[0].immediates,
-        "00000000"    // i32.const
-        "00000000"    // i32.const
-        "05000000"    // else code offset
-        "1d000000"    // else imm offset
-        "05000000"    // code_offset
-        "1d000000"    // imm_offset
-        "00000000"    // stack_drop
-        "00"_bytes);  // arity
+        "00000000"          // i32.const
+        "00000000"          // i32.const
+        "05000000"          // else code offset
+        "1d000000"          // else imm offset
+        "00"                // arity
+        "05000000"          // code_offset
+        "1d000000"          // imm_offset
+        "00000000"_bytes);  // stack_drop
 }
 
 TEST(parser_expr, instr_br_table)
@@ -360,30 +360,30 @@ TEST(parser_expr, instr_br_table)
     const auto expected_br_imm =
         "04000000"  // label_count
 
+        "00"        // arity
         "13000000"  // code_offset
         "8d000000"  // imm_offset
         "00000000"  // stack_drop
-        "00"        // arity
 
+        "00"        // arity
         "10000000"  // code_offset
         "7c000000"  // imm_offset
         "00000000"  // stack_drop
-        "00"        // arity
 
+        "00"        // arity
         "0d000000"  // code_offset
         "6b000000"  // imm_offset
         "00000000"  // stack_drop
-        "00"        // arity
 
+        "00"        // arity
         "0a000000"  // code_offset
         "5a000000"  // imm_offset
         "00000000"  // stack_drop
-        "00"        // arity
 
-        "16000000"   // code_offset
-        "9e000000"   // imm_offset
-        "00000000"   // stack_drop
-        "00"_bytes;  // arity
+        "00"               // arity
+        "16000000"         // code_offset
+        "9e000000"         // imm_offset
+        "00000000"_bytes;  // stack_drop
 
     EXPECT_EQ(code.immediates.substr(br_table_imm_offset, expected_br_imm.size()), expected_br_imm);
     EXPECT_EQ(code.max_stack_height, 1);
@@ -414,11 +414,11 @@ TEST(parser_expr, instr_br_table_empty_vector)
     // local_get before br_table
     const auto br_table_imm_offset = 4;
     const auto expected_br_imm =
-        "00000000"   // label_count
-        "06000000"   // code_offset
-        "26000000"   // imm_offset
-        "00000000"   // stack_drop
-        "00"_bytes;  // arity
+        "00000000"         // label_count
+        "00"               // arity
+        "06000000"         // code_offset
+        "26000000"         // imm_offset
+        "00000000"_bytes;  // stack_drop
     EXPECT_EQ(code.immediates.substr(br_table_imm_offset, expected_br_imm.size()), expected_br_imm);
     EXPECT_EQ(code.max_stack_height, 1);
 }

--- a/test/unittests/parser_expr_test.cpp
+++ b/test/unittests/parser_expr_test.cpp
@@ -102,10 +102,10 @@ TEST(parser_expr, loop_br)
     EXPECT_EQ(module.codesec[0].instructions,
         (std::vector{Instr::loop, Instr::br, Instr::end, Instr::end}));
     EXPECT_EQ(module.codesec[0].immediates,
-        "00000000"    // code_offset
-        "00000000"    // imm_offset
-        "00000000"    // stack_drop
-        "00"_bytes);  // arity
+        "00000000"          // code_offset
+        "00000000"          // imm_offset
+        "00000000"          // stack_drop
+        "00000000"_bytes);  // arity
 
     /* wat2wasm
     (func
@@ -123,7 +123,7 @@ TEST(parser_expr, loop_br)
             Instr::i32_const, Instr::loop, Instr::br, Instr::end, Instr::drop, Instr::end}));
     EXPECT_EQ(module_parent_stack.codesec[0].immediates,
         "00000000"          // i32.const
-        "00"                // arity
+        "00000000"          // arity
         "01000000"          // code_offset
         "04000000"          // imm_offset
         "00000000"_bytes);  // stack_drop
@@ -146,7 +146,7 @@ TEST(parser_expr, loop_br)
                                                   Instr::end, Instr::drop, Instr::end}));
     EXPECT_EQ(module_arity.codesec[0].immediates,
         "00000000"          // i32.const
-        "00"                // arity - always 0 for loop
+        "00000000"          // arity - always 0 for loop
         "00000000"          // code_offset
         "00000000"          // imm_offset
         "01000000"_bytes);  // stack_drop
@@ -163,9 +163,9 @@ TEST(parser_expr, loop_return)
     EXPECT_EQ(module.codesec[0].instructions,
         (std::vector{Instr::loop, Instr::return_, Instr::end, Instr::end}));
     EXPECT_EQ(module.codesec[0].immediates,
-        "00"                // arity
+        "00000000"          // arity
         "03000000"          // code_offset
-        "0d000000"          // imm_offset
+        "10000000"          // imm_offset
         "00000000"_bytes);  // stack_drop
 }
 
@@ -192,9 +192,9 @@ TEST(parser_expr, block_br)
     EXPECT_EQ(code.immediates,
         "0a000000"
         "01000000"
-        "00"        // arity
+        "00000000"  // arity
         "08000000"  // code_offset
-        "1d000000"  // imm_offset
+        "20000000"  // imm_offset
         "00000000"  // stack_drop
         "0b000000"
         "01000000"
@@ -217,9 +217,9 @@ TEST(parser_expr, block_br)
             Instr::i32_const, Instr::block, Instr::br, Instr::end, Instr::drop, Instr::end}));
     EXPECT_EQ(module_parent_stack.codesec[0].immediates,
         "00000000"          // i32.const
-        "00"                // arity
+        "00000000"          // arity
         "04000000"          // code_offset
-        "11000000"          // imm_offset
+        "14000000"          // imm_offset
         "00000000"_bytes);  // stack_drop
 
     /* wat2wasm
@@ -240,9 +240,9 @@ TEST(parser_expr, block_br)
                                                   Instr::br, Instr::end, Instr::drop, Instr::end}));
     EXPECT_EQ(module_arity.codesec[0].immediates,
         "00000000"          // i32.const
-        "01"                // arity
+        "01000000"          // arity
         "04000000"          // code_offset
-        "11000000"          // imm_offset
+        "14000000"          // imm_offset
         "00000000"_bytes);  // stack_drop
 }
 
@@ -257,9 +257,9 @@ TEST(parser_expr, block_return)
     EXPECT_EQ(module.codesec[0].instructions,
         (std::vector{Instr::block, Instr::return_, Instr::end, Instr::end}));
     EXPECT_EQ(module.codesec[0].immediates,
-        "00"                // arity
+        "00000000"          // arity
         "03000000"          // code_offset
-        "0d000000"          // imm_offset
+        "10000000"          // imm_offset
         "00000000"_bytes);  // stack_drop
 }
 
@@ -279,10 +279,10 @@ TEST(parser_expr, if_br)
     EXPECT_EQ(module.codesec[0].immediates,
         "00000000"          // i32.const
         "04000000"          // else code offset
-        "19000000"          // else imm offset
-        "00"                // arity
+        "1c000000"          // else imm offset
+        "00000000"          // arity
         "04000000"          // code_offset
-        "19000000"          // imm_offset
+        "1c000000"          // imm_offset
         "00000000"_bytes);  // stack_drop
 
     /* wat2wasm
@@ -304,10 +304,10 @@ TEST(parser_expr, if_br)
         "00000000"          // i32.const
         "00000000"          // i32.const
         "05000000"          // else code offset
-        "1d000000"          // else imm offset
-        "00"                // arity
+        "20000000"          // else imm offset
+        "00000000"          // arity
         "05000000"          // code_offset
-        "1d000000"          // imm_offset
+        "20000000"          // imm_offset
         "00000000"_bytes);  // stack_drop
 }
 
@@ -352,34 +352,34 @@ TEST(parser_expr, instr_br_table)
     // 1 local_get before br_table
     const auto br_table_imm_offset = 4;
     // br_imm_size = 12
-    // return_imm_size = br_imm_size + arity_size = 13
-    // br_0_offset = br_table_imm_offset + 4 + 1 + br_imm_size * 5 + 4 + return_imm_size = 86 = 0x56
-    // br_1_offset = br_0_offset + 4 + return_imm_size = 0x67
-    // br_2_offset = br_1_offset + 4 + return_imm_size = 0x78
-    // br_3_offset = br_2_offset + 4 + return_imm_size = 0x89
-    // br_4_offset = br_3_offset + 4 + return_imm_size = 0x9a
+    // return_imm_size = br_imm_size + arity_size = 16
+    // br_0_offset = br_table_imm_offset + 4 + 4 + br_imm_size * 5 + 4 + return_imm_size = 92 = 0x5c
+    // br_1_offset = br_0_offset + 4 + return_imm_size = 0x70
+    // br_2_offset = br_1_offset + 4 + return_imm_size = 0x84
+    // br_3_offset = br_2_offset + 4 + return_imm_size = 0x98
+    // br_4_offset = br_3_offset + 4 + return_imm_size = 0xac
     const auto expected_br_imm =
         "04000000"  // label_count
-        "00"        // arity
+        "00000000"  // arity
 
         "13000000"  // code_offset
-        "89000000"  // imm_offset
+        "98000000"  // imm_offset
         "00000000"  // stack_drop
 
         "10000000"  // code_offset
-        "78000000"  // imm_offset
+        "84000000"  // imm_offset
         "00000000"  // stack_drop
 
         "0d000000"  // code_offset
-        "67000000"  // imm_offset
+        "70000000"  // imm_offset
         "00000000"  // stack_drop
 
         "0a000000"  // code_offset
-        "56000000"  // imm_offset
+        "5c000000"  // imm_offset
         "00000000"  // stack_drop
 
         "16000000"         // code_offset
-        "9a000000"         // imm_offset
+        "ac000000"         // imm_offset
         "00000000"_bytes;  // stack_drop
 
     EXPECT_EQ(code.immediates.substr(br_table_imm_offset, expected_br_imm.size()), expected_br_imm);
@@ -412,9 +412,9 @@ TEST(parser_expr, instr_br_table_empty_vector)
     const auto br_table_imm_offset = 4;
     const auto expected_br_imm =
         "00000000"         // label_count
-        "00"               // arity
+        "00000000"         // arity
         "06000000"         // code_offset
-        "26000000"         // imm_offset
+        "2c000000"         // imm_offset
         "00000000"_bytes;  // stack_drop
     EXPECT_EQ(code.immediates.substr(br_table_imm_offset, expected_br_imm.size()), expected_br_imm);
     EXPECT_EQ(code.max_stack_height, 1);


### PR DESCRIPTION
Get rid of duplicated arity in `br_table` immediates.