### PR TITLE
clang-format: Use Cpp11 to lower requirements

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 ---
 Language:     Cpp
-Standard:     c++17
+Standard:     Cpp11
 BasedOnStyle: Chromium
 
 AccessModifierOffset: -4


### PR DESCRIPTION
Use deprecated "Standard: Cpp11" meaning "Latest" to lower requirements
of the clang-format tool version.