### PR TITLE
Add value type to ExternalGlobal and check it at instantiate

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -135,8 +135,11 @@ void match_imported_globals(const std::vector<GlobalType>& module_imported_globa
 
     for (size_t i = 0; i < imported_globals.size(); ++i)
     {
-        // TODO: match value type
-
+        if (imported_globals[i].type.value_type != module_imported_globals[i].value_type)
+        {
+            throw instantiate_error{
+                "global " + std::to_string(i) + " value type doesn't match module's global type"};
+        }
         if (imported_globals[i].type.is_mutable != module_imported_globals[i].is_mutable)
         {
             throw instantiate_error{"global " + std::to_string(i) +

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -137,7 +137,7 @@ void match_imported_globals(const std::vector<GlobalType>& module_imported_globa
     {
         // TODO: match value type
 
-        if (imported_globals[i].is_mutable != module_imported_globals[i].is_mutable)
+        if (imported_globals[i].type.is_mutable != module_imported_globals[i].is_mutable)
         {
             throw instantiate_error{"global " + std::to_string(i) +
                                     " mutability doesn't match module's global mutability"};
@@ -950,7 +950,7 @@ ExecutionResult execute(Instance& instance, FuncIdx func_idx, span<const Value> 
             const auto idx = read<uint32_t>(immediates);
             if (idx < instance.imported_globals.size())
             {
-                assert(instance.imported_globals[idx].is_mutable);
+                assert(instance.imported_globals[idx].type.is_mutable);
                 *instance.imported_globals[idx].value = stack.pop();
             }
             else
@@ -2011,14 +2011,14 @@ std::optional<ExternalGlobal> find_exported_global(Instance& instance, std::stri
     {
         // imported global is reexported
         return ExternalGlobal{instance.imported_globals[global_idx].value,
-            instance.imported_globals[global_idx].is_mutable};
+            instance.imported_globals[global_idx].type};
     }
     else
     {
         // global owned by instance
         const auto module_global_idx = global_idx - instance.imported_globals.size();
         return ExternalGlobal{&instance.globals[module_global_idx],
-            instance.module.globalsec[module_global_idx].type.is_mutable};
+            instance.module.globalsec[module_global_idx].type};
     }
 }
 

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -59,7 +59,7 @@ struct ExternalMemory
 struct ExternalGlobal
 {
     Value* value = nullptr;
-    bool is_mutable = false;
+    GlobalType type;
 };
 
 using bytes_ptr = std::unique_ptr<bytes, void (*)(bytes*)>;

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -94,7 +94,7 @@ TEST(api, resolve_imported_functions)
     EXPECT_EQ(external_functions.size(), 4);
 
     Value global = 0;
-    const std::vector<ExternalGlobal> external_globals{{&global, false}};
+    const std::vector<ExternalGlobal> external_globals{{&global, {ValType::i32, false}}};
     auto instance = instantiate(
         module, external_functions, {}, {}, std::vector<ExternalGlobal>(external_globals));
 
@@ -316,22 +316,22 @@ TEST(api, find_exported_global)
     auto opt_global = find_exported_global(*instance, "g1");
     ASSERT_TRUE(opt_global);
     EXPECT_EQ(*opt_global->value, 0);
-    EXPECT_TRUE(opt_global->is_mutable);
+    EXPECT_TRUE(opt_global->type.is_mutable);
 
     opt_global = find_exported_global(*instance, "g2");
     ASSERT_TRUE(opt_global);
     EXPECT_EQ(*opt_global->value, 1);
-    EXPECT_FALSE(opt_global->is_mutable);
+    EXPECT_FALSE(opt_global->type.is_mutable);
 
     opt_global = find_exported_global(*instance, "g3");
     ASSERT_TRUE(opt_global);
     EXPECT_EQ(*opt_global->value, 2);
-    EXPECT_TRUE(opt_global->is_mutable);
+    EXPECT_TRUE(opt_global->type.is_mutable);
 
     opt_global = find_exported_global(*instance, "g4");
     ASSERT_TRUE(opt_global);
     EXPECT_EQ(*opt_global->value, 3);
-    EXPECT_FALSE(opt_global->is_mutable);
+    EXPECT_FALSE(opt_global->type.is_mutable);
 
     EXPECT_FALSE(find_exported_global(*instance, "g5"));
     EXPECT_FALSE(find_exported_global(*instance, "f"));
@@ -352,18 +352,18 @@ TEST(api, find_exported_global)
         "017f0141010b071b050267310300026732030103746162010001660000036d656d02000a05010300010b");
 
     Value g1 = 42;
-    auto instance_reexported_global =
-        instantiate(parse(wasm_reexported_global), {}, {}, {}, {ExternalGlobal{&g1, false}});
+    auto instance_reexported_global = instantiate(
+        parse(wasm_reexported_global), {}, {}, {}, {ExternalGlobal{&g1, {ValType::i32, false}}});
 
     opt_global = find_exported_global(*instance_reexported_global, "g1");
     ASSERT_TRUE(opt_global);
     EXPECT_EQ(opt_global->value, &g1);
-    EXPECT_FALSE(opt_global->is_mutable);
+    EXPECT_FALSE(opt_global->type.is_mutable);
 
     opt_global = find_exported_global(*instance_reexported_global, "g2");
     ASSERT_TRUE(opt_global);
     EXPECT_EQ(*opt_global->value, 1);
-    EXPECT_TRUE(opt_global->is_mutable);
+    EXPECT_TRUE(opt_global->type.is_mutable);
 
     EXPECT_FALSE(find_exported_global(*instance_reexported_global, "g3").has_value());
 

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -299,38 +299,42 @@ TEST(api, find_exported_global)
     (module
       (func $f (export "f") nop)
       (global (export "g1") (mut i32) (i32.const 0))
-      (global (export "g2") i32 (i32.const 1))
-      (global (export "g3") (mut i32) (i32.const 2))
-      (global (export "g4") i32 (i32.const 3))
+      (global (export "g2") i64 (i64.const 1))
+      (global (export "g3") (mut f32) (f32.const 2.345))
+      (global (export "g4") f64 (f64.const 3.456))
       (table (export "tab") 0 anyfunc)
       (memory (export "mem") 0)
     )
      */
     const auto wasm = from_hex(
-        "0061736d010000000104016000000302010004040170000005030100000615047f0141000b7f0041010b7f0141"
-        "020b7f0041030b072507016600000267310300026732030102673303020267340303037461620100036d656d02"
-        "000a05010300010b");
+        "0061736d01000000010401600000030201000404017000000503010000061f047f0141000b7e0042010b7d0143"
+        "7b1416400b7c0044d9cef753e3a50b400b07250701660000026731030002673203010267330302026734030303"
+        "7461620100036d656d02000a05010300010b");
 
     auto instance = instantiate(parse(wasm));
 
     auto opt_global = find_exported_global(*instance, "g1");
     ASSERT_TRUE(opt_global);
-    EXPECT_EQ(*opt_global->value, 0);
+    EXPECT_EQ(opt_global->value->i64, 0);
+    EXPECT_EQ(opt_global->type.value_type, ValType::i32);
     EXPECT_TRUE(opt_global->type.is_mutable);
 
     opt_global = find_exported_global(*instance, "g2");
     ASSERT_TRUE(opt_global);
-    EXPECT_EQ(*opt_global->value, 1);
+    EXPECT_EQ(opt_global->value->i64, 1);
+    EXPECT_EQ(opt_global->type.value_type, ValType::i64);
     EXPECT_FALSE(opt_global->type.is_mutable);
 
     opt_global = find_exported_global(*instance, "g3");
     ASSERT_TRUE(opt_global);
-    EXPECT_EQ(*opt_global->value, 2);
+    EXPECT_EQ(opt_global->value->f32, 2.345f);
+    EXPECT_EQ(opt_global->type.value_type, ValType::f32);
     EXPECT_TRUE(opt_global->type.is_mutable);
 
     opt_global = find_exported_global(*instance, "g4");
     ASSERT_TRUE(opt_global);
-    EXPECT_EQ(*opt_global->value, 3);
+    EXPECT_EQ(opt_global->value->f64, 3.456);
+    EXPECT_EQ(opt_global->type.value_type, ValType::f64);
     EXPECT_FALSE(opt_global->type.is_mutable);
 
     EXPECT_FALSE(find_exported_global(*instance, "g5"));
@@ -341,7 +345,7 @@ TEST(api, find_exported_global)
     /* wat2wasm
     (module
       (global (export "g1") (import "test" "g2") i32)
-      (global (export "g2") (mut i32) (i32.const 1))
+      (global (export "g2") (mut i64) (i64.const 1))
       (table (export "tab") 0 anyfunc)
       (func (export "f") nop)
       (memory (export "mem") 0)
@@ -349,7 +353,7 @@ TEST(api, find_exported_global)
      */
     const auto wasm_reexported_global = from_hex(
         "0061736d01000000010401600000020c010474657374026732037f000302010004040170000005030100000606"
-        "017f0141010b071b050267310300026732030103746162010001660000036d656d02000a05010300010b");
+        "017e0142010b071b050267310300026732030103746162010001660000036d656d02000a05010300010b");
 
     Value g1 = 42;
     auto instance_reexported_global = instantiate(
@@ -358,11 +362,13 @@ TEST(api, find_exported_global)
     opt_global = find_exported_global(*instance_reexported_global, "g1");
     ASSERT_TRUE(opt_global);
     EXPECT_EQ(opt_global->value, &g1);
+    EXPECT_EQ(opt_global->type.value_type, ValType::i32);
     EXPECT_FALSE(opt_global->type.is_mutable);
 
     opt_global = find_exported_global(*instance_reexported_global, "g2");
     ASSERT_TRUE(opt_global);
-    EXPECT_EQ(*opt_global->value, 1);
+    EXPECT_EQ(opt_global->value->i64, 1);
+    EXPECT_EQ(opt_global->type.value_type, ValType::i64);
     EXPECT_TRUE(opt_global->type.is_mutable);
 
     EXPECT_FALSE(find_exported_global(*instance_reexported_global, "g3").has_value());

--- a/test/unittests/execute_test.cpp
+++ b/test/unittests/execute_test.cpp
@@ -141,7 +141,8 @@ TEST(execute, global_get_imported)
     const auto module = parse(wasm);
 
     Value global_value = 42;
-    auto instance = instantiate(module, {}, {}, {}, {ExternalGlobal{&global_value, false}});
+    auto instance =
+        instantiate(module, {}, {}, {}, {ExternalGlobal{&global_value, {ValType::i64, false}}});
 
     EXPECT_THAT(execute(*instance, 0, {}), Result(42));
 
@@ -173,8 +174,8 @@ TEST(execute, global_get_imported_and_internal)
 
     Value g1 = 40;
     Value g2 = 41;
-    auto instance =
-        instantiate(module, {}, {}, {}, {ExternalGlobal{&g1, false}, ExternalGlobal{&g2, false}});
+    auto instance = instantiate(module, {}, {}, {},
+        {ExternalGlobal{&g1, {ValType::i32, false}}, ExternalGlobal{&g2, {ValType::i32, false}}});
 
     EXPECT_THAT(execute(*instance, 0, {}), Result(40));
     EXPECT_THAT(execute(*instance, 1, {}), Result(41));
@@ -204,8 +205,8 @@ TEST(execute, global_get_float)
 
     Value g1 = 5.6f;
     Value g2 = 7.8;
-    auto instance = instantiate(
-        parse(wasm), {}, {}, {}, {ExternalGlobal{&g1, true}, ExternalGlobal{&g2, false}});
+    auto instance = instantiate(parse(wasm), {}, {}, {},
+        {ExternalGlobal{&g1, {ValType::f32, true}}, ExternalGlobal{&g2, {ValType::f64, false}}});
 
     EXPECT_THAT(execute(*instance, 0, {}), Result(5.6f));
     EXPECT_THAT(execute(*instance, 1, {}), Result(7.8));
@@ -266,7 +267,8 @@ TEST(execute, global_set_imported)
         "0061736d01000000010401600000020d01036d6f6404676c6f62037f01030201000a08010600412a24000b");
 
     Value global_value = 41;
-    auto instance = instantiate(parse(wasm), {}, {}, {}, {ExternalGlobal{&global_value, true}});
+    auto instance =
+        instantiate(parse(wasm), {}, {}, {}, {ExternalGlobal{&global_value, {ValType::i32, true}}});
     EXPECT_THAT(execute(*instance, 0, {}), Result());
     EXPECT_EQ(global_value, 42);
 }
@@ -291,8 +293,8 @@ TEST(execute, global_set_float)
 
     Value g1 = 5.6f;
     Value g2 = 7.8;
-    auto instance = instantiate(
-        parse(wasm), {}, {}, {}, {ExternalGlobal{&g1, true}, ExternalGlobal{&g2, true}});
+    auto instance = instantiate(parse(wasm), {}, {}, {},
+        {ExternalGlobal{&g1, {ValType::f32, true}}, ExternalGlobal{&g2, {ValType::f64, true}}});
 
     EXPECT_THAT(execute(*instance, 0, {}), Result());
     EXPECT_EQ(g1.f32, 11.22f);

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -378,7 +378,7 @@ TEST(instantiate, imported_globals_mismatched_mutability)
         "global 0 mutability doesn't match module's global mutability");
 }
 
