### PR TITLE
Validate constant expressions for global/offsets initialization

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -252,8 +252,8 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 5106
-          expected_failed: 326
+          expected_passed: 5108
+          expected_failed: 324
           expected_skipped: 6381
 
   sanitizers-macos:
@@ -270,8 +270,8 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 5106
-          expected_failed: 326
+          expected_passed: 5108
+          expected_failed: 324
           expected_skipped: 6381
 
   benchmark:
@@ -381,8 +381,8 @@ jobs:
           expected_failed: 8
           expected_skipped: 7323
       - spectest:
-          expected_passed: 5106
-          expected_failed: 326
+          expected_passed: 5108
+          expected_failed: 324
           expected_skipped: 6381
 
 workflows:

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -489,14 +489,9 @@ std::unique_ptr<Instance> instantiate(Module module,
     globals.reserve(module.globalsec.size());
     for (auto const& global : module.globalsec)
     {
-        // Wasm spec section 3.3.7 constrains initialization by another global to const imports only
-        // https://webassembly.github.io/spec/core/valid/instructions.html#expressions
-        if (global.expression.kind == ConstantExpression::Kind::GlobalGet &&
-            global.expression.value.global_index >= imported_globals.size())
-        {
-            throw instantiate_error(
-                "global can be initialized by another const global only if it's imported");
-        }
+        // Constraint to use global.get only with imported globals is checked at validation.
+        assert(global.expression.kind != ConstantExpression::Kind::GlobalGet ||
+               global.expression.value.global_index < imported_globals.size());
 
         const auto value = eval_constant_expression(
             global.expression, imported_globals, module.globalsec, globals);

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -550,6 +550,9 @@ Module parse(bytes_view input)
     if (!module.elementsec.empty() && !module.has_table())
         throw validation_error("element section encountered without a table section");
 
+    for (const auto& element : module.elementsec)
+        validate_constant_expression(element.offset, module);
+
     const auto total_global_count = module.get_global_count();
     for (const auto& global : module.globalsec)
     {

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -535,6 +535,9 @@ Module parse(bytes_view input)
     if (!module.datasec.empty() && !module.has_memory())
         throw validation_error("data section encountered without a memory section");
 
+    for (const auto& data : module.datasec)
+        validate_constant_expression(data.offset, module);
+
     if (module.imported_table_types.size() > 1)
         throw validation_error{"too many imported tables (at most one is allowed)"};
 

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -12,6 +12,22 @@
 
 namespace fizzy
 {
+namespace
+{
+void validate_constant_expression(const ConstantExpression& const_expr, const Module& module)
+{
+    if (const_expr.kind == ConstantExpression::Kind::Constant)
+        return;
+
+    const auto global_idx = const_expr.value.global_index;
+    if (global_idx >= module.get_global_count())
+        throw validation_error{"invalid global index in constant expression"};
+
+    if (module.is_global_mutable(global_idx))
+        throw validation_error("constant expression can use global.get only for const globals");
+}
+}  // namespace
+
 template <typename T>
 parser_result<T> parse(const uint8_t* pos, const uint8_t* end);
 
@@ -531,11 +547,26 @@ Module parse(bytes_view input)
     if (!module.elementsec.empty() && !module.has_table())
         throw validation_error("element section encountered without a table section");
 
+    const auto total_global_count = module.get_global_count();
+    for (const auto& global : module.globalsec)
+    {
+        validate_constant_expression(global.expression, module);
+
+        // Wasm spec section 3.3.7 constrains initialization by another global to const imports only
+        // https://webassembly.github.io/spec/core/valid/instructions.html#expressions
+        if (global.expression.kind == ConstantExpression::Kind::GlobalGet &&
+            global.expression.value.global_index >= module.imported_globals_mutability.size())
+        {
+            throw validation_error(
+                "global can be initialized by another const global only if it's imported");
+        }
+    }
+
+
     if (module.funcsec.size() != code_binaries.size())
         throw parser_error("malformed binary: number of function and code entries must match");
 
     const auto total_func_count = module.get_function_count();
-    const auto total_global_count = module.get_global_count();
 
     // Validate exports.
     std::unordered_set<std::string_view> export_names;

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -656,14 +656,15 @@ TEST(instantiate, data_section_offset_from_imported_global)
 
 TEST(instantiate, data_section_offset_from_mutable_global)
 {
-    Module module;
-    module.memorysec.emplace_back(Memory{{1, 1}});
-    module.globalsec.emplace_back(Global{true, {ConstantExpression::Kind::Constant, {42}}});
-    // Memory contents: 0, 0xaa, 0xff, 0, ...
-    module.datasec.emplace_back(Data{{ConstantExpression::Kind::GlobalGet, {0}}, {0xaa, 0xff}});
+    /* wat2wasm --no-check
+      (global (mut i32) (i32.const 42))
+      (memory 1 1)
+      (data (global.get 0) "\aa\ff")
+    */
+    const auto bin = from_hex("0061736d010000000504010101010606017f01412a0b0b08010023000b02aaff");
 
-    EXPECT_THROW_MESSAGE(instantiate(module), instantiate_error,
-        "constant expression can use global_get only for const globals");
+    EXPECT_THROW_MESSAGE(parse(bin), validation_error,
+        "constant expression can use global.get only for const globals");
 }
 
 TEST(instantiate, data_section_offset_too_large)

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -830,25 +830,6 @@ TEST(instantiate, globals_initialized_from_imported)
 
     ASSERT_EQ(instance->globals.size(), 1);
     EXPECT_EQ(instance->globals[0], 42);
-
-    // initializing from mutable global is not allowed
-    /* wat2wasm --no-check
-      (global (import "mod" "g1") (mut i32))
-      (global (mut i32) (global.get 0))
-    */
-    const auto bin_invalid1 =
-        from_hex("0061736d01000000020b01036d6f64026731037f010606017f0123000b");
-    EXPECT_THROW_MESSAGE(parse(bin_invalid1), validation_error,
-        "constant expression can use global.get only for const globals");
-
-    // initializing from non-imported global is not allowed
-    /* wat2wasm --no-check
-      (global i32 (i32.const 42))
-      (global (mut i32) (global.get 0))
-    */
-    const auto bin_invalid2 = from_hex("0061736d01000000060b027f00412a0b7f0123000b");
-    EXPECT_THROW_MESSAGE(parse(bin_invalid2), validation_error,
-        "global can be initialized by another const global only if it's imported");
 }
 
 TEST(instantiate, start_unreachable)

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -525,15 +525,19 @@ TEST(instantiate, element_section_offset_from_imported_global)
 
 TEST(instantiate, element_section_offset_from_mutable_global)
 {
-    Module module;
-    module.tablesec.emplace_back(Table{{4, std::nullopt}});
-    module.globalsec.emplace_back(Global{true, {ConstantExpression::Kind::Constant, {42}}});
-    // Table contents: 0, 0xaa, 0xff, 0, ...
-    module.elementsec.emplace_back(
-        Element{{ConstantExpression::Kind::GlobalGet, {0}}, {0xaa, 0xff}});
+    /* wat2wasm --no-check
+      (global (mut i32) (i32.const 42))
+      (table 4 funcref)
+      (elem (global.get 0) 0 1)
+      (func)
+      (func)
+    */
+    const auto bin = from_hex(
+        "0061736d0100000001040160000003030200000404017000040606017f01412a0b0908010023000b0200010a07"
+        "0202000b02000b");
 
-    EXPECT_THROW_MESSAGE(instantiate(module), instantiate_error,
-        "constant expression can use global_get only for const globals");
+    EXPECT_THROW_MESSAGE(parse(bin), validation_error,
+        "constant expression can use global.get only for const globals");
 }
 
 TEST(instantiate, element_section_offset_too_large)

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -523,23 +523,6 @@ TEST(instantiate, element_section_offset_from_imported_global)
     EXPECT_FALSE((*instance->table)[3].has_value());
 }
 
-TEST(instantiate, element_section_offset_from_mutable_global)
-{
-    /* wat2wasm --no-check
-      (global (mut i32) (i32.const 42))
-      (table 4 funcref)
-      (elem (global.get 0) 0 1)
-      (func)
-      (func)
-    */
-    const auto bin = from_hex(
-        "0061736d0100000001040160000003030200000404017000040606017f01412a0b0908010023000b0200010a07"
-        "0202000b02000b");
-
-    EXPECT_THROW_MESSAGE(parse(bin), validation_error,
-        "constant expression can use global.get only for const globals");
-}
-
 TEST(instantiate, element_section_offset_too_large)
 {
     Module module;

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -838,12 +838,8 @@ TEST(instantiate, globals_initialized_from_imported)
     */
     const auto bin_invalid1 =
         from_hex("0061736d01000000020b01036d6f64026731037f010606017f0123000b");
-    const auto module_invalid1 = parse(bin_invalid1);
-
-    ExternalGlobal g_mutable{&global_value, true};
-
-    EXPECT_THROW_MESSAGE(instantiate(module_invalid1, {}, {}, {}, {g_mutable}), instantiate_error,
-        "constant expression can use global_get only for const globals");
+    EXPECT_THROW_MESSAGE(parse(bin_invalid1), validation_error,
+        "constant expression can use global.get only for const globals");
 
     // initializing from non-imported global is not allowed
     /* wat2wasm --no-check
@@ -851,9 +847,7 @@ TEST(instantiate, globals_initialized_from_imported)
       (global (mut i32) (global.get 0))
     */
     const auto bin_invalid2 = from_hex("0061736d01000000060b027f00412a0b7f0123000b");
-    const auto module_invalid2 = parse(bin_invalid2);
-
-    EXPECT_THROW_MESSAGE(instantiate(module_invalid2, {}, {}), instantiate_error,
+    EXPECT_THROW_MESSAGE(parse(bin_invalid2), validation_error,
         "global can be initialized by another const global only if it's imported");
 }
 

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -654,19 +654,6 @@ TEST(instantiate, data_section_offset_from_imported_global)
     EXPECT_EQ(instance->memory->substr(42, 2), "aaff"_bytes);
 }
 
-TEST(instantiate, data_section_offset_from_mutable_global)
-{
-    /* wat2wasm --no-check
-      (global (mut i32) (i32.const 42))
-      (memory 1 1)
-      (data (global.get 0) "\aa\ff")
-    */
-    const auto bin = from_hex("0061736d010000000504010101010606017f01412a0b0b08010023000b02aaff");
-
-    EXPECT_THROW_MESSAGE(parse(bin), validation_error,
-        "constant expression can use global.get only for const globals");
-}
-
 TEST(instantiate, data_section_offset_too_large)
 {
     Module module;

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -857,30 +857,38 @@ TEST(parser, element_section_empty)
 
 TEST(parser, element_section)
 {
-    const auto table_contents = bytes{0x01, 0x70, 0x00, 0x7f};
-    const auto element_contents = make_vec({bytes{0x00, 0x41, 0x01, 0x0b, 0x02, 0x7f, 0x7f},
-        bytes{0x00, 0x41, 0x02, 0x0b, 0x02, 0x55, 0x55},
-        bytes{0x00, 0x23, 0x00, 0x0b, 0x02, 0x24, 0x24}});
-    const auto bin =
-        bytes{wasm_prefix} + make_section(4, table_contents) + make_section(9, element_contents);
-
+    /* wat2wasm
+      (global (import "m" "g") i32)
+      (table 0 10 funcref)
+      (elem (i32.const 1) 0 1)
+      (elem (i32.const 2) 2 3)
+      (elem (global.get 0) 0 3)
+      (func)
+      (func)
+      (func)
+      (func)
+    */
+    const auto bin = from_hex(
+        "0061736d01000000010401600000020801016d0167037f00030504000000000405017001000a0916030041010b"
+        "0200010041020b0202030023000b0200030a0d0402000b02000b02000b02000b");
     const auto module = parse(bin);
+
     ASSERT_EQ(module.elementsec.size(), 3);
     EXPECT_EQ(module.elementsec[0].offset.kind, ConstantExpression::Kind::Constant);
     EXPECT_EQ(module.elementsec[0].offset.value.constant, 1);
     ASSERT_EQ(module.elementsec[0].init.size(), 2);
-    EXPECT_EQ(module.elementsec[0].init[0], 0x7f);
-    EXPECT_EQ(module.elementsec[0].init[1], 0x7f);
+    EXPECT_EQ(module.elementsec[0].init[0], 0);
+    EXPECT_EQ(module.elementsec[0].init[1], 1);
     EXPECT_EQ(module.elementsec[1].offset.kind, ConstantExpression::Kind::Constant);
     EXPECT_EQ(module.elementsec[1].offset.value.constant, 2);
     ASSERT_EQ(module.elementsec[1].init.size(), 2);
-    EXPECT_EQ(module.elementsec[1].init[0], 0x55);
-    EXPECT_EQ(module.elementsec[1].init[1], 0x55);
+    EXPECT_EQ(module.elementsec[1].init[0], 2);
+    EXPECT_EQ(module.elementsec[1].init[1], 3);
     EXPECT_EQ(module.elementsec[2].offset.kind, ConstantExpression::Kind::GlobalGet);
     EXPECT_EQ(module.elementsec[2].offset.value.global_index, 0);
     ASSERT_EQ(module.elementsec[2].init.size(), 2);
-    EXPECT_EQ(module.elementsec[2].init[0], 0x24);
-    EXPECT_EQ(module.elementsec[2].init[1], 0x24);
+    EXPECT_EQ(module.elementsec[2].init[0], 0);
+    EXPECT_EQ(module.elementsec[2].init[1], 3);
 }
 
 TEST(parser, element_section_tableidx_nonzero)

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -594,10 +594,15 @@ TEST(parser, global_single_mutable_const_inited)
 
 TEST(parser, global_single_const_global_inited)
 {
-    const auto section_contents = bytes{0x01, 0x7f, 0x00, uint8_t(Instr::global_get), 0x01, 0x0b};
-    const auto bin = bytes{wasm_prefix} + make_section(6, section_contents);
-
+    /* wat2wasm
+      (global (import "m" "g1") i32)
+      (global (import "m" "g2") i32)
+      (global i32 (global.get 1))
+    */
+    const auto bin =
+        from_hex("0061736d01000000021102016d026731037f00016d026732037f000606017f0023010b");
     const auto module = parse(bin);
+
     ASSERT_EQ(module.globalsec.size(), 1);
     EXPECT_FALSE(module.globalsec[0].is_mutable);
     EXPECT_EQ(module.globalsec[0].expression.kind, ConstantExpression::Kind::GlobalGet);

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -1257,12 +1257,18 @@ TEST(parser, data_section_empty)
 
 TEST(parser, data_section)
 {
-    const auto section_contents =
-        make_vec({"0041010b02aaff"_bytes, "0041020b025555"_bytes, "0023000b022424"_bytes});
-    const auto bin = bytes{wasm_prefix} + make_section(5, make_vec({"0000"_bytes})) +
-                     make_section(11, section_contents);
-
+    /* wat2wasm
+      (global (import "m" "g") i32)
+      (memory 0)
+      (data (i32.const 1) "\aa\ff")
+      (data (i32.const 2) "\55\55")
+      (data (global.get 0) "\24\24")
+    */
+    const auto bin = from_hex(
+        "0061736d01000000020801016d0167037f0005030100000b16030041010b02aaff0041020b0255550023000b02"
+        "2424");
     const auto module = parse(bin);
+
     ASSERT_EQ(module.datasec.size(), 3);
     EXPECT_EQ(module.datasec[0].offset.kind, ConstantExpression::Kind::Constant);
     EXPECT_EQ(module.datasec[0].offset.value.constant, 1);

--- a/test/unittests/validation_test.cpp
+++ b/test/unittests/validation_test.cpp
@@ -24,6 +24,28 @@ TEST(validation, imported_function_unknown_type)
         parse(wasm), validation_error, "invalid type index of an imported function");
 }
 
+TEST(validation, globals_invalid_initializer)
+{
+    // initializing from mutable global is not allowed
+    /* wat2wasm --no-check
+      (global (import "mod" "g1") (mut i32))
+      (global (mut i32) (global.get 0))
+    */
+    const auto bin_invalid1 =
+        from_hex("0061736d01000000020b01036d6f64026731037f010606017f0123000b");
+    EXPECT_THROW_MESSAGE(parse(bin_invalid1), validation_error,
+        "constant expression can use global.get only for const globals");
+
+    // initializing from non-imported global is not allowed
+    /* wat2wasm --no-check
+      (global i32 (i32.const 42))
+      (global (mut i32) (global.get 0))
+    */
+    const auto bin_invalid2 = from_hex("0061736d01000000060b027f00412a0b7f0123000b");
+    EXPECT_THROW_MESSAGE(parse(bin_invalid2), validation_error,
+        "global can be initialized by another const global only if it's imported");
+}
+
 TEST(validation, import_memories_multiple)
 {
     const auto section_contents =

--- a/test/unittests/validation_test.cpp
+++ b/test/unittests/validation_test.cpp
@@ -140,6 +140,23 @@ TEST(validation, data_section_invalid_offset_expression)
         "constant expression can use global.get only for const globals");
 }
 
+TEST(validation, element_section_offset_from_mutable_global)
+{
+    /* wat2wasm --no-check
+      (global (mut i32) (i32.const 42))
+      (table 4 funcref)
+      (elem (global.get 0) 0 1)
+      (func)
+      (func)
+    */
+    const auto bin = from_hex(
+        "0061736d0100000001040160000003030200000404017000040606017f01412a0b0908010023000b0200010a07"
+        "0202000b02000b");
+
+    EXPECT_THROW_MESSAGE(parse(bin), validation_error,
+        "constant expression can use global.get only for const globals");
+}
+
 TEST(validation, i32_store_no_memory)
 {
     /* wat2wasm --no-check

--- a/test/unittests/validation_test.cpp
+++ b/test/unittests/validation_test.cpp
@@ -140,8 +140,20 @@ TEST(validation, data_section_invalid_offset_expression)
         "constant expression can use global.get only for const globals");
 }
 
-TEST(validation, element_section_offset_from_mutable_global)
+TEST(validation, element_section_invalid_offset_expression)
 {
+    /* wat2wasm --no-check
+      (table 4 funcref)
+      (elem (global.get 0) 0 1)
+      (func)
+      (func)
+    */
+    const auto bin1 = from_hex(
+        "0061736d0100000001040160000003030200000404017000040908010023000b0200010a070202000b02000b");
+
+    EXPECT_THROW_MESSAGE(
+        parse(bin1), validation_error, "invalid global index in constant expression");
+
     /* wat2wasm --no-check
       (global (mut i32) (i32.const 42))
       (table 4 funcref)
@@ -149,11 +161,11 @@ TEST(validation, element_section_offset_from_mutable_global)
       (func)
       (func)
     */
-    const auto bin = from_hex(
+    const auto bin2 = from_hex(
         "0061736d0100000001040160000003030200000404017000040606017f01412a0b0908010023000b0200010a07"
         "0202000b02000b");
 
-    EXPECT_THROW_MESSAGE(parse(bin), validation_error,
+    EXPECT_THROW_MESSAGE(parse(bin2), validation_error,
         "constant expression can use global.get only for const globals");
 }
 

--- a/test/unittests/validation_test.cpp
+++ b/test/unittests/validation_test.cpp
@@ -26,14 +26,22 @@ TEST(validation, imported_function_unknown_type)
 
 TEST(validation, globals_invalid_initializer)
 {
+    // initializing from non-existing global
+    /* wat2wasm --no-check
+      (global i32 (global.get 1))
+    */
+    const auto bin_invalid1 = from_hex("0061736d010000000606017f0023010b");
+    EXPECT_THROW_MESSAGE(
+        parse(bin_invalid1), validation_error, "invalid global index in constant expression");
+
     // initializing from mutable global is not allowed
     /* wat2wasm --no-check
       (global (import "mod" "g1") (mut i32))
       (global (mut i32) (global.get 0))
     */
-    const auto bin_invalid1 =
+    const auto bin_invalid2 =
         from_hex("0061736d01000000020b01036d6f64026731037f010606017f0123000b");
-    EXPECT_THROW_MESSAGE(parse(bin_invalid1), validation_error,
+    EXPECT_THROW_MESSAGE(parse(bin_invalid2), validation_error,
         "constant expression can use global.get only for const globals");
 
     // initializing from non-imported global is not allowed
@@ -41,8 +49,8 @@ TEST(validation, globals_invalid_initializer)
       (global i32 (i32.const 42))
       (global (mut i32) (global.get 0))
     */
-    const auto bin_invalid2 = from_hex("0061736d01000000060b027f00412a0b7f0123000b");
-    EXPECT_THROW_MESSAGE(parse(bin_invalid2), validation_error,
+    const auto bin_invalid3 = from_hex("0061736d01000000060b027f00412a0b7f0123000b");
+    EXPECT_THROW_MESSAGE(parse(bin_invalid3), validation_error,
         "global can be initialized by another const global only if it's imported");
 }
 

--- a/test/unittests/validation_test.cpp
+++ b/test/unittests/validation_test.cpp
@@ -118,6 +118,19 @@ TEST(validation, table_multi_min_limit)
         parse(bin), validation_error, "too many table sections (at most one is allowed)");
 }
 
+TEST(validation, data_section_offset_from_mutable_global)
+{
+    /* wat2wasm --no-check
+      (global (mut i32) (i32.const 42))
+      (memory 1 1)
+      (data (global.get 0) "\aa\ff")
+    */
+    const auto bin = from_hex("0061736d010000000504010101010606017f01412a0b0b08010023000b02aaff");
+
+    EXPECT_THROW_MESSAGE(parse(bin), validation_error,
+        "constant expression can use global.get only for const globals");
+}
+
 TEST(validation, i32_store_no_memory)
 {
     /* wat2wasm --no-check

--- a/test/unittests/validation_test.cpp
+++ b/test/unittests/validation_test.cpp
@@ -118,16 +118,25 @@ TEST(validation, table_multi_min_limit)
         parse(bin), validation_error, "too many table sections (at most one is allowed)");
 }
 
-TEST(validation, data_section_offset_from_mutable_global)
+TEST(validation, data_section_invalid_offset_expression)
 {
+    /* wat2wasm --no-check
+      (memory 1 1)
+      (data (global.get 0) "\aa\ff")
+    */
+    const auto bin1 = from_hex("0061736d010000000504010101010b08010023000b02aaff");
+
+    EXPECT_THROW_MESSAGE(
+        parse(bin1), validation_error, "invalid global index in constant expression");
+
     /* wat2wasm --no-check
       (global (mut i32) (i32.const 42))
       (memory 1 1)
       (data (global.get 0) "\aa\ff")
     */
-    const auto bin = from_hex("0061736d010000000504010101010606017f01412a0b0b08010023000b02aaff");
+    const auto bin2 = from_hex("0061736d010000000504010101010606017f01412a0b0b08010023000b02aaff");
 
-    EXPECT_THROW_MESSAGE(parse(bin), validation_error,
+    EXPECT_THROW_MESSAGE(parse(bin2), validation_error,
         "constant expression can use global.get only for const globals");
 }
 


### PR DESCRIPTION
More validation for number of instructions in const expr will be added in #377 

I will squash test commits before merging.