### PR TITLE
Fix reading  parent stack height from branch instructions immediates

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -248,7 +248,7 @@ void branch(
 {
     const auto code_offset = read<uint32_t>(immediates);
     const auto imm_offset = read<uint32_t>(immediates);
-    const auto stack_height = static_cast<size_t>(read<int>(immediates));
+    const auto stack_height = static_cast<size_t>(read<uint32_t>(immediates));
     const auto arity = read<uint8_t>(immediates);
 
     pc = code.instructions.data() + code_offset;


### PR DESCRIPTION
It's pushed to immediates as `uint32_t`, and should be read with the same type. https://github.com/wasmx/fizzy/blob/5db0431404c7c35d58e5288626b931b182c500ac/lib/fizzy/parser_expr.cpp#L128