### PR TITLE
Allocate space for locals together with stack

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -477,10 +477,7 @@ ExecutionResult execute(
     const auto& code = instance.module.codesec[code_idx];
     auto* const memory = instance.memory.get();
 
-    std::vector<Value> locals(args.size() + code.local_count);
-    std::copy_n(args.begin(), args.size(), locals.begin());
-
-    OperandStack stack(static_cast<size_t>(code.max_stack_height));
+    OperandStack stack(args, code.local_count, static_cast<size_t>(code.max_stack_height));
 
     const Instr* pc = code.instructions.data();
     const uint8_t* immediates = code.immediates.data();
@@ -614,22 +611,19 @@ ExecutionResult execute(
         case Instr::local_get:
         {
             const auto idx = read<uint32_t>(immediates);
-            assert(idx <= locals.size());
-            stack.push(locals[idx]);
+            stack.push(stack.local(idx));
             break;
         }
         case Instr::local_set:
         {
             const auto idx = read<uint32_t>(immediates);
-            assert(idx <= locals.size());
-            locals[idx] = stack.pop();
+            stack.local(idx) = stack.pop();
             break;
         }
         case Instr::local_tee:
         {
             const auto idx = read<uint32_t>(immediates);
-            assert(idx <= locals.size());
-            locals[idx] = stack.top();
+            stack.local(idx) = stack.top();
             break;
         }
         case Instr::global_get:

--- a/lib/fizzy/stack.hpp
+++ b/lib/fizzy/stack.hpp
@@ -127,17 +127,6 @@ public:
         m_top -= num;
     }
 
-    /// Shrinks the stack to the given new size by dropping items from the top.
-    ///
-    /// Requires new_size <= size().
-    /// shrink(0) clears entire stack and moves the top pointer below the stack base.
-    void shrink(size_t new_size) noexcept
-    {
-        assert(new_size <= size());
-        // For new_size == 0, the m_top will point below the storage.
-        m_top = bottom() + new_size - 1;
-    }
-
     /// Returns iterator to the bottom of the stack.
     const Value* rbegin() const noexcept { return bottom(); }
 

--- a/lib/fizzy/stack.hpp
+++ b/lib/fizzy/stack.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "cxx20/span.hpp"
 #include "value.hpp"
 #include <cassert>
 #include <cstdint>
@@ -49,17 +50,32 @@ public:
     }
 };
 
