### PR TITLE
Validate types for select instruction

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -270,8 +270,8 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 5418
-          expected_failed: 14
+          expected_passed: 5423
+          expected_failed: 9
           expected_skipped: 6381
 
   sanitizers-macos:
@@ -288,8 +288,8 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 5418
-          expected_failed: 14
+          expected_passed: 5423
+          expected_failed: 9
           expected_skipped: 6381
 
   benchmark:
@@ -400,8 +400,8 @@ jobs:
           expected_failed: 9
           expected_skipped: 7323
       - spectest:
-          expected_passed: 5418
-          expected_failed: 14
+          expected_passed: 5423
+          expected_failed: 9
           expected_skipped: 6381
       - collect_coverage_data
 

--- a/lib/fizzy/parser_expr.cpp
+++ b/lib/fizzy/parser_expr.cpp
@@ -63,6 +63,36 @@ struct ControlFrame
     {}
 };
 
+enum class OperandStackType : uint8_t
+{
+    Unknown = 0,
+    i32 = static_cast<uint8_t>(ValType::i32),
+    i64 = static_cast<uint8_t>(ValType::i64),
+    f32 = static_cast<uint8_t>(ValType::f32),
+    f64 = static_cast<uint8_t>(ValType::f64),
+};
+
+inline OperandStackType from_valtype(ValType val_type) noexcept
+{
+    return static_cast<OperandStackType>(val_type);
+}
+
+inline bool type_matches(OperandStackType actual_type, ValType expected_type) noexcept
+{
+    if (actual_type == OperandStackType::Unknown)
+        return true;
+
+    return static_cast<ValType>(actual_type) == expected_type;
+}
+
+inline bool type_matches(OperandStackType actual_type, OperandStackType expected_type) noexcept
+{
+    if (expected_type == OperandStackType::Unknown || actual_type == OperandStackType::Unknown)
+        return true;
+
+    return expected_type == actual_type;
+}
+
 /// Parses blocktype.
 ///
 /// Spec: https://webassembly.github.io/spec/core/binary/types.html#binary-blocktype.
@@ -82,7 +112,7 @@ parser_result<std::optional<ValType>> parse_blocktype(const uint8_t* pos, const 
     return {validate_valtype(type), pos};
 }
 
-void update_operand_stack(const ControlFrame& frame, Stack<ValType>& operand_stack,
+void update_operand_stack(const ControlFrame& frame, Stack<OperandStackType>& operand_stack,
     span<const ValType> inputs, span<const ValType> outputs)
 {
     const auto frame_stack_height = static_cast<int>(operand_stack.size());
@@ -103,16 +133,16 @@ void update_operand_stack(const ControlFrame& frame, Stack<ValType>& operand_sta
 
         const auto expected_type = *it;
         const auto actual_type = operand_stack.pop();
-        if (actual_type != expected_type)
+        if (!type_matches(actual_type, expected_type))
             throw validation_error{"type mismatch"};
     }
     // Push output values even if frame is unreachable.
     for (const auto output_type : outputs)
-        operand_stack.push(output_type);
+        operand_stack.push(from_valtype(output_type));
 }
 
-inline void drop_operand(
-    const ControlFrame& frame, Stack<ValType>& operand_stack, std::optional<ValType> expected_type)
+inline void drop_operand(const ControlFrame& frame, Stack<OperandStackType>& operand_stack,
+    OperandStackType expected_type)
 {
     if (!frame.unreachable &&
         static_cast<int>(operand_stack.size()) < frame.parent_stack_height + 1)
@@ -124,12 +154,17 @@ inline void drop_operand(
         return;
     }
 
-    const auto actual_type = operand_stack.pop();
-    if (expected_type.has_value() && actual_type != *expected_type)
+    if (!type_matches(operand_stack.pop(), expected_type))
         throw validation_error{"type mismatch"};
 }
 
-void update_result_stack(const ControlFrame& frame, Stack<ValType>& operand_stack)
+inline void drop_operand(
+    const ControlFrame& frame, Stack<OperandStackType>& operand_stack, ValType expected_type)
+{
+    return drop_operand(frame, operand_stack, from_valtype(expected_type));
+}
+
+void update_result_stack(const ControlFrame& frame, Stack<OperandStackType>& operand_stack)
 {
     const auto frame_stack_height = static_cast<int>(operand_stack.size());
 
@@ -142,7 +177,7 @@ void update_result_stack(const ControlFrame& frame, Stack<ValType>& operand_stac
         throw validation_error{"too many results"};
 
     if (arity != 0)
-        drop_operand(frame, operand_stack, frame.type);
+        drop_operand(frame, operand_stack, from_valtype(*frame.type));
 }
 
 inline std::optional<ValType> get_branch_frame_type(const ControlFrame& frame) noexcept
@@ -158,13 +193,13 @@ inline uint8_t get_branch_arity(const ControlFrame& frame) noexcept
 }
 
 inline void update_branch_stack(const ControlFrame& current_frame, const ControlFrame& branch_frame,
-    Stack<ValType>& operand_stack)
+    Stack<OperandStackType>& operand_stack)
 {
     assert(static_cast<int>(operand_stack.size()) >= current_frame.parent_stack_height);
 
     const auto branch_frame_type = get_branch_frame_type(branch_frame);
     if (branch_frame_type.has_value())
-        drop_operand(current_frame, operand_stack, *branch_frame_type);
+        drop_operand(current_frame, operand_stack, from_valtype(*branch_frame_type));
 }
 
 void push_branch_immediates(const ControlFrame& branch_frame, int stack_height, bytes& immediates)
