### PR TITLE
Investigate performance regression in 0.4

### DIFF
--- a/test/utils/fizzy_engine.cpp
+++ b/test/utils/fizzy_engine.cpp
@@ -56,8 +56,8 @@ FuncType translate_signature(std::string_view signature)
 fizzy::ExecutionResult env_adler32(fizzy::Instance& instance, fizzy::span<const Value> args, int)
 {
     assert(instance.memory != nullptr);
-    const auto ret = fizzy::test::adler32(
-        bytes_view{*instance.memory}.substr(args[0].as<uint32_t>(), args[1].as<uint32_t>()));
+    const auto ret =
+        fizzy::test::adler32(bytes_view{*instance.memory}.substr(args[0].i64, args[1].i64));
     return Value{ret};
 }
 }  // namespace


### PR DESCRIPTION
This partly reverts https://github.com/wasmx/fizzy/commit/67fd4c8be8ff30477d4b1f51025ae5600ca4c35e#diff-47ed36245217950f22b14dcb2472adbaR60

```
fizzy/execute/blake2b/512_bytes_rounds_1_mean                     -0.1249         -0.1249            88            77            88            77
fizzy/execute/blake2b/512_bytes_rounds_16_mean                    -0.1254         -0.1254          1333          1166          1333          1166
fizzy/execute/ecpairing/onepoint_mean                             -0.1190         -0.1190        440627        388179        440631        388183
fizzy/execute/keccak256/512_bytes_rounds_1_mean                   -0.0935         -0.0935           104            94           104            94
fizzy/execute/keccak256/512_bytes_rounds_16_mean                  -0.1024         -0.1024          1526          1370          1526          1370
fizzy/execute/memset/256_bytes_mean                               -0.1131         -0.1131             7             6             7             6
fizzy/execute/memset/60000_bytes_mean                             -0.1102         -0.1102          1576          1402          1576          1403
fizzy/execute/mul256_opt0/input0_mean                             -0.1387         -0.1387            29            25            29            25
fizzy/execute/mul256_opt0/input1_mean                             -0.1375         -0.1375            29            25            29            25
fizzy/execute/ramanujan_pi/33_runs_mean                           -0.0849         -0.0849           131           120           131           120
fizzy/execute/sha1/512_bytes_rounds_1_mean                        -0.0964         -0.0964            93            84            93            84
fizzy/execute/sha1/512_bytes_rounds_16_mean                       -0.0919         -0.0919          1299          1179          1299          1179
fizzy/execute/sha256/512_bytes_rounds_1_mean                      -0.1047         -0.1047            95            85            95            85
fizzy/execute/sha256/512_bytes_rounds_16_mean                     -0.1063         -0.1063          1304          1165          1304          1165
fizzy/execute/taylor_pi/pi_1000000_runs_mean                      -0.0375         -0.0375         42757         41154         42758         41154
fizzy/execute/micro/eli_interpreter/halt_mean                     -0.0371         -0.0371             0             0             0             0
fizzy/execute/micro/eli_interpreter/exec105_mean                  -0.0951         -0.0951             5             4             5             4
fizzy/execute/micro/factorial/10_mean                             -0.0405         -0.0405             0             0             0             0
fizzy/execute/micro/factorial/20_mean                             -0.0413         -0.0413             1             1             1             1
fizzy/execute/micro/fibonacci/24_mean                             -0.0382         -0.0382          7507          7221          7508          7221
fizzy/execute/micro/host_adler32/1_mean                           -0.0133         -0.0133             0             0             0             0
fizzy/execute/micro/host_adler32/100_mean                         -0.0006         -0.0006             3             3             3             3
fizzy/execute/micro/host_adler32/1000_mean                        +0.0058         +0.0058            29            29            29            29
fizzy/execute/micro/spinner/1_mean                                -0.0340         -0.0340             0             0             0             0
fizzy/execute/micro/spinner/1000_mean                             -0.1275         -0.1275            10             9            10             9
```