### PR TITLE
Implement float->int trunc instructions

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -271,9 +271,9 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 5581
+          expected_passed: 5589
           expected_failed: 9
-          expected_skipped: 6223
+          expected_skipped: 6215
 
   sanitizers-macos:
     executor: macos
@@ -289,9 +289,9 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 5581
+          expected_passed: 5589
           expected_failed: 9
-          expected_skipped: 6223
+          expected_skipped: 6215
 
   benchmark:
     machine:
@@ -397,13 +397,13 @@ jobs:
           at: ~/build
       - spectest:
           skip_validation: true
-          expected_passed: 4639
+          expected_passed: 4647
           expected_failed: 9
-          expected_skipped: 7165
+          expected_skipped: 7157
       - spectest:
-          expected_passed: 5581
+          expected_passed: 5589
           expected_failed: 9
-          expected_skipped: 6223
+          expected_skipped: 6215
       - collect_coverage_data
 
 workflows:

--- a/lib/fizzy/CMakeLists.txt
+++ b/lib/fizzy/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(
     parser_expr.cpp
     span.hpp
     stack.hpp
+    trunc_boundaries.hpp
     types.hpp
     utf8.cpp
     utf8.hpp

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -1273,6 +1273,7 @@ ExecutionResult execute(Instance& instance, FuncIdx func_idx, span<const Value> 
             binary_op(stack, rotr<uint32_t>);
             break;
         }
+
         case Instr::i64_clz:
         {
             unary_op(stack, clz64);
@@ -1395,6 +1396,19 @@ ExecutionResult execute(Instance& instance, FuncIdx func_idx, span<const Value> 
             binary_op(stack, rotr<uint64_t>);
             break;
         }
+
+        case Instr::f32_add:
+        {
+            binary_op(stack, std::plus<float>{});
+            break;
+        }
+
+        case Instr::f64_add:
+        {
+            binary_op(stack, std::plus<double>{});
+            break;
+        }
+
         case Instr::i32_wrap_i64:
         {
             stack.push(stack.pop().as<uint32_t>());
@@ -1481,16 +1495,6 @@ ExecutionResult execute(Instance& instance, FuncIdx func_idx, span<const Value> 
                 trap = true;
                 goto end;
             }
-            break;
-        }
-        case Instr::f32_add:
-        {
-            binary_op(stack, std::plus<float>{});
-            break;
-        }
-        case Instr::f64_add:
-        {
-            binary_op(stack, std::plus<double>{});
             break;
         }
 

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -6,9 +6,11 @@
 #include "limits.hpp"
 #include "module.hpp"
 #include "stack.hpp"
+#include "trunc_boundaries.hpp"
 #include "types.hpp"
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <cstring>
 #include <stack>
 
@@ -322,6 +324,23 @@ inline DstT extend(SrcT in) noexcept
     }
     else
         return DstT{in};
+}
+
+template <typename SrcT, typename DstT>
+inline bool trunc(OperandStack& stack) noexcept
+{
+    using boundaries = trunc_boundaries<SrcT, DstT>;
+
+    const auto input = stack.top().as<SrcT>();
+    if (input > boundaries::lower && input < boundaries::upper)
+    {
+        assert(!std::isnan(input));
+        assert(input != std::numeric_limits<SrcT>::infinity());
+        assert(input != -std::numeric_limits<SrcT>::infinity());
+        stack.top() = static_cast<DstT>(input);
+        return true;
+    }
+    return false;
 }
 
 template <typename DstT, typename SrcT = DstT>
@@ -1381,6 +1400,42 @@ ExecutionResult execute(Instance& instance, FuncIdx func_idx, span<const Value> 
             stack.push(stack.pop().as<uint32_t>());
             break;
         }