-TEST(instantiate, DISABLED_imported_globals_mismatched_type)
+TEST(instantiate, imported_globals_mismatched_type)
 {
     /* wat2wasm
       (global (export "g1") i64 (i64.const 0))
@@ -395,8 +395,8 @@ TEST(instantiate, DISABLED_imported_globals_mismatched_type)
     const auto bin2 = from_hex("0061736d01000000020b01036d6f64026731037f00");
     const auto module2 = parse(bin2);
 
-    EXPECT_THROW_MESSAGE(
-        instantiate(module2, {}, {}, {}, {*g}), instantiate_error, "type mismatch");
+    EXPECT_THROW_MESSAGE(instantiate(module2, {}, {}, {}, {*g}), instantiate_error,
+        "global 0 value type doesn't match module's global type");
 }
 
 TEST(instantiate, imported_globals_nullptr)

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -315,7 +315,8 @@ TEST(instantiate, imported_globals)
     auto instance = instantiate(module, {}, {}, {}, {g});
 
     ASSERT_EQ(instance->imported_globals.size(), 1);
-    EXPECT_EQ(instance->imported_globals[0].type.is_mutable, true);
+    EXPECT_EQ(instance->imported_globals[0].type.value_type, ValType::i32);
+    EXPECT_TRUE(instance->imported_globals[0].type.is_mutable);
     EXPECT_EQ(*instance->imported_globals[0].value, 42);
     ASSERT_EQ(instance->globals.size(), 0);
 }
@@ -336,8 +337,10 @@ TEST(instantiate, imported_globals_multiple)
     auto instance = instantiate(module, {}, {}, {}, {g1, g2});
 
     ASSERT_EQ(instance->imported_globals.size(), 2);
-    EXPECT_EQ(instance->imported_globals[0].type.is_mutable, true);
-    EXPECT_EQ(instance->imported_globals[1].type.is_mutable, false);
+    EXPECT_EQ(instance->imported_globals[0].type.value_type, ValType::i32);
+    EXPECT_TRUE(instance->imported_globals[0].type.is_mutable);
+    EXPECT_EQ(instance->imported_globals[1].type.value_type, ValType::i32);
+    EXPECT_FALSE(instance->imported_globals[1].type.is_mutable);
     EXPECT_EQ(*instance->imported_globals[0].value, 42);
     EXPECT_EQ(*instance->imported_globals[1].value, 43);
     ASSERT_EQ(instance->globals.size(), 0);
@@ -848,9 +851,11 @@ TEST(instantiate, globals_float)
 
     ASSERT_EQ(instance->imported_globals.size(), 2);
     EXPECT_EQ(instance->imported_globals[0].value->f32, 5.6f);
-    EXPECT_EQ(instance->imported_globals[0].type.is_mutable, true);
+    EXPECT_EQ(instance->imported_globals[0].type.value_type, ValType::f32);
+    EXPECT_TRUE(instance->imported_globals[0].type.is_mutable);
     EXPECT_EQ(instance->imported_globals[1].value->f64, 7.8);
-    EXPECT_EQ(instance->imported_globals[1].type.is_mutable, false);
+    EXPECT_EQ(instance->imported_globals[1].type.value_type, ValType::f64);
+    EXPECT_FALSE(instance->imported_globals[1].type.is_mutable);
     ASSERT_EQ(instance->globals.size(), 3);
     EXPECT_EQ(instance->globals[0].f32, 1.2f);
     EXPECT_EQ(instance->globals[1].f64, 3.4);

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -381,6 +381,31 @@ TEST(instantiate, imported_globals_mismatched_mutability)
 TEST(instantiate, imported_globals_mismatched_type)
 {
     /* wat2wasm
+      (global (import "mod" "g1") i32)
+    */
+    const auto bin1 = from_hex("0061736d01000000020b01036d6f64026731037f00");
+    const auto module1 = parse(bin1);
+
+    Value global_value = 42;
+    ExternalGlobal g{&global_value, {ValType::i64, false}};
+
+    EXPECT_THROW_MESSAGE(instantiate(module1, {}, {}, {}, {g}), instantiate_error,
+        "global 0 value type doesn't match module's global type");
+
+    /* wat2wasm
+      (global (import "mod" "g1") i64)
+      (global (import "mod" "g2") i32)
+    */
+    const auto bin2 = from_hex("0061736d01000000021502036d6f64026731037e00036d6f64026732037f00");
+    const auto module2 = parse(bin2);
+
+    EXPECT_THROW_MESSAGE(instantiate(module2, {}, {}, {}, {g, g}), instantiate_error,
+        "global 1 value type doesn't match module's global type");
+}
+
+TEST(instantiate, imported_global_from_another_module_mismatched_type)
+{
+    /* wat2wasm
       (global (export "g1") i64 (i64.const 0))
     */
     const auto bin1 = from_hex("0061736d010000000606017e0042000b0706010267310300");

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -311,11 +311,11 @@ TEST(instantiate, imported_globals)
     const auto module = parse(bin);
 
     Value global_value = 42;
-    ExternalGlobal g{&global_value, true};
+    ExternalGlobal g{&global_value, {ValType::i32, true}};
     auto instance = instantiate(module, {}, {}, {}, {g});
 
     ASSERT_EQ(instance->imported_globals.size(), 1);
-    EXPECT_EQ(instance->imported_globals[0].is_mutable, true);
+    EXPECT_EQ(instance->imported_globals[0].type.is_mutable, true);
     EXPECT_EQ(*instance->imported_globals[0].value, 42);
     ASSERT_EQ(instance->globals.size(), 0);
 }
