### PR TITLE
ci: Add native builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ executors:
       - image: ethereum/cpp-build-env:14-clang-10
   macos:
     macos:
-      xcode: 11.5.0
+      xcode: 11.6.0
 
 commands:
   description: "Install macOS system dependencies"

--- a/circle.yml
+++ b/circle.yml
@@ -216,10 +216,31 @@ jobs:
       - build
       - test
 
+  release-native-linux:
+    executor: linux-gcc-latest
+    environment:
+      BUILD_TYPE: Release
+      CMAKE_OPTIONS: -DNATIVE=ON
+    steps:
+      - checkout
+      - build
+      - test
+
   release-macos:
     executor: macos
     environment:
       BUILD_TYPE: Release
+    steps:
+      - install_macos_deps
+      - checkout
+      - build
+      - test
+
+  release-native-macos:
+    executor: macos
+    environment:
+      BUILD_TYPE: Release
+      CMAKE_OPTIONS: -DNATIVE=ON
     steps:
       - install_macos_deps
       - checkout
@@ -401,7 +422,9 @@ workflows:
     jobs:
       - lint
       - release-linux
+      - release-native-linux
       - release-macos
+      - release-native-macos
       - coverage
       - cxx20
       - sanitizers

--- a/test/unittests/validation_test.cpp
+++ b/test/unittests/validation_test.cpp
@@ -406,7 +406,7 @@ TEST(validation, load_alignment)
         {Instr::f64_load, 3},
     };
 
-    for (const auto test_case : test_cases)
+    for (const auto& test_case : test_cases)
     {
         const auto instr = test_case.first;
         const auto max_align = test_case.second;


### PR DESCRIPTION
On architectures with SSE4 and AVX, the floating point operations use different set of CPU instructions. Enabling native builds should tests these.