### PR TITLE
Add uint32_t i32 field to Value union

### DIFF
--- a/include/fizzy/fizzy.h
+++ b/include/fizzy/fizzy.h
@@ -18,11 +18,11 @@ typedef struct FizzyModule FizzyModule;
 typedef struct FizzyInstance FizzyInstance;
 
 /// The data type representing numeric values.
-///
-/// The #i64 member is used to represent values of both i32 and i64 type.
 typedef union FizzyValue
 {
-    /// Integer value.
+    /// 32-bit integer value.
+    uint32_t i32;
+    /// 64-bit integer value.
     uint64_t i64;
     /// 32-bit floating-point value.
     float f32;

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -1089,7 +1089,7 @@ ExecutionResult execute(Instance& instance, FuncIdx func_idx, const Value* args,
                 goto trap;
             const auto lhs = stack.top().as<int32_t>();
             if (lhs == std::numeric_limits<int32_t>::min() && rhs == -1)
-                stack.top() = 0;
+                stack.top() = int32_t{0};
             else
                 stack.top() = rem(lhs, rhs);
             break;
@@ -1199,7 +1199,7 @@ ExecutionResult execute(Instance& instance, FuncIdx func_idx, const Value* args,
                 goto trap;
             const auto lhs = stack.top().as<int64_t>();
             if (lhs == std::numeric_limits<int64_t>::min() && rhs == -1)
-                stack.top() = 0;
+                stack.top() = int64_t{0};
             else
                 stack.top() = rem(lhs, rhs);
             break;
@@ -1434,7 +1434,7 @@ ExecutionResult execute(Instance& instance, FuncIdx func_idx, const Value* args,
         }
         case Instr::i64_extend_i32_u:
         {
-            // effectively no-op
+            stack.top() = uint64_t{stack.top().i32};
             break;
         }
         case Instr::i64_trunc_f32_s:

--- a/lib/fizzy/instantiate.cpp
+++ b/lib/fizzy/instantiate.cpp
@@ -289,7 +289,7 @@ std::unique_ptr<Instance> instantiate(std::unique_ptr<const Module> module,
     {
         // Offset is validated to be i32, but it's used in 64-bit calculation below.
         const uint64_t offset =
-            eval_constant_expression(data.offset, imported_globals, globals).i64;
+            eval_constant_expression(data.offset, imported_globals, globals).i32;
 
         if (offset + data.init.size() > memory->size())
             throw instantiate_error{"data segment is out of memory bounds"};
@@ -304,7 +304,7 @@ std::unique_ptr<Instance> instantiate(std::unique_ptr<const Module> module,
     {
         // Offset is validated to be i32, but it's used in 64-bit calculation below.
         const uint64_t offset =
-            eval_constant_expression(element.offset, imported_globals, globals).i64;
+            eval_constant_expression(element.offset, imported_globals, globals).i32;
 
         if (offset + element.init.size() > table->size())
             throw instantiate_error{"element segment is out of table bounds"};

--- a/lib/fizzy/stack.hpp
+++ b/lib/fizzy/stack.hpp
@@ -116,7 +116,7 @@ public:
         m_top = m_bottom - 1;
 
         const auto local_variables = std::copy_n(args, num_args, m_locals);
-        std::fill_n(local_variables, num_local_variables, 0);
+        std::fill_n(local_variables, num_local_variables, Value{});
     }
 
     OperandStack(const OperandStack&) = delete;

--- a/lib/fizzy/value.hpp
+++ b/lib/fizzy/value.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <cassert>
 #include <cstdint>
 #include <limits>
 
@@ -12,6 +11,7 @@ namespace fizzy
 {
 union Value
 {
+    uint32_t i32;
     uint64_t i64;
     float f32;
     double f64;
@@ -26,11 +26,11 @@ union Value
     /// We need to support {signed,unsigned} x {32,64} integers. However, due to uint64_t being
     /// defined differently in different implementations we need to avoid the alias and provide
     /// constructors for unsigned long and unsigned long long independently.
-    constexpr Value(unsigned int v) noexcept : i64{v} {}
+    constexpr Value(unsigned int v) noexcept : i32{v} {}
     constexpr Value(unsigned long v) noexcept : i64{v} {}
     constexpr Value(unsigned long long v) noexcept : i64{v} {}
     constexpr Value(int64_t v) noexcept : i64{static_cast<uint64_t>(v)} {}
-    constexpr Value(int32_t v) noexcept : i64{static_cast<uint32_t>(v)} {}
+    constexpr Value(int32_t v) noexcept : i32{static_cast<uint32_t>(v)} {}
 
     constexpr Value(float v) noexcept : f32{v} {}
     constexpr Value(double v) noexcept : f64{v} {}
@@ -54,8 +54,7 @@ constexpr uint64_t Value::as<uint64_t>() const noexcept
 template <>
 constexpr uint32_t Value::as<uint32_t>() const noexcept
 {
-    assert((i64 & 0xffffffff00000000) == 0);
-    return static_cast<uint32_t>(i64);
+    return i32;
 }
 
 template <>
@@ -67,8 +66,7 @@ constexpr int64_t Value::as<int64_t>() const noexcept
 template <>
 constexpr int32_t Value::as<int32_t>() const noexcept
 {
-    assert((i64 & 0xffffffff00000000) == 0);
-    return static_cast<int32_t>(i64);
+    return static_cast<int32_t>(i32);
 }
 
 template <>

--- a/test/testfloat/testfloat.cpp
+++ b/test/testfloat/testfloat.cpp
@@ -268,6 +268,7 @@ bool eq(TypedValue v, uint64_t expected_bits, bool ignore_nans)
     switch (v.type)
     {
     case ValType::i32:
+        return v.value.i32 == expected_bits;
     case ValType::i64:
         return v.value.i64 == expected_bits;
     case ValType::f32:

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -47,7 +47,7 @@ TEST(api, execution_result_value)
     const ExecutionResult result = Value{1234_u32};
     EXPECT_FALSE(result.trapped);
     EXPECT_TRUE(result.has_value);
-    EXPECT_EQ(result.value.i64, 1234_u32);
+    EXPECT_EQ(result.value.i32, 1234_u32);
 }
 
 TEST(api, execution_result_bool_constructor)
@@ -65,7 +65,7 @@ TEST(api, execution_result_value_constructor)
     const ExecutionResult result{value};
     EXPECT_FALSE(result.trapped);
     EXPECT_TRUE(result.has_value);
-    EXPECT_EQ(result.value.i64, 1234_u32);
+    EXPECT_EQ(result.value.i32, 1234_u32);
 }
 
 TEST(api, resolve_imported_functions)

--- a/test/unittests/capi_test.cpp
+++ b/test/unittests/capi_test.cpp
@@ -378,7 +378,7 @@ TEST(capi, find_exported_global)
     ASSERT_TRUE(fizzy_find_exported_global(instance, "g1", &global));
     EXPECT_EQ(global.type.value_type, FizzyValueTypeI32);
     EXPECT_FALSE(global.type.is_mutable);
-    EXPECT_EQ(global.value->i64, 42);
+    EXPECT_EQ(global.value->i32, 42);
 
     EXPECT_FALSE(fizzy_find_exported_global(instance, "g2", &global));
     EXPECT_FALSE(fizzy_find_exported_global(instance, "foo", &global));
@@ -729,7 +729,7 @@ TEST(capi, memory_access)
     memory[0] = 0xaa;
     memory[1] = 0xbb;
 
-    EXPECT_EQ(fizzy_execute(instance, 0, nullptr, 0).value.i64, 0x22bbaa);
+    EXPECT_THAT(fizzy_execute(instance, 0, nullptr, 0), CResult(0x22bbaa_u32));
 
     fizzy_free_instance(instance);
 }
@@ -771,7 +771,7 @@ TEST(capi, imported_memory_access)
     auto* instance = fizzy_instantiate(module, nullptr, 0, nullptr, &memory, nullptr, 0);
     ASSERT_NE(instance, nullptr);
 
-    EXPECT_EQ(fizzy_execute(instance, 0, nullptr, 0).value.i64, 0x221100);
+    EXPECT_EQ(fizzy_execute(instance, 0, nullptr, 0).value.i32, 0x221100);
 
     EXPECT_EQ(fizzy_get_instance_memory_size(instance), 65536);
 
@@ -781,8 +781,8 @@ TEST(capi, imported_memory_access)
     memory_data[0] = 0xaa;
     memory_data[1] = 0xbb;
 
-    EXPECT_EQ(fizzy_execute(instance_memory, 0, nullptr, 0).value.i64, 0x22bbaa);
-    EXPECT_EQ(fizzy_execute(instance, 0, nullptr, 0).value.i64, 0x22bbaa);
+    EXPECT_EQ(fizzy_execute(instance_memory, 0, nullptr, 0).value.i32, 0x22bbaa);
+    EXPECT_EQ(fizzy_execute(instance, 0, nullptr, 0).value.i32, 0x22bbaa);
 
     fizzy_free_instance(instance);
     fizzy_free_instance(instance_memory);
@@ -838,7 +838,9 @@ TEST(capi, execute_with_host_function)
                                               nullptr},
         {{FizzyValueTypeI32, &inputs[0], 2},
             [](void*, FizzyInstance*, const FizzyValue* args, int) {
-                return FizzyExecutionResult{false, true, {args[0].i64 / args[1].i64}};
+                FizzyValue v;
+                v.i32 = args[0].i32 / args[1].i32;
+                return FizzyExecutionResult{false, true, {v}};
             },
             nullptr}};
 

--- a/test/unittests/cxx20_span_test.cpp
+++ b/test/unittests/cxx20_span_test.cpp
@@ -84,11 +84,11 @@ TEST(cxx20_span, stack)
     span<const Value> s(stack.rend() - num_items, num_items);
     EXPECT_FALSE(s.empty());
     EXPECT_EQ(s.size(), 2);
-    EXPECT_EQ(s[0].i64, 12);
-    EXPECT_EQ(s[1].i64, 13);
+    EXPECT_EQ(s[0].i32, 12);
+    EXPECT_EQ(s[1].i32, 13);
 
     stack[0] = 0;
-    EXPECT_EQ(s[1].i64, 0);
+    EXPECT_EQ(s[1].i32, 0);
 }
 
 TEST(cxx20_span, initializer_list)

--- a/test/unittests/execute_test.cpp
+++ b/test/unittests/execute_test.cpp
@@ -174,16 +174,16 @@ TEST(execute, global_get_imported)
     const auto wasm = from_hex(
         "0061736d010000000105016000017e020d01036d6f6404676c6f62037e00030201000a0601040023000b");
 
-    Value global_value = 42;
+    Value global_value = 42_u64;
     auto instance = instantiate(
         parse(wasm), {}, {}, {}, {ExternalGlobal{&global_value, {ValType::i64, false}}});
 
     EXPECT_THAT(execute(*instance, 0, {}), Result(42));
 
-    global_value = 0;
+    global_value = 0_u64;
     EXPECT_THAT(execute(*instance, 0, {}), Result(0));
 
-    global_value = 43;
+    global_value = 43_u64;
     EXPECT_THAT(execute(*instance, 0, {}), Result(43));
 }
 

--- a/test/unittests/stack_test.cpp
+++ b/test/unittests/stack_test.cpp
@@ -134,26 +134,26 @@ TEST(operand_stack, top)
 
     stack.push(1);
     EXPECT_EQ(stack.size(), 1);
-    EXPECT_EQ(stack.top().i64, 1);
-    EXPECT_EQ(stack[0].i64, 1);
+    EXPECT_EQ(stack.top().i32, 1);
+    EXPECT_EQ(stack[0].i32, 1);
 
     stack.top() = 101;
     EXPECT_EQ(stack.size(), 1);
-    EXPECT_EQ(stack.top().i64, 101);
-    EXPECT_EQ(stack[0].i64, 101);
+    EXPECT_EQ(stack.top().i32, 101);
+    EXPECT_EQ(stack[0].i32, 101);
 
     stack.drop(0);
     EXPECT_EQ(stack.size(), 1);
-    EXPECT_EQ(stack.top().i64, 101);
-    EXPECT_EQ(stack[0].i64, 101);
+    EXPECT_EQ(stack.top().i32, 101);
+    EXPECT_EQ(stack[0].i32, 101);
 
     stack.drop(1);
     EXPECT_EQ(stack.size(), 0);
 
     stack.push(2);
     EXPECT_EQ(stack.size(), 1);
-    EXPECT_EQ(stack.top().i64, 2);
-    EXPECT_EQ(stack[0].i64, 2);
+    EXPECT_EQ(stack.top().i32, 2);
+    EXPECT_EQ(stack[0].i32, 2);
 }
 
 TEST(operand_stack, small)
@@ -167,23 +167,23 @@ TEST(operand_stack, small)
     stack.push(2);
     stack.push(3);
     EXPECT_EQ(stack.size(), 3);
-    EXPECT_EQ(stack.top().i64, 3);
-    EXPECT_EQ(stack[0].i64, 3);
-    EXPECT_EQ(stack[1].i64, 2);
-    EXPECT_EQ(stack[2].i64, 1);
+    EXPECT_EQ(stack.top().i32, 3);
+    EXPECT_EQ(stack[0].i32, 3);
+    EXPECT_EQ(stack[1].i32, 2);
+    EXPECT_EQ(stack[2].i32, 1);
 
     stack[0] = 13;
     stack[1] = 12;
     stack[2] = 11;
     EXPECT_EQ(stack.size(), 3);
-    EXPECT_EQ(stack.top().i64, 13);
-    EXPECT_EQ(stack[0].i64, 13);
-    EXPECT_EQ(stack[1].i64, 12);
-    EXPECT_EQ(stack[2].i64, 11);
+    EXPECT_EQ(stack.top().i32, 13);
+    EXPECT_EQ(stack[0].i32, 13);
+    EXPECT_EQ(stack[1].i32, 12);
+    EXPECT_EQ(stack[2].i32, 11);
 
-    EXPECT_EQ(stack.pop().i64, 13);
+    EXPECT_EQ(stack.pop().i32, 13);
     EXPECT_EQ(stack.size(), 2);
-    EXPECT_EQ(stack.top().i64, 12);
+    EXPECT_EQ(stack.top().i32, 12);
 }
 
 TEST(operand_stack, small_with_locals)