@@ -330,14 +330,14 @@ TEST(instantiate, imported_globals_multiple)
     const auto module = parse(bin);
 
     Value global_value1 = 42;
-    ExternalGlobal g1{&global_value1, true};
+    ExternalGlobal g1{&global_value1, {ValType::i32, true}};
     Value global_value2 = 43;
-    ExternalGlobal g2{&global_value2, false};
+    ExternalGlobal g2{&global_value2, {ValType::i32, false}};
     auto instance = instantiate(module, {}, {}, {}, {g1, g2});
 
     ASSERT_EQ(instance->imported_globals.size(), 2);
-    EXPECT_EQ(instance->imported_globals[0].is_mutable, true);
-    EXPECT_EQ(instance->imported_globals[1].is_mutable, false);
+    EXPECT_EQ(instance->imported_globals[0].type.is_mutable, true);
+    EXPECT_EQ(instance->imported_globals[1].type.is_mutable, false);
     EXPECT_EQ(*instance->imported_globals[0].value, 42);
     EXPECT_EQ(*instance->imported_globals[1].value, 43);
     ASSERT_EQ(instance->globals.size(), 0);
@@ -353,7 +353,7 @@ TEST(instantiate, imported_globals_mismatched_count)
     const auto module = parse(bin);
 
     Value global_value = 42;