@@ -180,15 +215,16 @@ void push_branch_immediates(const ControlFrame& branch_frame, int stack_height, 
     push(immediates, get_branch_arity(branch_frame));  // arity is uint8_t
 }
 
-inline void mark_frame_unreachable(ControlFrame& frame, Stack<ValType>& operand_stack) noexcept
+inline void mark_frame_unreachable(
+    ControlFrame& frame, Stack<OperandStackType>& operand_stack) noexcept
 {
     frame.unreachable = true;
     operand_stack.shrink(static_cast<size_t>(frame.parent_stack_height));
 }
 
-inline void push_operand(Stack<ValType>& operand_stack, ValType type)
+inline void push_operand(Stack<OperandStackType>& operand_stack, ValType type)
 {
-    operand_stack.push(type);
+    operand_stack.push(from_valtype(type));
 }
 
 ValType find_local_type(
@@ -221,7 +257,7 @@ parser_result<Code> parse_expr(const uint8_t* pos, const uint8_t* end, FuncIdx f
     // instructions as defined in Wasm Validation Algorithm.
     Stack<ControlFrame> control_stack;
 
-    Stack<ValType> operand_stack;
+    Stack<OperandStackType> operand_stack;
 
     const auto func_type_idx = module.funcsec[func_idx];
     assert(func_type_idx < module.typesec.size());
@@ -342,7 +378,7 @@ parser_result<Code> parse_expr(const uint8_t* pos, const uint8_t* end, FuncIdx f
         case Instr::drop:
         case Instr::select:
             // TODO: for select validate that two top operands are the same type
-            drop_operand(frame, operand_stack, std::nullopt);
+            drop_operand(frame, operand_stack, OperandStackType::Unknown);
             break;
 
         case Instr::nop:
@@ -524,7 +560,7 @@ parser_result<Code> parse_expr(const uint8_t* pos, const uint8_t* end, FuncIdx f
             if (control_stack.empty())
                 continue_parsing = false;
             else if (frame_type.has_value())
-                operand_stack.push(*frame_type);
+                push_operand(operand_stack, *frame_type);
             break;
         }
 

--- a/test/unittests/validation_stack_test.cpp
+++ b/test/unittests/validation_stack_test.cpp
@@ -10,7 +10,7 @@
 using namespace fizzy;
 using namespace fizzy::test;
 
-TEST(validation_stack, DISABLED_select_stack_underflow)
+TEST(validation_stack, select_stack_underflow)
 {
     /* wat2wasm --no-check
     (func
@@ -24,7 +24,7 @@ TEST(validation_stack, DISABLED_select_stack_underflow)
     EXPECT_THROW_MESSAGE(parse(wasm), validation_error, "stack underflow");
 }
 
-TEST(validation_stack_type, DISABLED_select_stack_underflow_2)
+TEST(validation_stack_type, select_stack_underflow_2)
 {
     /* wat2wasm --no-check
     (func (param i32) (result i32)


### PR DESCRIPTION
Depends on #408 

Some of related spec tests were already passing by accident, because the tests are not great:

https://github.com/WebAssembly/spec/blob/636b862b9c8a25ad65fb240fefd673e7f23bcdd0/test/core/select.wast#L296-L307
```wat
(assert_invalid
  (module (func $type-num-vs-num (select (i32.const 1) (i64.const 1) (i32.const 1))))
  "type mismatch"
)
(assert_invalid
  (module (func $type-num-vs-num (select (i32.const 1) (f32.const 1.0) (i32.const 1))))
  "type mismatch"
)
(assert_invalid
  (module (func $type-num-vs-num (select (i32.const 1) (f64.const 1.0) (i32.const 1))))
  "type mismatch"
)
```
^ These were invalid but for the wrong reason - functions are void but have result of `select` on stack in the end.

https://github.com/WebAssembly/spec/blob/636b862b9c8a25ad65fb240fefd673e7f23bcdd0/test/core/select.wast#L326-L333
```wat
(assert_invalid
  (module
    (func $type-3rd-operand-empty
      (i32.const 0) (i32.const 0) (select) (drop)
    )
  )
  "type mismatch"
)
```
^ This was also invalid for the wrong reason - `select` popped two values and pushed 0, so it was type mismatch for `drop` instruction.

(added to "To Upstream")