### PR TITLE
test: Improve spectest runner output

### DIFF
--- a/test/smoketests/spectests/CMakeLists.txt
+++ b/test/smoketests/spectests/CMakeLists.txt
@@ -23,6 +23,36 @@ set_tests_properties(
 )
 
 add_test(
+        NAME fizzy/smoketests/spectests/showpassed
+        COMMAND fizzy-spectests ${CMAKE_CURRENT_LIST_DIR}/default --show-passed
+)
+set_tests_properties(
+        fizzy/smoketests/spectests/showpassed
+        PROPERTIES
+        PASS_REGULAR_EXPRESSION "PASSED 26, FAILED 1, SKIPPED 3"
+)
+
+add_test(
+        NAME fizzy/smoketests/spectests/showskipped
+        COMMAND fizzy-spectests ${CMAKE_CURRENT_LIST_DIR}/default --show-skipped
+)
+set_tests_properties(
+        fizzy/smoketests/spectests/showskipped
+        PROPERTIES
+        PASS_REGULAR_EXPRESSION "PASSED 26, FAILED 1, SKIPPED 3"
+)
+
+add_test(
+        NAME fizzy/smoketests/spectests/hidefailed
+        COMMAND fizzy-spectests ${CMAKE_CURRENT_LIST_DIR}/default --hide-failed
+)
+set_tests_properties(
+        fizzy/smoketests/spectests/hidefailed
+        PROPERTIES
+        PASS_REGULAR_EXPRESSION "PASSED 26, FAILED 1, SKIPPED 3"
+)
+
+add_test(
     NAME fizzy/smoketests/spectests/failures
     COMMAND fizzy-spectests ${CMAKE_CURRENT_LIST_DIR}/failures
 )
@@ -67,6 +97,9 @@ set_tests_properties(
 set_tests_properties(
     fizzy/smoketests/spectests/default
     fizzy/smoketests/spectests/skipvalidation
+    fizzy/smoketests/spectests/showpassed
+    fizzy/smoketests/spectests/showskipped
+    fizzy/smoketests/spectests/hidefailed
     fizzy/smoketests/spectests/failures
     fizzy/smoketests/spectests/broken
     fizzy/smoketests/spectests/cli-missing-dir-arg


### PR DESCRIPTION
Closes #450 

Current output without skipped:
```
> bin/fizzy-spectests ~/dev/wasm-spec/test/core/json/float_memory/
Running tests from /home/andrei/dev/wasm-spec/test/core/json/float_memory/float_memory.json
..s..ssFs..s..s..s..ssFs..s..s..s..ssFs..s..s..s..ssFs..s..s..s..ssFs..s..s..s..ssFs..s..s
Line 21: assert_return FAILED Incorrect returned value. Expected: 2141192192 (0x7fa00000) Actual: 0 (0x0)
Line 46: assert_return FAILED Incorrect returned value. Expected: 9219994337134247936 (0x7ff4000000000000) Actual: 0 (0x0)
Line 73: assert_return FAILED Incorrect returned value. Expected: 2141192192 (0x7fa00000) Actual: 0 (0x0)
Line 98: assert_return FAILED Incorrect returned value. Expected: 9219994337134247936 (0x7ff4000000000000) Actual: 0 (0x0)
Line 125: assert_return FAILED Incorrect returned value. Expected: 2144337921 (0x7fd00001) Actual: 0 (0x0)
Line 150: assert_return FAILED Incorrect returned value. Expected: 9222246136947933185 (0x7ffc000000000001) Actual: 0 (0x0)
90 tests ran from float_memory.json.
  PASSED 48, FAILED 6, SKIPPED 36.

TOTAL 90 tests ran from "/home/andrei/dev/wasm-spec/test/core/json/float_memory/".
  PASSED 48, FAILED 6, SKIPPED 36.
```

With skipped:
```
> bin/fizzy-spectests ~/dev/wasm-spec/test/core/json/float_memory/ --show-skipped
Running tests from /home/andrei/dev/wasm-spec/test/core/json/float_memory/float_memory.json
..s..ssFs..s..s..s..ssFs..s..s..s..ssFs..s..s..s..ssFs..s..s..s..ssFs..s..s..s..ssFs..s..s
Line 16: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 19: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 20: action SKIPPED Unsupported feature: Floating point instruction.
Line 21: assert_return FAILED Incorrect returned value. Expected: 2141192192 (0x7fa00000) Actual: 0 (0x0)
Line 22: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 25: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 28: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 41: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 44: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 45: action SKIPPED Unsupported feature: Floating point instruction.
Line 46: assert_return FAILED Incorrect returned value. Expected: 9219994337134247936 (0x7ff4000000000000) Actual: 0 (0x0)
Line 47: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 50: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 53: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 68: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 71: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 72: action SKIPPED Unsupported feature: Floating point instruction.
Line 73: assert_return FAILED Incorrect returned value. Expected: 2141192192 (0x7fa00000) Actual: 0 (0x0)
Line 74: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 77: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 80: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 93: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 96: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 97: action SKIPPED Unsupported feature: Floating point instruction.
Line 98: assert_return FAILED Incorrect returned value. Expected: 9219994337134247936 (0x7ff4000000000000) Actual: 0 (0x0)
Line 99: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 102: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 105: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 120: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 123: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 124: action SKIPPED Unsupported feature: Floating point instruction.
Line 125: assert_return FAILED Incorrect returned value. Expected: 2144337921 (0x7fd00001) Actual: 0 (0x0)
Line 126: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 129: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 132: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 145: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 148: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 149: action SKIPPED Unsupported feature: Floating point instruction.
Line 150: assert_return FAILED Incorrect returned value. Expected: 9222246136947933185 (0x7ffc000000000001) Actual: 0 (0x0)
Line 151: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 154: assert_return SKIPPED Unsupported feature: Floating point instruction.
Line 157: assert_return SKIPPED Unsupported feature: Floating point instruction.
90 tests ran from float_memory.json.
  PASSED 48, FAILED 6, SKIPPED 36.

TOTAL 90 tests ran from "/home/andrei/dev/wasm-spec/test/core/json/float_memory/".
  PASSED 48, FAILED 6, SKIPPED 36.
```

Also supported are `--show-passed` and `--hide-failed`.