### PR TITLE
Validate arity of labels in br_table

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -252,8 +252,8 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 4901
-          expected_failed: 531
+          expected_passed: 4903
+          expected_failed: 529
           expected_skipped: 6381
 
   sanitizers-macos:
@@ -270,8 +270,8 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 4901
-          expected_failed: 531
+          expected_passed: 4903
+          expected_failed: 529
           expected_skipped: 6381
 
   benchmark:
@@ -381,8 +381,8 @@ jobs:
           expected_failed: 8
           expected_skipped: 7323
       - spectest:
-          expected_passed: 4901
-          expected_failed: 531
+          expected_passed: 4903
+          expected_failed: 529
           expected_skipped: 6381
 
 workflows:


### PR DESCRIPTION
Required for #354.

There's a slight complication around loop's arity: turns out if there's loop in `br_table` labels, it's arity is considered always 0 (and then `br_table` is valid only if all labels have arity 0). 
It's difficult to find clear confirmation of this in the spec, but spec tests cover it in this case https://github.com/WebAssembly/spec/blob/636b862b9c8a25ad65fb240fefd673e7f23bcdd0/test/core/br_table.wast#L1229-L1244

  