@@ -196,14 +196,14 @@ TEST(operand_stack, small_with_locals)
 
     stack.push(0xff);
     EXPECT_EQ(stack.size(), 1);
-    EXPECT_EQ(stack.top().i64, 0xff);
-    EXPECT_EQ(stack[0].i64, 0xff);
+    EXPECT_EQ(stack.top().i32, 0xff);
+    EXPECT_EQ(stack[0].i32, 0xff);
 
-    EXPECT_EQ(stack.local(0).i64, 0xa1);
-    EXPECT_EQ(stack.local(1).i64, 0xa2);
-    EXPECT_EQ(stack.local(2).i64, 0);
-    EXPECT_EQ(stack.local(3).i64, 0);
-    EXPECT_EQ(stack.local(4).i64, 0);
+    EXPECT_EQ(stack.local(0).i32, 0xa1);
+    EXPECT_EQ(stack.local(1).i32, 0xa2);
+    EXPECT_EQ(stack.local(2).i32, 0);
+    EXPECT_EQ(stack.local(3).i32, 0);
+    EXPECT_EQ(stack.local(4).i32, 0);
 
     stack.local(0) = 0xc0;
     stack.local(1) = 0xc1;
@@ -211,19 +211,19 @@ TEST(operand_stack, small_with_locals)
     stack.local(3) = 0xc3;
     stack.local(4) = 0xc4;
 
