### PR TITLE
Use only uint32_t to immediates items

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -17,7 +17,7 @@ namespace fizzy
 namespace
 {
 // code_offset + imm_offset + stack_height + arity
-constexpr auto BranchImmediateSize = 3 * sizeof(uint32_t) + sizeof(uint8_t);
+constexpr auto BranchImmediateSize = 4 * sizeof(uint32_t);
 
 void match_imported_functions(const std::vector<FuncType>& module_imported_types,
     const std::vector<ExternalFunction>& imported_functions)
@@ -249,7 +249,7 @@ void branch(
     const auto code_offset = read<uint32_t>(immediates);
     const auto imm_offset = read<uint32_t>(immediates);
     const auto stack_height = static_cast<size_t>(read<uint32_t>(immediates));
-    const auto arity = read<uint8_t>(immediates);
+    const auto arity = read<uint32_t>(immediates);
 
     pc = code.instructions.data() + code_offset;
     immediates = code.immediates.data() + imm_offset;

--- a/lib/fizzy/parser_expr.cpp
+++ b/lib/fizzy/parser_expr.cpp
@@ -133,7 +133,7 @@ void push_branch_immediates(const ControlFrame& frame, bytes& immediates)
     push(immediates, static_cast<uint32_t>(frame.code_offset));
     push(immediates, static_cast<uint32_t>(frame.immediates_offset));
     push(immediates, static_cast<uint32_t>(frame.parent_stack_height));
-    push(immediates, get_branch_arity(frame));
+    push(immediates, uint32_t{get_branch_arity(frame)});
 }
 
 }  // namespace


### PR DESCRIPTION
```
fizzy/execute/blake2b/512_bytes_rounds_1_mean                     -0.0186         -0.0185            73            71            73            71
fizzy/execute/blake2b/512_bytes_rounds_16_mean                    -0.0174         -0.0174          1082          1064          1082          1064
fizzy/execute/ecpairing/onepoint_mean                             +0.0151         +0.0151        394324        400277        394326        400280
fizzy/execute/keccak256/512_bytes_rounds_1_mean                   +0.1255         +0.1255            84            94            84            94
fizzy/execute/keccak256/512_bytes_rounds_16_mean                  +0.1382         +0.1382          1197          1363          1197          1363
fizzy/execute/memset/256_bytes_mean                               -0.0338         -0.0335             6             6             6             6
fizzy/execute/memset/60000_bytes_mean                             -0.0439         -0.0439          1304          1247          1304          1247
fizzy/execute/mul256_opt0/input0_mean                             -0.0412         -0.0410            25            24            25            24
fizzy/execute/mul256_opt0/input1_mean                             -0.0397         -0.0395            25            24            25            24
fizzy/execute/sha1/512_bytes_rounds_1_mean                        -0.0118         -0.0117            80            79            80            79
fizzy/execute/sha1/512_bytes_rounds_16_mean                       -0.0133         -0.0133          1100          1085          1100          1086
fizzy/execute/sha256/512_bytes_rounds_1_mean                      -0.0022         -0.0021            75            75            75            75
fizzy/execute/sha256/512_bytes_rounds_16_mean                     -0.0022         -0.0022          1022          1020          1022          1020
fizzy/execute/micro/eli_interpreter/halt_mean                     -0.0021         -0.0019             0             0             0             0
fizzy/execute/micro/eli_interpreter/exec105_mean                  -0.0118         -0.0120             4             4             4             4
fizzy/execute/micro/factorial/10_mean                             -0.0035         -0.0030             1             1             1             1
fizzy/execute/micro/factorial/20_mean                             -0.0069         -0.0069             2             2             2             2
fizzy/execute/micro/fibonacci/24_mean                             -0.0059         -0.0059          9108          9054          9108          9054
fizzy/execute/micro/host_adler32/1_mean                           -0.0027         -0.0023             1             1             1             1
fizzy/execute/micro/host_adler32/100_mean                         +0.0058         +0.0060             6             6             6             6
fizzy/execute/micro/host_adler32/1000_mean                        +0.0017         +0.0018            58            59            58            59
fizzy/execute/micro/spinner/1_mean                                -0.0029         -0.0017             0             0             0             0
fizzy/execute/micro/spinner/1000_mean                             -0.0519         -0.0519             9             8             9             8
```