### PR TITLE
test: Add one more br_if test case 

### DIFF
--- a/test/unittests/execute_control_test.cpp
+++ b/test/unittests/execute_control_test.cpp
@@ -506,6 +506,28 @@ TEST(execute_control, br_if_stack_cleanup)
     EXPECT_THAT(execute(parse(bin), 0, {7}), Result(0));
 }
 
+TEST(execute_control, br_if_stack_cleanup_arity1)
+{
+    /* wat2wasm
+    (func (param i32) (result i32)
+        i64.const 1   ;; Additional stack item.
+        i32.const 0
+        local.get 0
+        br_if 0       ;; Clean up stack.
+        drop
+        drop
+        i32.const 1
+    )
+    */
+
+    const auto bin =
+        from_hex("0061736d0100000001060160017f017f030201000a10010e004201410020000d001a1a41010b");
+
+    const auto module = parse(bin);
+    EXPECT_THAT(execute(module, 0, {0}), Result(1));
+    EXPECT_THAT(execute(module, 0, {1}), Result(0));
+}
+
 TEST(execute_control, br_multiple_blocks_stack_cleanup)
 {
     /* wat2wasm


### PR DESCRIPTION
Idea taken from https://github.com/wasmx/fizzy/pull/367#issuecomment-637744483.

This seems to be running slightly slower, so leaving only tests case.
Diff for reference:
```diff
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -678,20 +678,19 @@ execution_result execute(
                 goto end;
             break;
         }
-        case Instr::br:
+
         case Instr::br_if:
-        case Instr::return_:
-        {
-            // Check condition for br_if.
-            if (instruction == Instr::br_if && static_cast<uint32_t>(stack.pop()) == 0)
+            if (static_cast<uint32_t>(stack.pop()) == 0)
             {
                 immediates += BranchImmediateSize;
                 break;
             }
-
+            [[fallthrough]];
+        case Instr::br:
+        case Instr::return_:
             branch(code, stack, pc, immediates);
             break;
-        }
+
         case Instr::br_table:
         {
             const auto br_table_size = read<uint32_t>(immediates);
```