+
+/// Contains current frame's locals (including arguments) and operand stack.
+/// The storage space for locals and operand stack together is allocated as a
+/// continuous memory. Elements occupy the storage space in the order:
+/// arguments, local variables, operand stack. Arguments and local variables can
+/// be accessed under a single namespace using local() method and are separate
+/// from the stack itself.
 class OperandStack
 {
     /// The size of the pre-allocated internal storage: 128 bytes.
     static constexpr auto small_storage_size = 128 / sizeof(Value);
 
-    /// The pointer to the top item, or below the stack bottom if stack is empty.
+    /// The pointer to the top item of the operand stack,
+    /// or below the stack bottom if stack is empty.
     ///
-    /// This pointer always alias m_storage, but it is kept as the first field
+    /// This pointer always alias m_locals, but it is kept as the first field
     /// because it is accessed the most. Therefore, it must be initialized
-    /// in the constructor after the m_storage.
+    /// in the constructor after the m_locals.
     Value* m_top;
+
+    /// The pointer to the beginning of the locals array.
+    /// This always points to one of the storages.
+    Value* m_locals;
+
+    /// The pointer to the bottom of the operand stack.
+    Value* m_bottom;
 
     /// The pre-allocated internal storage.
     Value m_small_storage[small_storage_size];
@@ -67,35 +83,56 @@ class OperandStack
     /// The unbounded storage for items.
     std::unique_ptr<Value[]> m_large_storage;
 
-    Value* bottom() noexcept { return m_large_storage ? m_large_storage.get() : m_small_storage; }
-
-    const Value* bottom() const noexcept
-    {
-        return m_large_storage ? m_large_storage.get() : m_small_storage;
-    }
-
 public:
     /// Default constructor.
     ///
-    /// Based on @p max_stack_height decides if to use small pre-allocated storage or allocate
-    /// large storage.
-    /// Sets the top item pointer to below the stack bottom.
-    explicit OperandStack(size_t max_stack_height)
+    /// Based on required storage space decides to use small pre-allocated
+    /// storage or allocate large storage.
+    /// Sets the top stack operand pointer to below the operand stack bottom.
+    /// @param args                 Function arguments. Values are copied at the beginning of the
+    ///                             storage space.
+    /// @param num_local_variables  The number of the function local variables (excluding
+    ///                             arguments). This number of values is zeroed in the storage space
+    ///                             after the arguments.
+    /// @param max_stack_height     The maximum operand stack height in the function. This excludes
+    ///                             args and num_local_variables.
+    OperandStack(span<const Value> args, size_t num_local_variables, size_t max_stack_height)
     {
-        if (max_stack_height > small_storage_size)
-            m_large_storage = std::make_unique<Value[]>(max_stack_height);
-        m_top = bottom() - 1;
+        const auto num_args = args.size();
+        const auto storage_size_required = num_args + num_local_variables + max_stack_height;
+
+        if (storage_size_required <= small_storage_size)
+        {
+            m_locals = &m_small_storage[0];
+        }
+        else
+        {
+            m_large_storage = std::make_unique<Value[]>(storage_size_required);
+            m_locals = &m_large_storage[0];
+        }
+
+        m_bottom = m_locals + num_args + num_local_variables;
+        m_top = m_bottom - 1;
+
+        std::copy(std::begin(args), std::end(args), m_locals);
+        std::fill_n(m_locals + num_args, num_local_variables, 0);
     }
 
     OperandStack(const OperandStack&) = delete;
     OperandStack& operator=(const OperandStack&) = delete;
 
+    Value& local(size_t index) noexcept
+    {
+        assert(m_locals + index < m_bottom);
+        return m_locals[index];
+    }
+
     /// The current number of items on the stack (aka stack height).
-    size_t size() const noexcept { return static_cast<size_t>(m_top + 1 - bottom()); }
+    size_t size() const noexcept { return static_cast<size_t>(m_top + 1 - m_bottom); }
 
     /// Returns the reference to the top item.
     /// Requires non-empty stack.
-    auto& top() noexcept
+    Value& top() noexcept
     {
         assert(size() != 0);
         return *m_top;
@@ -103,7 +140,7 @@ public:
 
     /// Returns the reference to the stack item on given position from the stack top.
     /// Requires index < size().
-    auto& operator[](size_t index) noexcept
+    Value& operator[](size_t index) noexcept
     {
         assert(index < size());
         return *(m_top - index);
@@ -115,7 +152,7 @@ public:
 
     /// Returns an item popped from the top of the stack.
     /// Requires non-empty stack.
-    auto pop() noexcept
+    Value pop() noexcept
     {
         assert(size() != 0);
         return *m_top--;
@@ -128,7 +165,7 @@ public:
     }
 
     /// Returns iterator to the bottom of the stack.
-    const Value* rbegin() const noexcept { return bottom(); }
+    const Value* rbegin() const noexcept { return m_bottom; }
 
     /// Returns end iterator counting from the bottom of the stack.
     const Value* rend() const noexcept { return m_top + 1; }

--- a/test/unittests/span_test.cpp
+++ b/test/unittests/span_test.cpp
@@ -50,7 +50,7 @@ TEST(span, array)
 
 TEST(span, stack)
 {
-    OperandStack stack(4);
+    OperandStack stack({}, 0, 4);
     stack.push(10);
     stack.push(11);
     stack.push(12);

--- a/test/unittests/stack_test.cpp
+++ b/test/unittests/stack_test.cpp
@@ -117,8 +117,6 @@ TEST(operand_stack, construct)
 {
     OperandStack stack(0);
     EXPECT_EQ(stack.size(), 0);
-    stack.shrink(0);
-    EXPECT_EQ(stack.size(), 0);
 }
 
 TEST(operand_stack, top)
@@ -136,7 +134,7 @@ TEST(operand_stack, top)
     EXPECT_EQ(stack.top().i64, 101);
     EXPECT_EQ(stack[0].i64, 101);
 
-    stack.shrink(0);
+    stack.drop(1);
     EXPECT_EQ(stack.size(), 0);
 
     stack.push(2);
@@ -185,23 +183,6 @@ TEST(operand_stack, large)
     for (int expected = max_height - 1; expected >= 0; --expected)
         EXPECT_EQ(stack.pop().i64, expected);
     EXPECT_EQ(stack.size(), 0);
-}
-
-TEST(operand_stack, shrink)
-{
-    constexpr auto max_height = 60;
-    OperandStack stack(max_height);
-
-    for (unsigned i = 0; i < max_height; ++i)
-        stack.push(i);
-
-    EXPECT_EQ(stack.size(), max_height);
-    constexpr auto new_height = max_height / 3;
-    stack.shrink(new_height);
-    EXPECT_EQ(stack.size(), new_height);
-    EXPECT_EQ(stack.top().i64, new_height - 1);
-    EXPECT_EQ(stack[0].i64, new_height - 1);
-    EXPECT_EQ(stack[new_height - 1].i64, 0);
 }
 
 TEST(operand_stack, rbegin_rend)

--- a/test/unittests/stack_test.cpp
+++ b/test/unittests/stack_test.cpp
@@ -115,13 +115,13 @@ TEST(stack, struct_item)
 
 TEST(operand_stack, construct)
 {
-    OperandStack stack(0);
+    OperandStack stack({}, 0, 0);
     EXPECT_EQ(stack.size(), 0);
 }
 
 TEST(operand_stack, top)
 {
-    OperandStack stack(1);
+    OperandStack stack({}, 0, 1);
     EXPECT_EQ(stack.size(), 0);
 
     stack.push(1);
@@ -145,7 +145,7 @@ TEST(operand_stack, top)
 
 TEST(operand_stack, small)
 {
-    OperandStack stack(3);
+    OperandStack stack({}, 0, 3);
     EXPECT_EQ(stack.size(), 0);
 
     stack.push(1);
@@ -174,7 +174,7 @@ TEST(operand_stack, small)
 TEST(operand_stack, large)
 {
     constexpr auto max_height = 33;
-    OperandStack stack(max_height);
+    OperandStack stack({}, 0, max_height);
 
     for (unsigned i = 0; i < max_height; ++i)
         stack.push(i);
@@ -187,7 +187,7 @@ TEST(operand_stack, large)
 
 TEST(operand_stack, rbegin_rend)
 {
-    OperandStack stack(3);
+    OperandStack stack({}, 0, 3);
     EXPECT_EQ(stack.rbegin(), stack.rend());
 
     stack.push(1);
@@ -200,7 +200,7 @@ TEST(operand_stack, rbegin_rend)
 
 TEST(operand_stack, to_vector)
 {
-    OperandStack stack(3);
+    OperandStack stack({}, 0, 3);
     EXPECT_THAT(std::vector(stack.rbegin(), stack.rend()), IsEmpty());
 
     stack.push(1);


### PR DESCRIPTION
This move memory management of args and locals to OperandStack where
space for all can be allocated in single go.