### PR TITLE
Move execute(Module, ...) to execute_helpers.hpp (testutils)

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -1464,12 +1464,6 @@ end:
     return {trap, {stack.rbegin(), stack.rend()}};
 }
 
-execution_result execute(const Module& module, FuncIdx func_idx, std::vector<uint64_t> args)
-{
-    auto instance = instantiate(module);
-    return execute(*instance, func_idx, std::move(args));
-}
-
 std::vector<ExternalFunction> resolve_imported_functions(
     const Module& module, std::vector<ImportedFunction> imported_functions)
 {

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -97,8 +97,6 @@ std::unique_ptr<Instance> instantiate(Module module,
 execution_result execute(
     Instance& instance, FuncIdx func_idx, std::vector<uint64_t> args, int depth = 0);
 
-// TODO: remove this helper
-execution_result execute(const Module& module, FuncIdx func_idx, std::vector<uint64_t> args);
 
 // Function that should be used by instantiate as imports, identified by module and function name.
 struct ImportedFunction

--- a/test/unittests/end_to_end_test.cpp
+++ b/test/unittests/end_to_end_test.cpp
@@ -31,8 +31,9 @@ TEST(end_to_end, milestone1)
     const auto wasm = from_hex(
         "0061736d0100000001070160027f7f017f030201000a13011101017f200020016a20026a220220006a0b");
     const auto module = parse(wasm);
+    auto instance = instantiate(module);
 
-    EXPECT_THAT(execute(module, 0, {20, 22}), Result(20 + 22 + 20));
+    EXPECT_THAT(execute(*instance, 0, {20, 22}), Result(20 + 22 + 20));
 }
 
 TEST(end_to_end, milestone2)
@@ -128,7 +129,8 @@ TEST(end_to_end, nested_loops_in_c)
     const auto func_idx = find_exported_function(module, "test");
     ASSERT_TRUE(func_idx);
 
-    EXPECT_THAT(execute(module, *func_idx, {10, 2, 5}), Result(4));
+    auto instance = instantiate(module);
+    EXPECT_THAT(execute(*instance, *func_idx, {10, 2, 5}), Result(4));
 }
 
 TEST(end_to_end, memset)

--- a/test/unittests/execute_call_test.cpp
+++ b/test/unittests/execute_call_test.cpp
@@ -7,6 +7,7 @@
 #include "parser.hpp"
 #include <gtest/gtest.h>
 #include <test/utils/asserts.hpp>
+#include <test/utils/execute_helpers.hpp>
 #include <test/utils/hex.hpp>
 
 using namespace fizzy;

--- a/test/unittests/execute_control_test.cpp
+++ b/test/unittests/execute_control_test.cpp
@@ -6,6 +6,7 @@
 #include "parser.hpp"
 #include <gtest/gtest.h>
 #include <test/utils/asserts.hpp>
+#include <test/utils/execute_helpers.hpp>
 #include <test/utils/hex.hpp>
 
 using namespace fizzy;

--- a/test/unittests/execute_numeric_test.cpp
+++ b/test/unittests/execute_numeric_test.cpp
@@ -6,6 +6,7 @@
 #include "parser.hpp"
 #include <gtest/gtest.h>
 #include <test/utils/asserts.hpp>
+#include <test/utils/execute_helpers.hpp>
 #include <test/utils/hex.hpp>
 
 using namespace fizzy;

--- a/test/unittests/execute_test.cpp
+++ b/test/unittests/execute_test.cpp
@@ -7,6 +7,7 @@
 #include "parser.hpp"
 #include <gtest/gtest.h>
 #include <test/utils/asserts.hpp>
+#include <test/utils/execute_helpers.hpp>
 #include <test/utils/hex.hpp>
 
 using namespace fizzy;

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(
     adler32.hpp
     asserts.cpp
     asserts.hpp
+    execute_helpers.hpp
     fizzy_engine.cpp
     hex.cpp
     hex.hpp

--- a/test/utils/execute_helpers.hpp
+++ b/test/utils/execute_helpers.hpp
@@ -1,0 +1,16 @@
+// Fizzy: A fast WebAssembly interpreter
+// Copyright 2020 The Fizzy Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "execute.hpp"
+
+namespace fizzy::test
+{
+inline execution_result execute(const Module& module, FuncIdx func_idx, std::vector<uint64_t> args)
+{
+    auto instance = instantiate(module);
+    return execute(*instance, func_idx, std::move(args));
+}
+}  // namespace fizzy::test


### PR DESCRIPTION
This an overload of execute that takes a module and instantiate it internally. This is convenient for unit tests but rather not desirable in "public" headers. So it is moved to testutils.