-    ExternalGlobal g{&global_value, true};
+    ExternalGlobal g{&global_value, {ValType::i32, true}};
     EXPECT_THROW_MESSAGE(instantiate(module, {}, {}, {}, {g}), instantiate_error,
         "module requires 2 imported globals, 1 provided");
 }
@@ -368,9 +368,9 @@ TEST(instantiate, imported_globals_mismatched_mutability)
     const auto module = parse(bin);
 
     Value global_value1 = 42;
-    ExternalGlobal g1{&global_value1, false};
+    ExternalGlobal g1{&global_value1, {ValType::i32, false}};
     Value global_value2 = 42;
-    ExternalGlobal g2{&global_value2, true};
+    ExternalGlobal g2{&global_value2, {ValType::i32, true}};
     EXPECT_THROW_MESSAGE(instantiate(module, {}, {}, {}, {g1, g2}), instantiate_error,
         "global 0 mutability doesn't match module's global mutability");
 }
@@ -405,7 +405,7 @@ TEST(instantiate, imported_globals_nullptr)
     const auto bin = from_hex("0061736d01000000021502036d6f64026731037f00036d6f64026732037f00");
     const auto module = parse(bin);
 
-    ExternalGlobal g{nullptr, false};
+    ExternalGlobal g{nullptr, {ValType::i32, false}};
     EXPECT_THROW_MESSAGE(instantiate(module, {}, {}, {}, {g, g}), instantiate_error,
         "global 0 has a null pointer to value");
 }
