### PR TITLE
Validate number of instructions in constant expression

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -252,8 +252,8 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 5138
-          expected_failed: 294
+          expected_passed: 5140
+          expected_failed: 292
           expected_skipped: 6381
 
   sanitizers-macos:
@@ -270,8 +270,8 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 5138
-          expected_failed: 294
+          expected_passed: 5140
+          expected_failed: 292
           expected_skipped: 6381
 
   benchmark:
@@ -381,8 +381,8 @@ jobs:
           expected_failed: 9
           expected_skipped: 7323
       - spectest:
-          expected_passed: 5138
-          expected_failed: 294
+          expected_passed: 5140
+          expected_failed: 292
           expected_skipped: 6381
 
 workflows:

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -612,20 +612,6 @@ TEST(parser, global_multi_global_inited)
     EXPECT_EQ(module.globalsec[0].expression.value.global_index, 0x01);
 }
 
-TEST(parser, global_single_multi_instructions_inited)
-{
-    const auto section_contents = bytes{
-        0x01, 0x7f, 0x01, uint8_t(Instr::i32_const), 0x10, uint8_t(Instr::i64_const), 0x7f, 0x0b};
-    const auto bin = bytes{wasm_prefix} + make_section(6, section_contents);
-
-    const auto module = parse(bin);
-    ASSERT_EQ(module.globalsec.size(), 1);
-    EXPECT_TRUE(module.globalsec[0].type.is_mutable);
-    EXPECT_EQ(module.globalsec[0].type.value_type, ValType::i32);
-    EXPECT_EQ(module.globalsec[0].expression.kind, ConstantExpression::Kind::Constant);
-    EXPECT_EQ(module.globalsec[0].expression.value.constant, uint64_t(-1));
-}
-
 TEST(parser, global_multi_const_inited)
 {
     const auto section_contents =
@@ -916,7 +902,7 @@ TEST(parser, element_section_invalid_initializer)
 TEST(parser, element_section_no_table_section)
 {
     const auto wasm =
-        bytes{wasm_prefix} + make_section(9, make_vec({"000b"_bytes + make_vec({"00"_bytes})}));
+        bytes{wasm_prefix} + make_section(9, make_vec({"0041000b"_bytes + make_vec({"00"_bytes})}));
     EXPECT_THROW_MESSAGE(
         parse(wasm), validation_error, "element section encountered without a table section");
 }

--- a/test/unittests/validation_test.cpp
+++ b/test/unittests/validation_test.cpp
@@ -52,6 +52,19 @@ TEST(validation, globals_invalid_initializer)
     const auto bin_invalid3 = from_hex("0061736d01000000060b027f00412a0b7f0123000b");
     EXPECT_THROW_MESSAGE(parse(bin_invalid3), validation_error,
         "global can be initialized by another const global only if it's imported");
+
+    /* wat2wasm --no-check
+      (global (mut i32) (i32.const 16) (i32.const -1))
+    */
+    const auto bin_multi = from_hex("0061736d010000000608017f014110417f0b");
+    EXPECT_THROW_MESSAGE(
+        parse(bin_multi), validation_error, "constant expression has multiple instructions");
+
+    /* wat2wasm --no-check
+      (global (mut i64))
+    */
+    const auto bin_no_instr = from_hex("0061736d010000000604017e010b");
+    EXPECT_THROW_MESSAGE(parse(bin_no_instr), validation_error, "constant expression is empty");
 }
 
 TEST(validation, import_memories_multiple)


### PR DESCRIPTION
~~Based on #372~~
Based on #397

According to [validation spec](https://webassembly.github.io/spec/core/valid/modules.html#globals), result of constant expression has type
- `[t]` for global initializer
- `[i32]` for offset initializers

This implies that constant expression can have only single `*.const` or `global.get` instruction.

Spec tests check that with expected error "type mismatch": https://github.com/WebAssembly/spec/blob/60facfbb74cbb9f818258bbb07d02c581352e592/test/core/global.wast#L281-L289