-    EXPECT_EQ(stack.local(0).i64, 0xc0);
-    EXPECT_EQ(stack.local(1).i64, 0xc1);
-    EXPECT_EQ(stack.local(2).i64, 0xc2);
-    EXPECT_EQ(stack.local(3).i64, 0xc3);
-    EXPECT_EQ(stack.local(4).i64, 0xc4);
+    EXPECT_EQ(stack.local(0).i32, 0xc0);
+    EXPECT_EQ(stack.local(1).i32, 0xc1);
+    EXPECT_EQ(stack.local(2).i32, 0xc2);
+    EXPECT_EQ(stack.local(3).i32, 0xc3);
+    EXPECT_EQ(stack.local(4).i32, 0xc4);
 
-    EXPECT_EQ(stack.pop().i64, 0xff);
+    EXPECT_EQ(stack.pop().i32, 0xff);
     EXPECT_EQ(stack.size(), 0);
-    EXPECT_EQ(stack.local(0).i64, 0xc0);
-    EXPECT_EQ(stack.local(1).i64, 0xc1);
-    EXPECT_EQ(stack.local(2).i64, 0xc2);
-    EXPECT_EQ(stack.local(3).i64, 0xc3);
-    EXPECT_EQ(stack.local(4).i64, 0xc4);
+    EXPECT_EQ(stack.local(0).i32, 0xc0);
+    EXPECT_EQ(stack.local(1).i32, 0xc1);
+    EXPECT_EQ(stack.local(2).i32, 0xc2);
+    EXPECT_EQ(stack.local(3).i32, 0xc3);
+    EXPECT_EQ(stack.local(4).i32, 0xc4);
 }
 
 TEST(operand_stack, large)