@@ -526,7 +526,7 @@ TEST(instantiate, element_section_offset_from_imported_global)
         "0200010a0b02040041010b040041020b");
 
     Value global_value = 1;
-    ExternalGlobal g{&global_value, false};
+    ExternalGlobal g{&global_value, {ValType::i32, false}};
 
     auto instance = instantiate(parse(bin), {}, {}, {}, {g});
 
@@ -649,7 +649,7 @@ TEST(instantiate, data_section_offset_from_imported_global)
     const auto module = parse(bin);
 
     Value global_value = 42;
-    ExternalGlobal g{&global_value, false};
+    ExternalGlobal g{&global_value, {ValType::i32, false}};
 
     auto instance = instantiate(module, {}, {}, {}, {g});
 
@@ -795,13 +795,13 @@ TEST(instantiate, globals_with_imported)
     const auto module = parse(bin);
 
     Value global_value = 41;
-    ExternalGlobal g{&global_value, true};
+    ExternalGlobal g{&global_value, {ValType::i32, true}};
 
     auto instance = instantiate(module, {}, {}, {}, {g});
 
     ASSERT_EQ(instance->imported_globals.size(), 1);
     EXPECT_EQ(*instance->imported_globals[0].value, 41);
-    EXPECT_EQ(instance->imported_globals[0].is_mutable, true);
+    EXPECT_EQ(instance->imported_globals[0].type.is_mutable, true);
     ASSERT_EQ(instance->globals.size(), 2);
     EXPECT_EQ(instance->globals[0], 42);
     EXPECT_EQ(instance->globals[1], 43);
