### PR TITLE
Introduce Value type for operands

### DIFF
--- a/lib/fizzy/CMakeLists.txt
+++ b/lib/fizzy/CMakeLists.txt
@@ -24,5 +24,6 @@ target_sources(
     types.hpp
     utf8.cpp
     utf8.hpp
+    value.hpp
 )
 target_compile_features(fizzy PUBLIC cxx_std_17)

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -611,7 +611,7 @@ ExecutionResult execute(Instance& instance, FuncIdx func_idx, span<const uint64_
     const auto& code = instance.module.codesec[code_idx];
     auto* const memory = instance.memory.get();
 
-    std::vector<uint64_t> locals(args.size() + code.local_count, 0);
+    std::vector<Value> locals(args.size() + code.local_count);
     std::copy_n(args.begin(), args.size(), locals.begin());
 
     OperandStack stack(static_cast<size_t>(code.max_stack_height));

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -270,7 +270,8 @@ bool invoke_function(
 {
     const auto num_args = func_type.inputs.size();
     assert(stack.size() >= num_args);
-    span<const uint64_t> call_args{stack.rend() - num_args, num_args};
+    const auto* first_arg = stack.rend() - num_args;
+    span<const uint64_t> call_args{&first_arg->i64, num_args};  // FIXME: hack!
     stack.drop(num_args);
 
     const auto ret = func(instance, call_args, depth + 1);

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -8,6 +8,7 @@
 #include "module.hpp"
 #include "span.hpp"
 #include "types.hpp"
+#include "value.hpp"
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -19,10 +20,10 @@ struct ExecutionResult
 {
     const bool trapped = false;
     const bool has_value = false;
-    const uint64_t value = 0;
+    const Value value = 0;
 
     /// Constructs result with a value.
-    constexpr ExecutionResult(uint64_t _value) noexcept : has_value{true}, value{_value} {}
+    constexpr ExecutionResult(Value _value) noexcept : has_value{true}, value{_value} {}
 
     /// Constructs result in "void" or "trap" state depending on the success flag.
     /// Prefer using Void and Trap constants instead.
@@ -36,7 +37,7 @@ struct Instance;
 
 struct ExternalFunction
 {
-    std::function<ExecutionResult(Instance&, span<const uint64_t>, int depth)> function;
+    std::function<ExecutionResult(Instance&, span<const Value>, int depth)> function;
     FuncType type;
 };
 
@@ -104,12 +105,12 @@ std::unique_ptr<Instance> instantiate(Module module,
 
 // Execute a function on an instance.
 ExecutionResult execute(
-    Instance& instance, FuncIdx func_idx, span<const uint64_t> args, int depth = 0);
+    Instance& instance, FuncIdx func_idx, span<const Value> args, int depth = 0);
 
 inline ExecutionResult execute(
-    Instance& instance, FuncIdx func_idx, std::initializer_list<uint64_t> args)
+    Instance& instance, FuncIdx func_idx, std::initializer_list<Value> args)
 {
-    return execute(instance, func_idx, span<const uint64_t>{args});
+    return execute(instance, func_idx, span<const Value>{args});
 }
 
 
@@ -120,7 +121,7 @@ struct ImportedFunction
     std::string name;
     std::vector<ValType> inputs;
     std::optional<ValType> output;
-    std::function<ExecutionResult(Instance&, span<const uint64_t>, int depth)> function;
+    std::function<ExecutionResult(Instance&, span<const Value>, int depth)> function;
 };
 
 // Create vector of ExternalFunctions ready to be passed to instantiate.

--- a/lib/fizzy/stack.hpp
+++ b/lib/fizzy/stack.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "value.hpp"
 #include <cassert>
 #include <cstdint>
 #include <memory>
@@ -59,24 +60,24 @@ public:
 class OperandStack
 {
     /// The size of the pre-allocated internal storage: 128 bytes.
-    static constexpr auto small_storage_size = 128 / sizeof(uint64_t);
+    static constexpr auto small_storage_size = 128 / sizeof(Value);
 
     /// The pointer to the top item, or below the stack bottom if stack is empty.
     ///
     /// This pointer always alias m_storage, but it is kept as the first field
     /// because it is accessed the most. Therefore, it must be initialized
     /// in the constructor after the m_storage.
-    uint64_t* m_top;
+    Value* m_top;
 
     /// The pre-allocated internal storage.
-    uint64_t m_small_storage[small_storage_size];
+    Value m_small_storage[small_storage_size];
 
     /// The unbounded storage for items.
-    std::unique_ptr<uint64_t[]> m_large_storage;
+    std::unique_ptr<Value[]> m_large_storage;
 
-    uint64_t* bottom() { return m_large_storage ? m_large_storage.get() : m_small_storage; }
+    Value* bottom() { return m_large_storage ? m_large_storage.get() : m_small_storage; }
 
-    const uint64_t* bottom() const
+    const Value* bottom() const
     {
         return m_large_storage ? m_large_storage.get() : m_small_storage;
     }
@@ -90,7 +91,7 @@ public:
     explicit OperandStack(size_t max_stack_height)
     {
         if (max_stack_height > small_storage_size)
-            m_large_storage = std::make_unique<uint64_t[]>(max_stack_height);
+            m_large_storage = std::make_unique<Value[]>(max_stack_height);
         m_top = bottom() - 1;
     }
 
@@ -118,7 +119,7 @@ public:
 
     /// Pushes an item on the stack.
     /// The stack max height limit is not checked.
-    void push(uint64_t item) noexcept { *++m_top = item; }
+    void push(Value item) noexcept { *++m_top = item; }
 
     /// Returns an item popped from the top of the stack.
     /// Requires non-empty stack.
@@ -146,9 +147,9 @@ public:
     }
 
     /// Returns iterator to the bottom of the stack.
-    const uint64_t* rbegin() const noexcept { return bottom(); }
+    const Value* rbegin() const noexcept { return bottom(); }
 
     /// Returns end iterator counting from the bottom of the stack.
-    const uint64_t* rend() const noexcept { return m_top + 1; }
+    const Value* rend() const noexcept { return m_top + 1; }
 };
 }  // namespace fizzy

