### PR TITLE
Check floats compliance with IEEE 754

### DIFF
--- a/lib/fizzy/value.hpp
+++ b/lib/fizzy/value.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 
 namespace fizzy
 {
@@ -13,6 +14,9 @@ union Value
     uint64_t i64;
     float f32;
     double f64;
+
+    static_assert(std::numeric_limits<decltype(f32)>::is_iec559);
+    static_assert(std::numeric_limits<decltype(f64)>::is_iec559);
 
     Value() = default;
 


### PR DESCRIPTION
This checks if the floating point types used to implement `f32` and `f64` Wasm types are compliant with IEEE 754.

The CMake check is rather difficult to do. We would need to check if a test program compiles.