### PR TITLE
Keep number of stack items to drop for branches

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -264,11 +264,11 @@ void branch(
     {
         assert(arity == 1);
         const auto result = stack.top();
-        stack.shrink(stack.size() - stack_drop);
+        stack.drop(stack_drop);
         stack.top() = result;
     }
     else
-        stack.shrink(stack.size() - stack_drop);
+        stack.drop(stack_drop);
 }
 
 template <class F>
@@ -278,7 +278,7 @@ bool invoke_function(
     const auto num_args = func_type.inputs.size();
     assert(stack.size() >= num_args);
     std::vector<uint64_t> call_args{stack.rend() - num_args, stack.rend()};
-    stack.shrink(stack.size() - num_args);
+    stack.drop(num_args);
 
     const auto ret = func(instance, std::move(call_args), depth + 1);
     // Bubble up traps

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -251,23 +251,24 @@ void branch(
 {
     const auto code_offset = read<uint32_t>(immediates);
     const auto imm_offset = read<uint32_t>(immediates);
-    const auto stack_height = static_cast<size_t>(read<uint32_t>(immediates));
+    const auto stack_drop = read<uint32_t>(immediates);
     const auto arity = read<uint8_t>(immediates);
 
     pc = code.instructions.data() + code_offset;
     immediates = code.immediates.data() + imm_offset;
 
     // When branch is taken, additional stack items must be dropped.
-    assert(stack.size() >= stack_height + arity);
+    assert(static_cast<int>(stack_drop) >= 0);
+    assert(stack.size() >= stack_drop + arity);
     if (arity != 0)
     {
         assert(arity == 1);
         const auto result = stack.top();
-        stack.shrink(stack_height);
-        stack.push(result);
+        stack.shrink(stack.size() - stack_drop);
+        stack.top() = result;
     }
     else
-        stack.shrink(stack_height);
+        stack.shrink(stack.size() - stack_drop);
 }
 
 template <class F>

--- a/lib/fizzy/stack.hpp
+++ b/lib/fizzy/stack.hpp
@@ -68,18 +68,18 @@ class OperandStack
     /// in the constructor after the m_storage.
     uint64_t* m_top;
 
-    /// The bottom of the stack. Set in the constructor and never modified.
-    ///
-    /// TODO: This pointer is rarely used and may be removed.
-    ///       The value can be recomputed as (m_large_storage ? m_large_storage : m_small_storage).
-    ///       Moreover, methods using it may be replaced by ones not needing bottom of the stack.
-    uint64_t* m_bottom;
-
     /// The pre-allocated internal storage.
     uint64_t m_small_storage[small_storage_size];
 
     /// The unbounded storage for items.
     std::unique_ptr<uint64_t[]> m_large_storage;
+
+    uint64_t* bottom() { return m_large_storage ? m_large_storage.get() : m_small_storage; }
+
+    const uint64_t* bottom() const
+    {
+        return m_large_storage ? m_large_storage.get() : m_small_storage;
+    }
 
 public:
     /// Default constructor.
@@ -89,23 +89,16 @@ public:
     /// Sets the top item pointer to below the stack bottom.
     explicit OperandStack(size_t max_stack_height)
     {
-        if (max_stack_height <= small_storage_size)
-        {
-            m_bottom = &m_small_storage[0];
-        }
-        else
-        {
+        if (max_stack_height > small_storage_size)
             m_large_storage = std::make_unique<uint64_t[]>(max_stack_height);
-            m_bottom = &m_large_storage[0];
-        }
-        m_top = m_bottom - 1;
+        m_top = bottom() - 1;
     }
 
     OperandStack(const OperandStack&) = delete;
     OperandStack& operator=(const OperandStack&) = delete;
 
     /// The current number of items on the stack (aka stack height).
-    [[nodiscard]] size_t size() noexcept { return static_cast<size_t>(m_top + 1 - m_bottom); }
+    [[nodiscard]] size_t size() noexcept { return static_cast<size_t>(m_top + 1 - bottom()); }
 
     /// Returns the reference to the top item.
     /// Requires non-empty stack.
@@ -149,11 +142,11 @@ public:
     {
         assert(new_size <= size());
         // For new_size == 0, the m_top will point below the storage.
-        m_top = m_bottom + new_size - 1;
+        m_top = bottom() + new_size - 1;
     }
 
     /// Returns iterator to the bottom of the stack.
-    [[nodiscard]] const uint64_t* rbegin() const noexcept { return m_bottom; }
+    [[nodiscard]] const uint64_t* rbegin() const noexcept { return bottom(); }
 
     /// Returns end iterator counting from the bottom of the stack.
     [[nodiscard]] const uint64_t* rend() const noexcept { return m_top + 1; }

--- a/lib/fizzy/stack.hpp
+++ b/lib/fizzy/stack.hpp
@@ -135,6 +135,12 @@ public:
         return *m_top--;
     }
 
+    void drop(size_t num) noexcept
+    {
+        assert(num <= size());
+        m_top -= num;
+    }
+
     /// Shrinks the stack to the given new size by dropping items from the top.
     ///
     /// Requires new_size <= size().

--- a/test/unittests/parser_expr_test.cpp
+++ b/test/unittests/parser_expr_test.cpp
@@ -105,7 +105,7 @@ TEST(parser_expr, loop_br)
     EXPECT_EQ(module.codesec[0].immediates,
         "00000000"    // code_offset
         "00000000"    // imm_offset
-        "00000000"    // stack_height
+        "00000000"    // stack_drop
         "00"_bytes);  // arity
 
     /* wat2wasm
@@ -126,7 +126,7 @@ TEST(parser_expr, loop_br)
         "00000000"    // i32.const
         "01000000"    // code_offset
         "04000000"    // imm_offset
-        "01000000"    // stack_height
+        "00000000"    // stack_drop
         "00"_bytes);  // arity
 
     /* wat2wasm
@@ -149,7 +149,7 @@ TEST(parser_expr, loop_br)
         "00000000"    // i32.const
         "00000000"    // code_offset
         "00000000"    // imm_offset
-        "00000000"    // stack_height
+        "01000000"    // stack_drop
         "00"_bytes);  // arity - always 0 for loop
 }
 
@@ -166,7 +166,7 @@ TEST(parser_expr, loop_return)
     EXPECT_EQ(module.codesec[0].immediates,
         "03000000"    // code_offset
         "0d000000"    // imm_offset
-        "00000000"    // stack_height
+        "00000000"    // stack_drop
         "00"_bytes);  // arity
 }
 
@@ -195,7 +195,7 @@ TEST(parser_expr, block_br)
         "01000000"
         "08000000"  // code_offset
         "1d000000"  // imm_offset
-        "00000000"  // stack_height
+        "00000000"  // stack_drop
         "00"        // arity
         "0b000000"
         "01000000"
@@ -220,7 +220,7 @@ TEST(parser_expr, block_br)
         "00000000"    // i32.const
         "04000000"    // code_offset
         "11000000"    // imm_offset
-        "01000000"    // stack_height
+        "00000000"    // stack_drop
         "00"_bytes);  // arity
 
     /* wat2wasm
@@ -243,7 +243,7 @@ TEST(parser_expr, block_br)
         "00000000"  // i32.const
         "04000000"  // code_offset
         "11000000"  // imm_offset
-        "00000000"  // stack_height
+        "00000000"  // stack_drop
         "01"_bytes);
 }
 
@@ -260,7 +260,7 @@ TEST(parser_expr, block_return)
     EXPECT_EQ(module.codesec[0].immediates,
         "03000000"    // code_offset
         "0d000000"    // imm_offset
-        "00000000"    // stack_height
+        "00000000"    // stack_drop
         "00"_bytes);  // arity
 }
 
@@ -283,7 +283,7 @@ TEST(parser_expr, if_br)
         "19000000"    // else imm offset
         "04000000"    // code_offset
         "19000000"    // imm_offset
-        "00000000"    // stack_height
+        "00000000"    // stack_drop
         "00"_bytes);  // arity
 
     /* wat2wasm
@@ -308,7 +308,7 @@ TEST(parser_expr, if_br)
         "1d000000"    // else imm offset
         "05000000"    // code_offset
         "1d000000"    // imm_offset
-        "01000000"    // stack_height
+        "00000000"    // stack_drop
         "00"_bytes);  // arity
 }
 
@@ -363,27 +363,27 @@ TEST(parser_expr, instr_br_table)
 
         "13000000"  // code_offset
         "8d000000"  // imm_offset
-        "00000000"  // stack_height
+        "00000000"  // stack_drop
         "00"        // arity
 
         "10000000"  // code_offset
         "7c000000"  // imm_offset
-        "00000000"  // stack_height
+        "00000000"  // stack_drop
         "00"        // arity
 
         "0d000000"  // code_offset
         "6b000000"  // imm_offset
-        "00000000"  // stack_height
+        "00000000"  // stack_drop
         "00"        // arity
 
         "0a000000"  // code_offset
         "5a000000"  // imm_offset
-        "00000000"  // stack_height
+        "00000000"  // stack_drop
         "00"        // arity
 
         "16000000"   // code_offset
         "9e000000"   // imm_offset
-        "00000000"   // stack_height
+        "00000000"   // stack_drop
         "00"_bytes;  // arity
 
     EXPECT_EQ(code.immediates.substr(br_table_imm_offset, expected_br_imm.size()), expected_br_imm);
@@ -418,7 +418,7 @@ TEST(parser_expr, instr_br_table_empty_vector)
         "00000000"   // label_count
         "06000000"   // code_offset
         "26000000"   // imm_offset
-        "00000000"   // stack_height
+        "00000000"   // stack_drop
         "00"_bytes;  // arity
     EXPECT_EQ(code.immediates.substr(br_table_imm_offset, expected_br_imm.size()), expected_br_imm);
     EXPECT_EQ(code.max_stack_height, 1);


### PR DESCRIPTION
Instead of keeping information about the absolute height to rewind the
stack to, keep the number of stack items to drop (without the number of
results - arity of the result type).

This makes OperandStack simpler (no need to track the bottom of the stack). No speed change.