--- a/lib/fizzy/value.hpp
+++ b/lib/fizzy/value.hpp
@@ -1,0 +1,20 @@
+// Fizzy: A fast WebAssembly interpreter
+// Copyright 2019-2020 The Fizzy Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+namespace fizzy
+{
+union Value
+{
+    uint64_t i64;
+
+    Value() = default;
+    constexpr Value(uint64_t v) noexcept : i64{v} {}
+
+    constexpr operator uint64_t() const noexcept { return i64; }
+};
+}  // namespace fizzy

--- a/test/spectests/spectests.cpp
+++ b/test/spectests/spectests.cpp
@@ -416,7 +416,7 @@ private:
             return std::nullopt;
         }
 
-        std::vector<uint64_t> args;
+        std::vector<fizzy::Value> args;
         for (const auto& arg : action.at("args"))
         {
             const auto arg_type = arg.at("type").get<std::string>();

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(
     validation_stack_test.cpp
     validation_stack_type_test.cpp
     validation_test.cpp
+    value_test.cpp
     wasm_engine_test.cpp
 )
 

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -14,12 +14,12 @@ using namespace fizzy::test;
 
 namespace
 {
-auto function_returning_value(uint64_t value) noexcept
+auto function_returning_value(Value value) noexcept
 {
-    return [value](Instance&, span<const uint64_t>, int) { return value; };
+    return [value](Instance&, span<const Value>, int) { return value; };
 }
 
-ExecutionResult function_returning_void(Instance&, span<const uint64_t>, int) noexcept
+ExecutionResult function_returning_void(Instance&, span<const Value>, int) noexcept
 {
     return Void;
 }
@@ -43,7 +43,7 @@ TEST(api, execution_result_void)
 
 TEST(api, execution_result_value)
 {
-    const ExecutionResult result = 1234;
+    const ExecutionResult result = Value{1234};
     EXPECT_FALSE(result.trapped);
     EXPECT_TRUE(result.has_value);
     EXPECT_EQ(result.value, 1234);
@@ -58,9 +58,9 @@ TEST(api, execution_result_bool_constructor)
     EXPECT_EQ(result.value, 0);
 }
 
-TEST(api, execution_result_uint64_constructor)
+TEST(api, execution_result_value_constructor)
 {
-    uint64_t value = 1234;
+    Value value{1234};
     const ExecutionResult result{value};
     EXPECT_FALSE(result.trapped);
     EXPECT_TRUE(result.has_value);
@@ -262,7 +262,7 @@ TEST(api, find_exported_function)
         "0061736d010000000105016000017f021001087370656374657374036261720000040401700000050401010102"
         "0606017f0041000b07170403666f6f000001670300037461620100036d656d0200");
 
-    auto bar = [](Instance&, span<const uint64_t>, int) { return 42; };
+    auto bar = [](Instance&, span<const Value>, int) { return Value{42}; };
     const auto bar_type = FuncType{{}, {ValType::i32}};
 
     auto instance_reexported_function =

--- a/test/unittests/execute_call_test.cpp
+++ b/test/unittests/execute_call_test.cpp
@@ -147,11 +147,11 @@ TEST(execute_call, call_indirect_imported_table)
 
     const Module module = parse(bin);
 
-    auto f1 = [](Instance&, span<const uint64_t>, int) { return 1; };
-    auto f2 = [](Instance&, span<const uint64_t>, int) { return 2; };
-    auto f3 = [](Instance&, span<const uint64_t>, int) { return 3; };
-    auto f4 = [](Instance&, span<const uint64_t>, int) { return 4; };
-    auto f5 = [](Instance&, span<const uint64_t>, int) { return Trap; };
+    auto f1 = [](Instance&, span<const Value>, int) { return Value{1}; };
+    auto f2 = [](Instance&, span<const Value>, int) { return Value{2}; };
+    auto f3 = [](Instance&, span<const Value>, int) { return Value{3}; };
+    auto f4 = [](Instance&, span<const Value>, int) { return Value{4}; };
+    auto f5 = [](Instance&, span<const Value>, int) { return Trap; };
 
     auto out_i32 = FuncType{{}, {ValType::i32}};
     auto out_i64 = FuncType{{}, {ValType::i64}};
@@ -218,9 +218,7 @@ TEST(execute_call, imported_function_call)
 
     const auto module = parse(wasm);
 
-    constexpr auto host_foo = [](Instance&, span<const uint64_t>, int) -> ExecutionResult {
-        return 42;
-    };
+    constexpr auto host_foo = [](Instance&, span<const Value>, int) { return Value{42}; };
     const auto host_foo_type = module.typesec[0];
 
     auto instance = instantiate(module, {{host_foo, host_foo_type}});
@@ -245,9 +243,7 @@ TEST(execute_call, imported_function_call_with_arguments)
 
     const auto module = parse(wasm);
 
-    auto host_foo = [](Instance&, span<const uint64_t> args, int) -> ExecutionResult {
-        return args[0] * 2;
-    };
+    auto host_foo = [](Instance&, span<const Value> args, int) { return Value{args[0] * 2}; };
     const auto host_foo_type = module.typesec[0];
 
     auto instance = instantiate(module, {{host_foo, host_foo_type}});
@@ -289,11 +285,11 @@ TEST(execute_call, imported_functions_call_indirect)
     ASSERT_EQ(module.importsec.size(), 2);
     ASSERT_EQ(module.codesec.size(), 2);
 
-    constexpr auto sqr = [](Instance&, span<const uint64_t> args, int) -> ExecutionResult {
-        return args[0] * args[0];
+    constexpr auto sqr = [](Instance&, span<const Value> args, int) {
+        return Value{args[0] * args[0]};
     };
-    constexpr auto isqrt = [](Instance&, span<const uint64_t> args, int) -> ExecutionResult {
-        return (11 + args[0] / 11) / 2;
+    constexpr auto isqrt = [](Instance&, span<const Value> args, int) {
+        return Value{(11 + args[0] / 11) / 2};
     };
 
     auto instance = instantiate(module, {{sqr, module.typesec[0]}, {isqrt, module.typesec[0]}});
@@ -337,8 +333,9 @@ TEST(execute_call, imported_function_from_another_module)
     const auto func_idx = fizzy::find_exported_function(module1, "sub");
     ASSERT_TRUE(func_idx.has_value());
 
-    auto sub = [&instance1, func_idx](Instance&, span<const uint64_t> args,
-                   int) -> ExecutionResult { return fizzy::execute(*instance1, *func_idx, args); };
+    auto sub = [&instance1, func_idx](Instance&, span<const Value> args, int) -> ExecutionResult {
+        return fizzy::execute(*instance1, *func_idx, args);
+    };
 
     auto instance2 = instantiate(module2, {{sub, module1.typesec[0]}});
 
@@ -514,7 +511,7 @@ TEST(execute_call, call_imported_infinite_recursion)
         "0061736d010000000105016000017f020b01036d6f6403666f6f0000030201000a0601040010000b");
 
     const auto module = parse(wasm);
-    auto host_foo = [](Instance& instance, span<const uint64_t>, int depth) -> ExecutionResult {
+    auto host_foo = [](Instance& instance, span<const Value>, int depth) -> ExecutionResult {
         return execute(instance, 0, {}, depth + 1);
     };
     const auto host_foo_type = module.typesec[0];

--- a/test/unittests/execute_control_test.cpp
+++ b/test/unittests/execute_control_test.cpp
@@ -664,7 +664,7 @@ TEST(execute_control, br_1_out_of_function_and_imported_function)
         "0061736d010000000108026000006000017f02150108696d706f727465640866756e6374696f6e000003020101"
         "0a0d010b00034041010c010b41000b");
 
-    constexpr auto fake_imported_function = [](Instance&, span<const uint64_t>,
+    constexpr auto fake_imported_function = [](Instance&, span<const Value>,
                                                 int) noexcept -> ExecutionResult { return Void; };
 
     const auto module = parse(bin);

--- a/test/unittests/execute_test.cpp
+++ b/test/unittests/execute_test.cpp
@@ -12,7 +12,7 @@
 
 using namespace fizzy;
 using namespace fizzy::test;
-using namespace testing;
+using testing::ElementsAre;
 
 TEST(execute, end)
 {
@@ -601,8 +601,8 @@ TEST(execute, imported_function)
     const auto module = parse(wasm);
     ASSERT_EQ(module.typesec.size(), 1);
 
-    constexpr auto host_foo = [](Instance&, span<const uint64_t> args, int) -> ExecutionResult {
-        return args[0] + args[1];
+    constexpr auto host_foo = [](Instance&, span<const Value> args, int) {
+        return Value{args[0] + args[1]};
     };
 
     auto instance = instantiate(module, {{host_foo, module.typesec[0]}});
@@ -621,11 +621,11 @@ TEST(execute, imported_two_functions)
     const auto module = parse(wasm);
     ASSERT_EQ(module.typesec.size(), 1);
 
-    constexpr auto host_foo1 = [](Instance&, span<const uint64_t> args, int) -> ExecutionResult {
-        return args[0] + args[1];
+    constexpr auto host_foo1 = [](Instance&, span<const Value> args, int) {
+        return Value{args[0] + args[1]};
     };
-    constexpr auto host_foo2 = [](Instance&, span<const uint64_t> args, int) -> ExecutionResult {
-        return args[0] * args[1];
+    constexpr auto host_foo2 = [](Instance&, span<const Value> args, int) {
+        return Value{args[0] * args[1]};
     };
 
     auto instance =
@@ -648,11 +648,11 @@ TEST(execute, imported_functions_and_regular_one)
         "0061736d0100000001070160027f7f017f021702036d6f6404666f6f310000036d6f6404666f6f320000030201"
         "000a0901070041aa80a8010b");
 
-    constexpr auto host_foo1 = [](Instance&, span<const uint64_t> args, int) -> ExecutionResult {
-        return args[0] + args[1];
+    constexpr auto host_foo1 = [](Instance&, span<const Value> args, int) {
+        return Value{args[0] + args[1]};
     };
-    constexpr auto host_foo2 = [](Instance&, span<const uint64_t> args, int) -> ExecutionResult {
-        return args[0] * args[0];
+    constexpr auto host_foo2 = [](Instance&, span<const Value> args, int) {
+        return Value{args[0] * args[0]};
     };
 
     const auto module = parse(wasm);
@@ -663,8 +663,8 @@ TEST(execute, imported_functions_and_regular_one)
     EXPECT_THAT(execute(*instance, 1, {20}), Result(400));
 
     // check correct number of arguments is passed to host
-    constexpr auto count_args = [](Instance&, span<const uint64_t> args, int) -> ExecutionResult {
-        return args.size();
+    constexpr auto count_args = [](Instance&, span<const Value> args, int) {
+        return Value{args.size()};
     };
 
     auto instance_counter =
@@ -688,11 +688,11 @@ TEST(execute, imported_two_functions_different_type)
         "0061736d01000000010c0260027f7f017f60017e017e021702036d6f6404666f6f310000036d6f6404666f6f32"
         "0001030201010a0901070042aa80a8010b");
 
-    constexpr auto host_foo1 = [](Instance&, span<const uint64_t> args, int) -> ExecutionResult {
-        return args[0] + args[1];
+    constexpr auto host_foo1 = [](Instance&, span<const Value> args, int) {
+        return Value{args[0] + args[1]};
     };
-    constexpr auto host_foo2 = [](Instance&, span<const uint64_t> args, int) -> ExecutionResult {
-        return args[0] * args[0];
+    constexpr auto host_foo2 = [](Instance&, span<const Value> args, int) {
+        return Value{args[0] * args[0]};
     };
 
     const auto module = parse(wasm);
@@ -712,7 +712,7 @@ TEST(execute, imported_function_traps)
     */
     const auto wasm = from_hex("0061736d0100000001070160027f7f017f020b01036d6f6403666f6f0000");
 
-    constexpr auto host_foo = [](Instance&, span<const uint64_t>, int) -> ExecutionResult {
+    constexpr auto host_foo = [](Instance&, span<const Value>, int) -> ExecutionResult {
         return Trap;
     };
 
@@ -1005,7 +1005,7 @@ TEST(execute, reuse_args)
 
     auto instance = instantiate(parse(wasm));
 
-    const std::vector<uint64_t> args{20, 3};
+    const std::vector<Value> args{20, 3};
     const auto expected = args[0] % (args[0] / args[1]);
     EXPECT_THAT(execute(*instance, 0, args), Result(expected));
     EXPECT_THAT(args, ElementsAre(20, 3));

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -31,7 +31,7 @@ TEST(instantiate, imported_functions)
     const auto bin = from_hex("0061736d0100000001060160017f017f020b01036d6f6403666f6f0000");
     const auto module = parse(bin);
 
-    auto host_foo = [](Instance&, span<const uint64_t>, int) -> ExecutionResult { return Trap; };
+    auto host_foo = [](Instance&, span<const Value>, int) { return Trap; };
     auto instance = instantiate(module, {{host_foo, module.typesec[0]}});
 
     ASSERT_EQ(instance->imported_functions.size(), 1);
@@ -52,8 +52,8 @@ TEST(instantiate, imported_functions_multiple)
         "0061736d0100000001090260017f017f600000021702036d6f6404666f6f310000036d6f6404666f6f320001");
     const auto module = parse(bin);
 
-    auto host_foo1 = [](Instance&, span<const uint64_t>, int) -> ExecutionResult { return Trap; };
-    auto host_foo2 = [](Instance&, span<const uint64_t>, int) -> ExecutionResult { return Trap; };
+    auto host_foo1 = [](Instance&, span<const Value>, int) { return Trap; };
+    auto host_foo2 = [](Instance&, span<const Value>, int) { return Trap; };
     auto instance =
         instantiate(module, {{host_foo1, module.typesec[0]}, {host_foo2, module.typesec[1]}});
 
@@ -88,7 +88,7 @@ TEST(instantiate, imported_function_wrong_type)
     const auto bin = from_hex("0061736d0100000001060160017f017f020b01036d6f6403666f6f0000");
     const auto module = parse(bin);
 
-    auto host_foo = [](Instance&, span<const uint64_t>, int) -> ExecutionResult { return Trap; };
+    auto host_foo = [](Instance&, span<const Value>, int) { return Trap; };
     const auto host_foo_type = FuncType{{}, {}};
 
     EXPECT_THROW_MESSAGE(instantiate(module, {{host_foo, host_foo_type}}), instantiate_error,
@@ -567,7 +567,7 @@ TEST(instantiate, element_section_fills_imported_table)
         "0061736d010000000105016000017f020b01016d037461620170000403050400000000090f020041010b020001"
         "0041020b0202030a1504040041010b040041020b040041030b040041040b");
 
-    auto f0 = [](Instance&, span<const uint64_t>, int) { return 0; };
+    auto f0 = [](Instance&, span<const Value>, int) { return Value{0}; };
 
     table_elements table(4);
     table[0] = ExternalFunction{f0, FuncType{{}, {ValType::i32}}};
@@ -595,7 +595,7 @@ TEST(instantiate, element_section_out_of_bounds_doesnt_change_imported_table)
         "0b0200000a0601040041010b");
     Module module = parse(bin);
 
-    auto f0 = [](Instance&, span<const uint64_t>, int) { return 0; };
+    auto f0 = [](Instance&, span<const Value>, int) { return Value{0}; };
 
     table_elements table(3);
     table[0] = ExternalFunction{f0, FuncType{{}, {ValType::i32}}};

--- a/test/unittests/span_test.cpp
+++ b/test/unittests/span_test.cpp
@@ -57,7 +57,7 @@ TEST(span, stack)
     stack.push(13);
 
     constexpr auto num_items = 2;
-    span<const uint64_t> s(stack.rend() - num_items, num_items);
+    span<const Value> s(stack.rend() - num_items, num_items);
     EXPECT_EQ(s.size(), 2);
     EXPECT_EQ(s[0], 12);
     EXPECT_EQ(s[1], 13);

--- a/test/unittests/value_test.cpp
+++ b/test/unittests/value_test.cpp
@@ -1,0 +1,39 @@
+// Fizzy: A fast WebAssembly interpreter
+// Copyright 2020 The Fizzy Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "value.hpp"
+#include <gtest/gtest.h>
+
+using namespace fizzy;
+
+TEST(value, value_initialization)
+{
+    Value v{};
+    EXPECT_EQ(v.i64, 0);
+}
+
+TEST(value, constructor_from_i64)
+{
+    Value v = 1;
+    EXPECT_EQ(v.i64, 1);
+    v = 2;
+    EXPECT_EQ(v.i64, 2);
+    v = false;
+    EXPECT_EQ(v.i64, 0);
+    v = true;
+    EXPECT_EQ(v.i64, 1);
+    v = uint64_t{111};
+    EXPECT_EQ(v.i64, 111);
+
+    constexpr auto max_i64 = std::numeric_limits<uint64_t>::max();
+    v = max_i64;
+    EXPECT_EQ(v.i64, max_i64);
+}
+
+TEST(value, implicit_conversion_to_i64)
+{
+    const Value v{1};
+    const uint64_t x = v;
+    EXPECT_EQ(x, 1);
+}

--- a/test/utils/asserts.cpp
+++ b/test/utils/asserts.cpp
@@ -14,7 +14,7 @@ std::ostream& operator<<(std::ostream& os, ExecutionResult result)
 
     os << "result(";
     if (result.has_value)
-        os << result.value;
+        os << result.value.i64;
     os << ")";
     return os;
 }

--- a/test/utils/asserts.cpp
+++ b/test/utils/asserts.cpp
@@ -12,10 +12,12 @@ std::ostream& operator<<(std::ostream& os, ExecutionResult result)
     if (result.trapped)
         return os << "trapped";
 
+    const auto format_flags = os.flags();
     os << "result(";
     if (result.has_value)
-        os << result.value.i64;
+        os << result.value.i64 << " [0x" << std::hex << result.value.i64 << "]";
     os << ")";
+    os.flags(format_flags);
     return os;
 }
 }  // namespace fizzy

--- a/test/utils/execute_helpers.hpp
+++ b/test/utils/execute_helpers.hpp
@@ -10,7 +10,7 @@
 namespace fizzy::test
 {
 inline ExecutionResult execute(
-    const Module& module, FuncIdx func_idx, std::initializer_list<uint64_t> args)
+    const Module& module, FuncIdx func_idx, std::initializer_list<Value> args)
 {
     auto instance = instantiate(module);
     return execute(*instance, func_idx, args);


### PR DESCRIPTION
The `Value` is an union for now containing only `i64` value. Later to be extended with `f32`, `f64` and maybe `i32`.

I added implicit conversions from/to `uint64_t` to limit the number of required changes.

The conversion from `std::initializer_list<uint64_t>` not possible in a type safe manner. I guess we will need something like `template<typename T...> TypedArgs` to construct a container of `Value`s. This will also handle usage of different value types in execution invocation.

All will get more complicated if we want constructor from other types (e.g. `float`, `unsigned int`) as we will get ambiguities (e.g. `0` is of type `int` and will not know where to go).