@@ -237,7 +237,7 @@ TEST(operand_stack, large)
 
     EXPECT_EQ(stack.size(), max_height);
     for (int expected = max_height - 1; expected >= 0; --expected)
-        EXPECT_EQ(stack.pop().i64, expected);
+        EXPECT_EQ(stack.pop().i32, expected);
     EXPECT_EQ(stack.size(), 0);
 }
 
@@ -255,25 +255,25 @@ TEST(operand_stack, large_with_locals)
 
     EXPECT_EQ(stack.size(), max_height);
     for (unsigned i = 0; i < max_height; ++i)
-        EXPECT_EQ(stack[i].i64, max_height - i - 1);
+        EXPECT_EQ(stack[i].i32, max_height - i - 1);
 
-    EXPECT_EQ(stack.local(0).i64, 0xa1);
-    EXPECT_EQ(stack.local(1).i64, 0xa2);
+    EXPECT_EQ(stack.local(0).i32, 0xa1);
+    EXPECT_EQ(stack.local(1).i32, 0xa2);
 
     for (unsigned i = num_args; i < num_args + num_locals; ++i)
-        EXPECT_EQ(stack.local(i).i64, 0);
+        EXPECT_EQ(stack.local(i).i32, 0);
 
     for (unsigned i = 0; i < num_args + num_locals; ++i)
         stack.local(i) = fizzy::Value{i};
     for (unsigned i = 0; i < num_args + num_locals; ++i)