@@ -817,7 +817,7 @@ TEST(instantiate, globals_initialized_from_imported)
     const auto module = parse(bin);
 
     Value global_value = 42;
-    ExternalGlobal g{&global_value, false};
+    ExternalGlobal g{&global_value, {ValType::i32, false}};
 
     auto instance = instantiate(module, {}, {}, {}, {g});
 
@@ -840,17 +840,17 @@ TEST(instantiate, globals_float)
     const auto module = parse(bin);
 
     Value global_value1 = 5.6f;
-    ExternalGlobal g1{&global_value1, true};
+    ExternalGlobal g1{&global_value1, {ValType::f32, true}};
     Value global_value2 = 7.8;
-    ExternalGlobal g2{&global_value2, false};
+    ExternalGlobal g2{&global_value2, {ValType::f64, false}};
 
     auto instance = instantiate(module, {}, {}, {}, {g1, g2});
 
     ASSERT_EQ(instance->imported_globals.size(), 2);
     EXPECT_EQ(instance->imported_globals[0].value->f32, 5.6f);
-    EXPECT_EQ(instance->imported_globals[0].is_mutable, true);
+    EXPECT_EQ(instance->imported_globals[0].type.is_mutable, true);
     EXPECT_EQ(instance->imported_globals[1].value->f64, 7.8);
-    EXPECT_EQ(instance->imported_globals[1].is_mutable, false);
+    EXPECT_EQ(instance->imported_globals[1].type.is_mutable, false);
     ASSERT_EQ(instance->globals.size(), 3);
     EXPECT_EQ(instance->globals[0].f32, 1.2f);
     EXPECT_EQ(instance->globals[1].f64, 3.4);


### PR DESCRIPTION
This fixes the disabled instantiation test.

Not covered by spec tests.