### PR TITLE
parser: Save global value type during parsing

### DIFF
--- a/lib/fizzy/module.hpp
+++ b/lib/fizzy/module.hpp
@@ -42,8 +42,8 @@ struct Module
     std::vector<Table> imported_table_types;
     // Types of memories defined in import section
     std::vector<Memory> imported_memory_types;
-    // Mutability of globals defined in import section
-    std::vector<bool> imported_globals_mutability;
+    // Types of globals defined in import section
+    std::vector<GlobalType> imported_global_types;
 
     const FuncType& get_function_type(FuncIdx idx) const noexcept
     {
@@ -65,7 +65,7 @@ struct Module
 
     size_t get_global_count() const noexcept
     {
-        return imported_globals_mutability.size() + globalsec.size();
+        return imported_global_types.size() + globalsec.size();
     }
 
     bool has_table() const noexcept { return !tablesec.empty() || !imported_table_types.empty(); }
@@ -78,9 +78,9 @@ struct Module
     bool is_global_mutable(GlobalIdx idx) const noexcept
     {
         assert(idx < get_global_count());
-        return idx < imported_globals_mutability.size() ?
-                   imported_globals_mutability[idx] :
-                   globalsec[idx - imported_globals_mutability.size()].is_mutable;
+        return idx < imported_global_types.size() ?
+                   imported_global_types[idx].is_mutable :
+                   globalsec[idx - imported_global_types.size()].type.is_mutable;
     }
 };
 }  // namespace fizzy

--- a/lib/fizzy/types.hpp
+++ b/lib/fizzy/types.hpp
@@ -295,10 +295,17 @@ struct ConstantExpression
     } value;
 };
 
+// https://webassembly.github.io/spec/core/binary/types.html#binary-globaltype
+struct GlobalType
+{
+    ValType value_type = ValType::i32;
+    bool is_mutable = false;
+};
+
 // https://webassembly.github.io/spec/core/binary/modules.html#global-section
 struct Global
 {
-    bool is_mutable = false;
+    GlobalType type;
     ConstantExpression expression;
 };
 
@@ -320,7 +327,7 @@ struct Import
     {
         TypeIdx function_type_index = 0;
         Memory memory;
-        bool global_mutable;
+        GlobalType global;
         Table table;
     } desc;
 };

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -382,6 +382,27 @@ TEST(instantiate, imported_globals_mismatched_mutability)
         "global 0 mutability doesn't match module's global mutability");
 }
 
