### PR TITLE
test: Add proper f{32,64}_add tests

### DIFF
--- a/test/unittests/floating_point_utils_test.cpp
+++ b/test/unittests/floating_point_utils_test.cpp
@@ -190,3 +190,16 @@ TEST(floating_point_utils, compare_double)
     EXPECT_NE(FP{cnan}, snan);
     EXPECT_NE(cnan, FP{snan});
 }
+
+TEST(floating_point_utils, compare_zero)
+{
+    EXPECT_EQ(FP{0.0}, FP{0.0});
+    EXPECT_EQ(FP{-0.0}, FP{-0.0});
+    EXPECT_EQ(FP{0.0f}, FP{0.0f});
+    EXPECT_EQ(FP{-0.0f}, FP{-0.0f});
+
+    EXPECT_NE(FP{-0.0}, FP{0.0});
+    EXPECT_NE(FP{0.0}, FP{-0.0});
+    EXPECT_NE(FP{-0.0f}, FP{0.0f});
+    EXPECT_NE(FP{0.0f}, FP{-0.0f});
+}


### PR DESCRIPTION
It adds/fixes some testing helpers for floating point instructions.

Then it adds wasm spec-driver tests for `fadd`, i.e. it adds checks for these points from the definition:
![image](https://user-images.githubusercontent.com/573380/89800909-b1bb2800-db2f-11ea-81c8-1f2c8c143282.png)
