### PR TITLE
refactor: move FuncType comparisons operators to types.hpp

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -19,16 +19,6 @@ namespace
 // code_offset + imm_offset + stack_height + arity
 constexpr auto BranchImmediateSize = 3 * sizeof(uint32_t) + sizeof(uint8_t);
 
-inline bool operator==(const FuncType& lhs, const FuncType& rhs)
-{
-    return lhs.inputs == rhs.inputs && lhs.outputs == rhs.outputs;
-}
-
-inline bool operator!=(const FuncType& lhs, const FuncType& rhs)
-{
-    return !(lhs == rhs);
-}
-
 void match_imported_functions(const std::vector<FuncType>& module_imported_types,
     const std::vector<ExternalFunction>& imported_functions)
 {

--- a/lib/fizzy/types.hpp
+++ b/lib/fizzy/types.hpp
@@ -32,6 +32,16 @@ struct FuncType
     std::vector<ValType> outputs;
 };
 
+inline bool operator==(const FuncType& lhs, const FuncType& rhs) noexcept
+{
+    return lhs.inputs == rhs.inputs && lhs.outputs == rhs.outputs;
+}
+
+inline bool operator!=(const FuncType& lhs, const FuncType& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+
 // https://webassembly.github.io/spec/core/binary/types.html#binary-limits
 struct Limits
 {

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(
     parser_test.cpp
     stack_test.cpp
     test_utils_test.cpp
+    types_test.cpp
     utf8_test.cpp
     validation_stack_test.cpp
     validation_test.cpp

--- a/test/unittests/types_test.cpp
+++ b/test/unittests/types_test.cpp
@@ -1,0 +1,46 @@
+// Fizzy: A fast WebAssembly interpreter
+// Copyright 2019-2020 The Fizzy Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "types.hpp"
+#include <gtest/gtest.h>
+
+using namespace fizzy;
+using namespace testing;
+
+TEST(types, functype)
+{
+    const FuncType functype_v = {};
+    const FuncType functype_v_v = {};
+    const FuncType functype_i = {{ValType::i32}, {}};
+    const FuncType functype_ii = {{ValType::i32, ValType::i32}, {}};
+    const FuncType functype_I = {{ValType::i64}, {}};
+    const FuncType functype_i_i = {{ValType::i32}, {ValType::i32}};
+    const FuncType functype_i_ii = {{ValType::i32}, {ValType::i32, ValType::i32}};
+    const FuncType functype_ii_i = {{ValType::i32, ValType::i32}, {ValType::i32}};
+
+    EXPECT_TRUE(functype_v == functype_v);
+    EXPECT_TRUE(functype_v == functype_v_v);
+    EXPECT_FALSE(functype_v != functype_v);
+    EXPECT_FALSE(functype_v != functype_v_v);
+
+    EXPECT_FALSE(functype_v == functype_i);
+    EXPECT_FALSE(functype_i == functype_ii);
+    EXPECT_FALSE(functype_i == functype_i_i);
+    EXPECT_FALSE(functype_i == functype_i_ii);
+    EXPECT_FALSE(functype_i == functype_ii_i);
+    EXPECT_FALSE(functype_i == functype_I);
+    EXPECT_FALSE(functype_I == functype_i_i);
+    EXPECT_FALSE(functype_I == functype_i_ii);
+    EXPECT_FALSE(functype_I == functype_ii_i);
+
+    EXPECT_TRUE(functype_v != functype_i);
+    EXPECT_TRUE(functype_i != functype_ii);
+    EXPECT_TRUE(functype_i != functype_i_i);
+    EXPECT_TRUE(functype_i != functype_i_ii);
+    EXPECT_TRUE(functype_i != functype_ii_i);
+    EXPECT_TRUE(functype_i != functype_I);
+    EXPECT_TRUE(functype_I != functype_i_i);
+    EXPECT_TRUE(functype_I != functype_i_ii);
+    EXPECT_TRUE(functype_I != functype_ii_i);
+}


### PR DESCRIPTION
As requested by @gumb0 in #331.