-        EXPECT_EQ(stack.local(i).i64, i);
+        EXPECT_EQ(stack.local(i).i32, i);
 
     for (int expected = max_height - 1; expected >= 0; --expected)
-        EXPECT_EQ(stack.pop().i64, expected);
+        EXPECT_EQ(stack.pop().i32, expected);
     EXPECT_EQ(stack.size(), 0);
 
     for (unsigned i = 0; i < num_args + num_locals; ++i)
-        EXPECT_EQ(stack.local(i).i64, i);
+        EXPECT_EQ(stack.local(i).i32, i);
 }
 
 
@@ -286,8 +286,8 @@ TEST(operand_stack, rbegin_rend)
     stack.push(2);
     stack.push(3);
     EXPECT_LT(stack.rbegin(), stack.rend());
-    EXPECT_EQ(stack.rbegin()->i64, 1);
-    EXPECT_EQ((stack.rend() - 1)->i64, 3);
+    EXPECT_EQ(stack.rbegin()->i32, 1);
+    EXPECT_EQ((stack.rend() - 1)->i32, 3);
 }
 
 TEST(operand_stack, rbegin_rend_locals)
@@ -299,16 +299,16 @@ TEST(operand_stack, rbegin_rend_locals)
     stack.push(1);
     EXPECT_LT(stack.rbegin(), stack.rend());
     EXPECT_EQ(stack.rend() - stack.rbegin(), 1);