+TEST(instantiate, DISABLED_imported_globals_mismatched_type)
+{
+    /* wat2wasm
+      (global (export "g1") i64 (i64.const 0))
+    */
+    const auto bin1 = from_hex("0061736d010000000606017e0042000b0706010267310300");
+    auto instance1 = instantiate(parse(bin1));
+
+    const auto g = find_exported_global(*instance1, "g1");
+    ASSERT_TRUE(g.has_value());
+
+    /* wat2wasm
+      (global (import "mod" "g1") i32)
+    */
+    const auto bin2 = from_hex("0061736d01000000020b01036d6f64026731037f00");
+    const auto module2 = parse(bin2);
+
+    EXPECT_THROW_MESSAGE(
+        instantiate(module2, {}, {}, {}, {*g}), instantiate_error, "type mismatch");
+}
+
 TEST(instantiate, imported_globals_nullptr)
 {
     /* wat2wasm

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -527,7 +527,8 @@ TEST(instantiate, element_section_offset_from_mutable_global)
 {
     Module module;
     module.tablesec.emplace_back(Table{{4, std::nullopt}});
-    module.globalsec.emplace_back(Global{true, {ConstantExpression::Kind::Constant, {42}}});
+    module.globalsec.emplace_back(
+        Global{{ValType::i32, true}, {ConstantExpression::Kind::Constant, {42}}});
     // Table contents: 0, 0xaa, 0xff, 0, ...
     module.elementsec.emplace_back(
         Element{{ConstantExpression::Kind::GlobalGet, {0}}, {0xaa, 0xff}});
@@ -626,7 +627,8 @@ TEST(instantiate, data_section_offset_from_global)
 {
     Module module;
     module.memorysec.emplace_back(Memory{{1, 1}});
-    module.globalsec.emplace_back(Global{false, {ConstantExpression::Kind::Constant, {42}}});
+    module.globalsec.emplace_back(
+        Global{{ValType::i32, false}, {ConstantExpression::Kind::Constant, {42}}});
     // Memory contents: 0, 0xaa, 0xff, 0, ...
     module.datasec.emplace_back(Data{{ConstantExpression::Kind::GlobalGet, {0}}, {0xaa, 0xff}});
 
@@ -658,7 +660,8 @@ TEST(instantiate, data_section_offset_from_mutable_global)
 {
     Module module;
     module.memorysec.emplace_back(Memory{{1, 1}});
-    module.globalsec.emplace_back(Global{true, {ConstantExpression::Kind::Constant, {42}}});
+    module.globalsec.emplace_back(
+        Global{{ValType::i32, true}, {ConstantExpression::Kind::Constant, {42}}});
     // Memory contents: 0, 0xaa, 0xff, 0, ...
     module.datasec.emplace_back(Data{{ConstantExpression::Kind::GlobalGet, {0}}, {0xaa, 0xff}});
 
@@ -769,7 +772,8 @@ TEST(instantiate, data_elem_section_errors_dont_change_imports)
 TEST(instantiate, globals_single)
 {
     Module module;
-    module.globalsec.emplace_back(Global{true, {ConstantExpression::Kind::Constant, {42}}});
+    module.globalsec.emplace_back(
+        Global{{ValType::i32, true}, {ConstantExpression::Kind::Constant, {42}}});
 
     auto instance = instantiate(module);
 
@@ -780,8 +784,10 @@ TEST(instantiate, globals_single)
 TEST(instantiate, globals_multiple)
 {
     Module module;
-    module.globalsec.emplace_back(Global{true, {ConstantExpression::Kind::Constant, {42}}});
-    module.globalsec.emplace_back(Global{false, {ConstantExpression::Kind::Constant, {43}}});
+    module.globalsec.emplace_back(
+        Global{{ValType::i32, true}, {ConstantExpression::Kind::Constant, {42}}});
+    module.globalsec.emplace_back(
+        Global{{ValType::i32, false}, {ConstantExpression::Kind::Constant, {43}}});
 
     auto instance = instantiate(module);
 

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -341,7 +341,8 @@ TEST(parser, import_multiple)
     EXPECT_EQ(module.importsec[2].module, "m3");
     EXPECT_EQ(module.importsec[2].name, "bar");
     EXPECT_EQ(module.importsec[2].kind, ExternalKind::Global);
-    EXPECT_FALSE(module.importsec[2].desc.global_mutable);
+    EXPECT_FALSE(module.importsec[2].desc.global.is_mutable);
+    EXPECT_EQ(module.importsec[2].desc.global.value_type, ValType::i32);
     EXPECT_EQ(module.importsec[3].module, "m4");
     EXPECT_EQ(module.importsec[3].name, "tab");
     EXPECT_EQ(module.importsec[3].kind, ExternalKind::Table);
@@ -587,7 +588,8 @@ TEST(parser, global_single_mutable_const_inited)
 
     const auto module = parse(bin);
     ASSERT_EQ(module.globalsec.size(), 1);
-    EXPECT_TRUE(module.globalsec[0].is_mutable);
+    EXPECT_TRUE(module.globalsec[0].type.is_mutable);
+    EXPECT_EQ(module.globalsec[0].type.value_type, ValType::i32);
     EXPECT_EQ(module.globalsec[0].expression.kind, ConstantExpression::Kind::Constant);
     EXPECT_EQ(module.globalsec[0].expression.value.constant, 0x10);
 }
@@ -599,7 +601,8 @@ TEST(parser, global_single_const_global_inited)
 
     const auto module = parse(bin);
     ASSERT_EQ(module.globalsec.size(), 1);
-    EXPECT_FALSE(module.globalsec[0].is_mutable);
+    EXPECT_FALSE(module.globalsec[0].type.is_mutable);
+    EXPECT_EQ(module.globalsec[0].type.value_type, ValType::i32);
     EXPECT_EQ(module.globalsec[0].expression.kind, ConstantExpression::Kind::GlobalGet);
     EXPECT_EQ(module.globalsec[0].expression.value.global_index, 0x01);
 }
@@ -612,7 +615,8 @@ TEST(parser, global_single_multi_instructions_inited)
 
     const auto module = parse(bin);
     ASSERT_EQ(module.globalsec.size(), 1);
-    EXPECT_TRUE(module.globalsec[0].is_mutable);
+    EXPECT_TRUE(module.globalsec[0].type.is_mutable);
+    EXPECT_EQ(module.globalsec[0].type.value_type, ValType::i32);
     EXPECT_EQ(module.globalsec[0].expression.kind, ConstantExpression::Kind::Constant);
     EXPECT_EQ(module.globalsec[0].expression.value.constant, uint64_t(-1));
 }
@@ -626,10 +630,12 @@ TEST(parser, global_multi_const_inited)
 
     const auto module = parse(bin);
     ASSERT_EQ(module.globalsec.size(), 2);
-    EXPECT_FALSE(module.globalsec[0].is_mutable);
+    EXPECT_FALSE(module.globalsec[0].type.is_mutable);
+    EXPECT_EQ(module.globalsec[0].type.value_type, ValType::i32);
     EXPECT_EQ(module.globalsec[0].expression.kind, ConstantExpression::Kind::Constant);
     EXPECT_EQ(module.globalsec[0].expression.value.constant, 0x01);
-    EXPECT_TRUE(module.globalsec[1].is_mutable);
+    EXPECT_TRUE(module.globalsec[1].type.is_mutable);
+    EXPECT_EQ(module.globalsec[1].type.value_type, ValType::i32);
     EXPECT_EQ(module.globalsec[1].expression.kind, ConstantExpression::Kind::Constant);
     EXPECT_EQ(module.globalsec[1].expression.value.constant, uint32_t(-1));
 }


### PR DESCRIPTION
Required for type validation, pulled out from #385 