### PR TITLE
Mark size() const in OperandStack

### DIFF
--- a/lib/fizzy/stack.hpp
+++ b/lib/fizzy/stack.hpp
@@ -99,7 +99,7 @@ public:
     OperandStack& operator=(const OperandStack&) = delete;
 
     /// The current number of items on the stack (aka stack height).
-    size_t size() noexcept { return static_cast<size_t>(m_top + 1 - bottom()); }
+    size_t size() const noexcept { return static_cast<size_t>(m_top + 1 - bottom()); }
 
     /// Returns the reference to the top item.
     /// Requires non-empty stack.


### PR DESCRIPTION
cppcheck complains that the assertions which use `size()` could have side-effects because `size()` is not marked const -- I agree with that, but not sure if this has caused any downside.