-    EXPECT_EQ(stack.rbegin()->i64, 1);
-    EXPECT_EQ((stack.rend() - 1)->i64, 1);
+    EXPECT_EQ(stack.rbegin()->i32, 1);
+    EXPECT_EQ((stack.rend() - 1)->i32, 1);
 
     stack.push(2);
     EXPECT_LT(stack.rbegin(), stack.rend());
     EXPECT_EQ(stack.rend() - stack.rbegin(), 2);
-    EXPECT_EQ(stack.rbegin()->i64, 1);
-    EXPECT_EQ((stack.rbegin() + 1)->i64, 2);
-    EXPECT_EQ((stack.rend() - 1)->i64, 2);
-    EXPECT_EQ((stack.rend() - 2)->i64, 1);
+    EXPECT_EQ(stack.rbegin()->i32, 1);
+    EXPECT_EQ((stack.rbegin() + 1)->i32, 2);
+    EXPECT_EQ((stack.rend() - 1)->i32, 2);
+    EXPECT_EQ((stack.rend() - 2)->i32, 1);
 }
 
 TEST(operand_stack, to_vector)
@@ -322,7 +322,7 @@ TEST(operand_stack, to_vector)
 
     auto const result = std::vector(stack.rbegin(), stack.rend());
     EXPECT_EQ(result.size(), 3);
-    EXPECT_EQ(result[0].i64, 1);
-    EXPECT_EQ(result[1].i64, 2);
-    EXPECT_EQ(result[2].i64, 3);
+    EXPECT_EQ(result[0].i32, 1);
+    EXPECT_EQ(result[1].i32, 2);
+    EXPECT_EQ(result[2].i32, 3);
 }

--- a/test/unittests/test_utils_test.cpp
+++ b/test/unittests/test_utils_test.cpp
@@ -52,7 +52,7 @@ TEST(test_utils, print_execution_result)
     EXPECT_EQ(str_void.str(), "result()");
 
     std::stringstream str_value;
-    str_value << ExecutionResult{Value{42}};
+    str_value << ExecutionResult{Value{42_u64}};
     EXPECT_EQ(str_value.str(), "result(42 [0x2a])");
 }
 
@@ -67,7 +67,9 @@ TEST(test_utils, print_c_execution_result)
     EXPECT_EQ(str_void.str(), "result()");
 
     std::stringstream str_value;
-    str_value << FizzyExecutionResult{false, true, {42}};
+    FizzyValue v;
+    v.i64 = 42;
+    str_value << FizzyExecutionResult{false, true, v};
     EXPECT_EQ(str_value.str(), "result(42 [0x2a])");
 }
 