+        case Instr::i32_trunc_f32_s:
+        {
+            if (!trunc<float, int32_t>(stack))
+            {
+                trap = true;
+                goto end;
+            }
+            break;
+        }
+        case Instr::i32_trunc_f32_u:
+        {
+            if (!trunc<float, uint32_t>(stack))
+            {
+                trap = true;
+                goto end;
+            }
+            break;
+        }
+        case Instr::i32_trunc_f64_s:
+        {
+            if (!trunc<double, int32_t>(stack))
+            {
+                trap = true;
+                goto end;
+            }
+            break;
+        }
+        case Instr::i32_trunc_f64_u:
+        {
+            if (!trunc<double, uint32_t>(stack))
+            {
+                trap = true;
+                goto end;
+            }
+            break;
+        }
         case Instr::i64_extend_i32_s:
         {
             const auto value = stack.pop().as<int32_t>();
@@ -1390,6 +1445,42 @@ ExecutionResult execute(Instance& instance, FuncIdx func_idx, span<const Value> 
         case Instr::i64_extend_i32_u:
         {
             // effectively no-op
+            break;
+        }
+        case Instr::i64_trunc_f32_s:
+        {
+            if (!trunc<float, int64_t>(stack))
+            {
+                trap = true;
+                goto end;
+            }
+            break;
+        }
+        case Instr::i64_trunc_f32_u:
+        {
+            if (!trunc<float, uint64_t>(stack))
+            {
+                trap = true;
+                goto end;
+            }
+            break;
+        }
+        case Instr::i64_trunc_f64_s:
+        {
+            if (!trunc<double, int64_t>(stack))
+            {
+                trap = true;
+                goto end;
+            }
+            break;
+        }
+        case Instr::i64_trunc_f64_u:
+        {
+            if (!trunc<double, uint64_t>(stack))
+            {
+                trap = true;
+                goto end;
+            }
             break;
         }
         case Instr::f32_add:
@@ -1445,14 +1536,6 @@ ExecutionResult execute(Instance& instance, FuncIdx func_idx, span<const Value> 
         case Instr::f64_min:
         case Instr::f64_max:
         case Instr::f64_copysign:
-        case Instr::i32_trunc_f32_s:
-        case Instr::i32_trunc_f32_u:
-        case Instr::i32_trunc_f64_s:
-        case Instr::i32_trunc_f64_u:
-        case Instr::i64_trunc_f32_s:
-        case Instr::i64_trunc_f32_u:
-        case Instr::i64_trunc_f64_s:
-        case Instr::i64_trunc_f64_u:
         case Instr::f32_convert_i32_s:
         case Instr::f32_convert_i32_u:
         case Instr::f32_convert_i64_s:

--- a/lib/fizzy/trunc_boundaries.hpp
+++ b/lib/fizzy/trunc_boundaries.hpp
@@ -1,0 +1,81 @@
+// Fizzy: A fast WebAssembly interpreter
+// Copyright 2020 The Fizzy Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+namespace fizzy
+{
+/// Provides _exclusive_ lower and upper boundaries of the range
+/// for which SrcT -> DstT trunc operation has defined results.
+/// Theoretical values are (INTEGER_MIN - 1, INTEGER_MAX + 1) which is
+/// (-2^N - 1, 2^N) where N is the number of integer bits without the sign bit.
+/// However, not all of the theoretical values are representable by the given
+/// floating-point type. Deviations are explained below.
+template <typename SrcT, typename DstT>
+struct trunc_boundaries;
+
+template <>
+struct trunc_boundaries<float, int32_t>
+{
+    /// The first representable value lower than theoretical -2147483649.
+    static constexpr float lower = -2147483904.0;
+
+    static constexpr float upper = 2147483648.0;
+};
+
+template <>
+struct trunc_boundaries<float, uint32_t>
+{
+    static constexpr float lower = -1.0;
+    static constexpr float upper = 4294967296.0;
+};
+
+template <>
+struct trunc_boundaries<double, int32_t>
+{
+    static constexpr double lower = -2147483649.0;
+    static constexpr double upper = 2147483648.0;
+};
+
+template <>
+struct trunc_boundaries<double, uint32_t>
+{
+    static constexpr double lower = -1.0;
+    static constexpr double upper = 4294967296.0;
+};
+
+template <>
+struct trunc_boundaries<float, int64_t>
+{
+    /// The first representable value lower than theoretical -9223372036854775809.
+    static constexpr float lower = -9223373136366403584.0;
+
+    static constexpr float upper = 9223372036854775808.0;
+};
+
+template <>
+struct trunc_boundaries<float, uint64_t>
+{
+    static constexpr float lower = -1.0;
+    static constexpr float upper = 18446744073709551616.0;
+};
+
+template <>
+struct trunc_boundaries<double, int64_t>
+{
+    /// The first representable value lower than theoretical -9223372036854775809.
+    static constexpr double lower = -9223372036854777856.0;
+
+    static constexpr double upper = 9223372036854775808.0;
+};
+
+template <>
+struct trunc_boundaries<double, uint64_t>
+{
+    static constexpr double lower = -1.0;
+    static constexpr double upper = 18446744073709551616.0;
+};
+}  // namespace fizzy

--- a/test/unittests/execute_floating_point_test.cpp
+++ b/test/unittests/execute_floating_point_test.cpp
@@ -4,9 +4,12 @@
 
 #include "execute.hpp"
 #include "parser.hpp"
+#include "trunc_boundaries.hpp"
 #include <gtest/gtest.h>
 #include <test/utils/asserts.hpp>
+#include <test/utils/floating_point_utils.hpp>
 #include <test/utils/hex.hpp>
+#include <cmath>
 
 using namespace fizzy;
 using namespace fizzy::test;
@@ -66,4 +69,213 @@ TEST(execute_floating_point, f64_add)
 
     auto instance = instantiate(parse(wasm));
     EXPECT_THAT(execute(*instance, 0, {1.0011, 6.0066}), Result(7.0077));
+}
+
+
+template <typename SrcT, typename DstT>
+struct ConversionPairWasmTraits;
+
+template <>
+struct ConversionPairWasmTraits<float, int32_t>
+{
+    static constexpr auto opcode_name = "i32_trunc_f32_s";
+    static constexpr auto opcode = Instr::i32_trunc_f32_s;
+    static constexpr auto src_valtype = ValType::f32;
+    static constexpr auto dst_valtype = ValType::i32;
+};
+template <>
+struct ConversionPairWasmTraits<float, uint32_t>
+{
+    static constexpr auto opcode_name = "i32_trunc_f32_u";
+    static constexpr auto opcode = Instr::i32_trunc_f32_u;
+    static constexpr auto src_valtype = ValType::f32;
+    static constexpr auto dst_valtype = ValType::i32;
+};
+template <>
+struct ConversionPairWasmTraits<double, int32_t>
+{
+    static constexpr auto opcode_name = "i32_trunc_f64_s";
+    static constexpr auto opcode = Instr::i32_trunc_f64_s;
+    static constexpr auto src_valtype = ValType::f64;
+    static constexpr auto dst_valtype = ValType::i32;
+};
+template <>
+struct ConversionPairWasmTraits<double, uint32_t>
+{
+    static constexpr auto opcode_name = "i32_trunc_f64_u";
+    static constexpr auto opcode = Instr::i32_trunc_f64_u;
+    static constexpr auto src_valtype = ValType::f64;
+    static constexpr auto dst_valtype = ValType::i32;
+};
+template <>
+struct ConversionPairWasmTraits<float, int64_t>
+{
+    static constexpr auto opcode_name = "i64_trunc_f32_s";
+    static constexpr auto opcode = Instr::i64_trunc_f32_s;
+    static constexpr auto src_valtype = ValType::f32;
+    static constexpr auto dst_valtype = ValType::i64;
+};
+template <>
+struct ConversionPairWasmTraits<float, uint64_t>
+{
+    static constexpr auto opcode_name = "i64_trunc_f32_u";
+    static constexpr auto opcode = Instr::i64_trunc_f32_u;
+    static constexpr auto src_valtype = ValType::f32;
+    static constexpr auto dst_valtype = ValType::i64;
+};
+template <>
+struct ConversionPairWasmTraits<double, int64_t>
+{
+    static constexpr auto opcode_name = "i64_trunc_f64_s";
+    static constexpr auto opcode = Instr::i64_trunc_f64_s;
+    static constexpr auto src_valtype = ValType::f64;
+    static constexpr auto dst_valtype = ValType::i64;
+};
+template <>
+struct ConversionPairWasmTraits<double, uint64_t>
+{
+    static constexpr auto opcode_name = "i64_trunc_f64_u";
+    static constexpr auto opcode = Instr::i64_trunc_f64_u;
+    static constexpr auto src_valtype = ValType::f64;
+    static constexpr auto dst_valtype = ValType::i64;
+};
+
+template <typename SrcT, typename DstT>
+struct ConversionPair : ConversionPairWasmTraits<SrcT, DstT>
+{
+    using src_type = SrcT;
+    using dst_type = DstT;
+};
+
+struct ConversionName
+{
+    template <typename T>
+    static std::string GetName(int /*unused*/)
+    {
+        return T::opcode_name;
+    }
+};
+
+template <typename T>
+class execute_floating_point_trunc : public testing::Test
+{
+};
+
+using TruncPairs = testing::Types<ConversionPair<float, int32_t>, ConversionPair<float, uint32_t>,
+    ConversionPair<double, int32_t>, ConversionPair<double, uint32_t>,
+    ConversionPair<float, int64_t>, ConversionPair<float, uint64_t>,
+    ConversionPair<double, int64_t>, ConversionPair<double, uint64_t>>;
+TYPED_TEST_SUITE(execute_floating_point_trunc, TruncPairs, ConversionName);
+
+TYPED_TEST(execute_floating_point_trunc, trunc)
+{
+    using FloatT = typename TypeParam::src_type;
+    using IntT = typename TypeParam::dst_type;
+    using FloatLimits = std::numeric_limits<FloatT>;
+    using IntLimits = std::numeric_limits<IntT>;
+
+    /* wat2wasm
+    (func (param f32) (result i32)
+      local.get 0
+      i32.trunc_f32_s
+    )
+    */
+    auto wasm = from_hex("0061736d0100000001060160017d017f030201000a070105002000a80b");
+
+    // Find and replace changeable values: types and the conversion instruction.
+    constexpr auto param_type = static_cast<uint8_t>(ValType::f32);
+    constexpr auto result_type = static_cast<uint8_t>(ValType::i32);
+    constexpr auto opcode = static_cast<uint8_t>(Instr::i32_trunc_f32_s);
+    ASSERT_EQ(std::count(wasm.begin(), wasm.end(), param_type), 1);
+    ASSERT_EQ(std::count(wasm.begin(), wasm.end(), result_type), 1);
+    ASSERT_EQ(std::count(wasm.begin(), wasm.end(), opcode), 1);
+    *std::find(wasm.begin(), wasm.end(), param_type) = static_cast<uint8_t>(TypeParam::src_valtype);
+    *std::find(wasm.begin(), wasm.end(), result_type) =
+        static_cast<uint8_t>(TypeParam::dst_valtype);
+    *std::find(wasm.begin(), wasm.end(), opcode) = static_cast<uint8_t>(TypeParam::opcode);
+
+    auto instance = instantiate(parse(wasm));
+
+    // Zero.
+    EXPECT_THAT(execute(*instance, 0, {FloatT{0}}), Result(IntT{0}));
+    EXPECT_THAT(execute(*instance, 0, {-FloatT{0}}), Result(IntT{0}));
+
+    // Something around 0.0.
+    EXPECT_THAT(execute(*instance, 0, {FloatLimits::denorm_min()}), Result(IntT{0}));
+    EXPECT_THAT(execute(*instance, 0, {-FloatLimits::denorm_min()}), Result(IntT{0}));
+
+    // Something smaller than 2.0.
+    EXPECT_THAT(execute(*instance, 0, {std::nextafter(FloatT{2}, FloatT{0})}), Result(IntT{1}));
+
+    // Something bigger than -1.0.
+    EXPECT_THAT(execute(*instance, 0, {std::nextafter(FloatT{-1}, FloatT{0})}), Result(IntT{0}));
+
+    {
+        // BOUNDARIES OF DEFINITION
+        //
+        // Here we want to identify and test the boundary values of the defined behavior of the
+        // trunc instructions. For undefined results the execution must trap.
+        // Note that floating point type can represent any power of 2.
+
+        using expected_boundaries = trunc_boundaries<FloatT, IntT>;
+
+        // For iN with max value 2^N-1 the float(2^N) exists and trunc(float(2^N)) to iN
+        // is undefined.
+        const auto upper_boundary = std::pow(FloatT{2}, FloatT{IntLimits::digits});
+        EXPECT_EQ(upper_boundary, expected_boundaries::upper);
+        EXPECT_THAT(execute(*instance, 0, {upper_boundary}), Traps());
+
+        // But the trunc() of the next float value smaller than 2^N is defined.
+        // Depending on the resolution of the floating point type, the result integer value may
+        // be other than 2^(N-1).
+        const auto max_defined = std::nextafter(upper_boundary, FloatT{0});
+        const auto max_defined_int = static_cast<IntT>(max_defined);
+        EXPECT_THAT(execute(*instance, 0, {max_defined}), Result(max_defined_int));
+
+        // The lower boundary is:
+        // - for signed integers: -2^N - 1,
+        // - for unsigned integers: -1.
+        // However, the -2^N - 1 may be not representative in a float type so we compute it as
+        // floor(-2^N - epsilon).
+        const auto min_defined_int = IntLimits::min();
+        const auto lower_boundary =
+            std::floor(std::nextafter(FloatT{min_defined_int}, -FloatLimits::infinity()));
+        EXPECT_EQ(lower_boundary, expected_boundaries::lower);
+        EXPECT_THAT(execute(*instance, 0, {lower_boundary}), Traps());
+
+        const auto min_defined = std::nextafter(lower_boundary, FloatT{0});
+        EXPECT_THAT(execute(*instance, 0, {min_defined}), Result(min_defined_int));
+    }
+
+    {
+        // NaNs.
+        EXPECT_THAT(execute(*instance, 0, {FloatLimits::quiet_NaN()}), Traps());
+        EXPECT_THAT(execute(*instance, 0, {FloatLimits::signaling_NaN()}), Traps());
+        EXPECT_THAT(execute(*instance, 0, {FP<FloatT>::nan(FP<FloatT>::canon)}), Traps());
+        EXPECT_THAT(execute(*instance, 0, {-FP<FloatT>::nan(FP<FloatT>::canon)}), Traps());
+        EXPECT_THAT(execute(*instance, 0, {FP<FloatT>::nan(FP<FloatT>::canon + 1)}), Traps());
+        EXPECT_THAT(execute(*instance, 0, {-FP<FloatT>::nan(FP<FloatT>::canon + 1)}), Traps());
+        EXPECT_THAT(execute(*instance, 0, {FP<FloatT>::nan(1)}), Traps());
+        EXPECT_THAT(execute(*instance, 0, {-FP<FloatT>::nan(1)}), Traps());
+        EXPECT_THAT(execute(*instance, 0, {FP<FloatT>::nan(0xdead)}), Traps());
+        EXPECT_THAT(execute(*instance, 0, {-FP<FloatT>::nan(0xdead)}), Traps());
+        const auto signaling_nan = FP<FloatT>::nan(FP<FloatT>::canon >> 1);
+        EXPECT_THAT(execute(*instance, 0, {signaling_nan}), Traps());
+        EXPECT_THAT(execute(*instance, 0, {-signaling_nan}), Traps());
+
+        const auto inf = FloatLimits::infinity();
+        EXPECT_THAT(execute(*instance, 0, {inf}), Traps());
+        EXPECT_THAT(execute(*instance, 0, {-inf}), Traps());
+
+        EXPECT_THAT(execute(*instance, 0, {FloatLimits::max()}), Traps());
+        EXPECT_THAT(execute(*instance, 0, {FloatLimits::lowest()}), Traps());
+    }
+
+    if constexpr (IntLimits::is_signed)
+    {
+        // Something bigger than -2.0.
+        const auto arg = std::nextafter(FloatT{-2}, FloatT{0});
+        const auto result = execute(*instance, 0, {arg});
+        EXPECT_EQ(result.value.template as<IntT>(), FloatT{-1});
+    }
 }


### PR DESCRIPTION
The operator from the wasm spec is partial, i.e. it has some undefined results.
![image](https://user-images.githubusercontent.com/573380/89308598-bd5fa800-d672-11ea-829a-92dd2cbf547e.png)
But, the execution spec requires to trap on operator's undefined result.
![image](https://user-images.githubusercontent.com/573380/89308772-f009a080-d672-11ea-910b-ca0ec310dd04.png)
