### PR TITLE
Implement f64.promote_f32 instruction

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -271,9 +271,9 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 10556
+          expected_passed: 10560
           expected_failed: 3
-          expected_skipped: 1254
+          expected_skipped: 1250
 
   sanitizers-macos:
     executor: macos
@@ -289,9 +289,9 @@ jobs:
       - benchmark:
           min_time: "0.01"
       - spectest:
-          expected_passed: 10556
+          expected_passed: 10560
           expected_failed: 3
-          expected_skipped: 1254
+          expected_skipped: 1250
 
   benchmark:
     machine:
@@ -397,13 +397,13 @@ jobs:
           at: ~/build
       - spectest:
           skip_validation: true
-          expected_passed: 9614
+          expected_passed: 9618
           expected_failed: 3
-          expected_skipped: 2196
+          expected_skipped: 2192
       - spectest:
-          expected_passed: 10556
+          expected_passed: 10560
           expected_failed: 3
-          expected_skipped: 1254
+          expected_skipped: 1250
       - collect_coverage_data
 
 workflows:

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -1661,6 +1661,11 @@ ExecutionResult execute(Instance& instance, FuncIdx func_idx, span<const Value> 
             convert<uint64_t, double>(stack);
             break;
         }
+        case Instr::f64_promote_f32:
+        {
+            stack.top() = double{stack.top().f32};
+            break;
+        }
 
         case Instr::f32_abs:
         case Instr::f32_neg:
@@ -1689,7 +1694,6 @@ ExecutionResult execute(Instance& instance, FuncIdx func_idx, span<const Value> 
         case Instr::f64_max:
         case Instr::f64_copysign:
         case Instr::f32_demote_f64:
-        case Instr::f64_promote_f32:
         case Instr::i32_reinterpret_f32:
         case Instr::i64_reinterpret_f64:
         case Instr::f32_reinterpret_i32:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/573380/89320624-fd7a5700-d681-11ea-9e00-f87923f2cf42.png)

This is rather straight forward as conversion `f32` to `f64` is lossless. The only fancy checks are for `NaN` values. Canonical NaN must be converted to canonical one, and any other NaN must be converted to any arithmetic NaN.

https://webassembly.github.io/spec/core/exec/numerics.html#op-promote