--- a/test/unittests/typed_value_test.cpp
+++ b/test/unittests/typed_value_test.cpp
@@ -12,13 +12,13 @@ TEST(typed_value, construct_contexpr)
 {
     constexpr TypedValue i32{int32_t{-1}};
     static_assert(i32.type == ValType::i32);
-    static_assert(i32.value.i64 == uint32_t(-1));
+    static_assert(i32.value.i32 == uint32_t(-1));
     EXPECT_EQ(i32.type, ValType::i32);
     EXPECT_EQ(i32.value.i64, uint32_t(-1));
 
     constexpr TypedValue u32{uint32_t{0xfffffffe}};
     static_assert(u32.type == ValType::i32);
-    static_assert(u32.value.i64 == uint32_t{0xfffffffe});
+    static_assert(u32.value.i32 == uint32_t{0xfffffffe});
     EXPECT_EQ(u32.type, ValType::i32);
     EXPECT_EQ(u32.value.i64, uint32_t{0xfffffffe});
 
@@ -51,11 +51,11 @@ TEST(typed_value, construct)
 {
     const TypedValue i32{int32_t{-1}};
     EXPECT_EQ(i32.type, ValType::i32);
-    EXPECT_EQ(i32.value.i64, uint32_t(-1));
+    EXPECT_EQ(i32.value.i32, uint32_t(-1));
 
     const TypedValue u32{uint32_t{0xfffffffe}};
     EXPECT_EQ(u32.type, ValType::i32);
-    EXPECT_EQ(u32.value.i64, uint32_t{0xfffffffe});
+    EXPECT_EQ(u32.value.i32, uint32_t{0xfffffffe});
 
     const TypedValue i64{int64_t{-1}};
     EXPECT_EQ(i64.type, ValType::i64);

--- a/test/unittests/value_test.cpp
+++ b/test/unittests/value_test.cpp
@@ -13,12 +13,42 @@ TEST(value, value_initialization)
     EXPECT_EQ(v.i64, 0);
 }
 
+TEST(value, constructor_from_i32)
+{
+    Value v = int32_t{1};
+    EXPECT_EQ(v.i32, 1);
+    v = int32_t{-2};
+    EXPECT_EQ(v.i32, 0xfffffffe);
+    v = uint32_t{111};
+    EXPECT_EQ(v.i32, 111);
+
+    constexpr auto max_i32 = std::numeric_limits<uint32_t>::max();
+    v = max_i32;
+    EXPECT_EQ(v.i32, max_i32);
+}
+
+TEST(value, constructor_from_int)
+{
+    // The int type is likely the int32_t but it deserves separate test
+    // because it is also the type of the bare integer literal.
+    Value v = 0;
+    EXPECT_EQ(v.i32, 0);
+    v = -3;
+    EXPECT_EQ(v.i32, 0xfffffffd);
+
+    constexpr auto max_int = std::numeric_limits<int>::max();
+    v = max_int;
+    EXPECT_EQ(v.i32, max_int);
+}
+
 TEST(value, constructor_from_i64)
 {
-    Value v = 1;
+    Value v = int64_t{1};
     EXPECT_EQ(v.i64, 1);
-    v = 2;
+    v = int64_t{2};
     EXPECT_EQ(v.i64, 2);
+    v = int64_t{-13};
+    EXPECT_EQ(v.i64, 0xfffffffffffffff3);
     v = uint64_t{111};
     EXPECT_EQ(v.i64, 111);
 
@@ -29,7 +59,7 @@ TEST(value, constructor_from_i64)
 
 TEST(value, constructor_from_unsigned_ints)
 {
-    EXPECT_EQ(Value{uint32_t{0xdededefe}}.i64, 0xdededefe);
+    EXPECT_EQ(Value{uint32_t{0xdededefe}}.i32, 0xdededefe);
     EXPECT_EQ(Value{uint64_t{0xdededededededefe}}.i64, 0xdededededededefe);
     EXPECT_EQ(Value{static_cast<unsigned long>(0xdededededededefe)}.i64, 0xdededededededefe);
     EXPECT_EQ(Value{static_cast<unsigned long long>(0xdededededededefe)}.i64, 0xdededededededefe);
@@ -37,7 +67,7 @@ TEST(value, constructor_from_unsigned_ints)
 
 TEST(value, constructor_from_signed_ints)
 {
-    EXPECT_EQ(Value{int32_t{-3}}.i64, 0xfffffffd);
+    EXPECT_EQ(Value{int32_t{-3}}.i32, 0xfffffffd);
     EXPECT_EQ(Value{int64_t{-3}}.i64, 0xfffffffffffffffd);
 }
 

--- a/test/utils/asserts.hpp
+++ b/test/utils/asserts.hpp
@@ -61,7 +61,7 @@ MATCHER_P(Result, value, "")  // NOLINT(readability-redundant-string-init)
         {
             if (arg.type == ValType::i32)
             {
-                return arg.value.i64 == static_cast<uint32_t>(value);
+                return arg.value.i32 == static_cast<uint32_t>(value);
             }
             else if (arg.type == ValType::i64 && value >= 0)
             {
@@ -104,8 +104,7 @@ MATCHER_P(CResult, value, "")  // NOLINT(readability-redundant-string-init)
     }
     else if constexpr (std::is_same_v<value_type, uint32_t>)
     {
-        // always check 64 bit of result
-        return arg.value.i64 == uint64_t{value};
+        return arg.value.i32 == value;
     }
     else if constexpr (std::is_same_v<value_type, uint64_t>)
     {
@@ -156,8 +155,7 @@ namespace fizzy::test
 {
 inline uint32_t as_uint32(fizzy::Value value)
 {
-    EXPECT_EQ(value.i64 & 0xffffffff00000000, 0);
-    return static_cast<uint32_t>(value.i64);
+    return value.i32;
 }
 
 std::ostream& operator<<(std::ostream& os, const TypedExecutionResult&);

--- a/test/utils/fizzy_c_engine.cpp
+++ b/test/utils/fizzy_c_engine.cpp
@@ -112,6 +112,8 @@ WasmEngine::Result FizzyCEngine::execute(
     const auto* module = fizzy_get_instance_module(m_instance.get());
     const auto func_type = fizzy_get_function_type(module, func_idx);
     assert(args.size() == func_type.inputs_size);
+    assert(func_type.output != FizzyValueTypeF32 && func_type.output != FizzyValueTypeF64 &&
+           "floating point result types are not supported");
     const auto first_arg = reinterpret_cast<const FizzyValue*>(args.data());
     const auto status = fizzy_execute(m_instance.get(), func_idx, first_arg, 0);
     if (status.trapped)

--- a/test/utils/fizzy_c_engine.cpp
+++ b/test/utils/fizzy_c_engine.cpp
@@ -108,13 +108,16 @@ WasmEngine::Result FizzyCEngine::execute(
     WasmEngine::FuncRef func_ref, const std::vector<uint64_t>& args)
 {
     static_assert(sizeof(uint64_t) == sizeof(FizzyValue));
+    const auto func_idx = static_cast<uint32_t>(func_ref);
+    const auto* module = fizzy_get_instance_module(m_instance.get());
+    const auto func_type = fizzy_get_function_type(module, func_idx);
+    assert(args.size() == func_type.inputs_size);
     const auto first_arg = reinterpret_cast<const FizzyValue*>(args.data());
-    const auto status =
-        fizzy_execute(m_instance.get(), static_cast<uint32_t>(func_ref), first_arg, 0);
+    const auto status = fizzy_execute(m_instance.get(), func_idx, first_arg, 0);
     if (status.trapped)
         return {true, std::nullopt};
     else if (status.has_value)
-        return {false, status.value.i64};
+        return {false, func_type.output == FizzyValueTypeI32 ? status.value.i32 : status.value.i64};
     else
         return {false, std::nullopt};
 }

--- a/test/utils/fizzy_engine.cpp
+++ b/test/utils/fizzy_engine.cpp
@@ -142,7 +142,11 @@ WasmEngine::Result FizzyEngine::execute(
     if (status.trapped)
         return {true, std::nullopt};
     else if (status.has_value)
+    {
+        assert(func_type.outputs[0] != ValType::f32 && func_type.outputs[0] != ValType::f64 &&
+               "floating point result types are not supported");
         return {false, func_type.outputs[0] == ValType::i32 ? status.value.i32 : status.value.i64};
+    }
     else
         return {false, std::nullopt};
 }

--- a/test/utils/fizzy_engine.cpp
+++ b/test/utils/fizzy_engine.cpp
@@ -136,13 +136,13 @@ WasmEngine::Result FizzyEngine::execute(
 {
     static_assert(sizeof(uint64_t) == sizeof(Value));
     const auto first_arg = reinterpret_cast<const Value*>(args.data());
-    assert(args.size() ==
-           m_instance->module->get_function_type(static_cast<uint32_t>(func_ref)).inputs.size());
+    const auto& func_type = m_instance->module->get_function_type(static_cast<uint32_t>(func_ref));
+    assert(args.size() == func_type.inputs.size());
     const auto status = fizzy::execute(*m_instance, static_cast<uint32_t>(func_ref), first_arg);
     if (status.trapped)
         return {true, std::nullopt};
     else if (status.has_value)
-        return {false, status.value.i64};
+        return {false, func_type.outputs[0] == ValType::i32 ? status.value.i32 : status.value.i64};
     else
         return {false, std::nullopt};
 }


### PR DESCRIPTION

Problems this introduces
- `stack.top() = 0` only zeros the `.i32` now.
- `FizzyValue{1}` only inits the `.i32` part. This is excessively used in C API tests. And cannot be disabled. In C++20 you can do `FizzyValue{.i64 = 1}`.