### PR TITLE
Validate types of instructions in constant expressions

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -270,8 +270,8 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 5352
-          expected_failed: 80
+          expected_passed: 5356
+          expected_failed: 76
           expected_skipped: 6381
 
   sanitizers-macos:
@@ -288,8 +288,8 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 5352
-          expected_failed: 80
+          expected_passed: 5356
+          expected_failed: 76
           expected_skipped: 6381
 
   benchmark:
@@ -400,8 +400,8 @@ jobs:
           expected_failed: 9
           expected_skipped: 7323
       - spectest:
-          expected_passed: 5352
-          expected_failed: 80
+          expected_passed: 5356
+          expected_failed: 76
           expected_skipped: 6381
       - collect_coverage_data
 


### PR DESCRIPTION
Type mismatch when constant expression uses `global.get` looks to be not covered by spec tests (passed tests don't change here when I disable it).