### PR TITLE
ci: Coverage with GCC

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -106,10 +106,29 @@ commands:
             llvm-cov report -instr-profile fizzy.profdata -Xdemangler llvm-cxxfilt $binaries > coverage/report.txt
             llvm-cov show -format=html -instr-profile fizzy.profdata -Xdemangler llvm-cxxfilt -region-coverage-lt=100 $binaries > coverage/missing.html
             llvm-cov show -format=html -instr-profile fizzy.profdata -Xdemangler llvm-cxxfilt $binaries > coverage/full.html
-            llvm-cov export -instr-profile fizzy.profdata -format=lcov $binaries > fizzy.lcov
+            llvm-cov export -instr-profile fizzy.profdata -format=lcov $binaries > coverage.lcov
       - store_artifacts:
           path: ~/build/coverage
           destination: coverage
+
+  upload_coverage_data:
+    description: "Upload coverage data"
+    steps:
+      - run:
+          name: "Upgrade codecov"
+          command: sudo pip3 install --upgrade --quiet --no-cache-dir codecov
+      - run:
+          name: "Upload to Codecov"
+          command: |
+            # Convert to relative paths
+            sed -i 's|$(pwd)/||' ~/build/coverage.lcov
+
+            counter=1
+            until codecov --required --file ~/build/coverage.lcov -X gcov || [ $counter = 5 ]; do
+              counter=$((counter+1))
+              sleep 1
+              echo "Try #$counter..."
+            done
 
 
   benchmark:
@@ -250,8 +269,7 @@ jobs:
       - test
 
   coverage-clang:
-    docker:
-      - image: ethereum/cpp-build-env:14-clang-10
+    executor: linux-clang-latest
     steps:
       - checkout
       - build:
@@ -262,21 +280,6 @@ jobs:
             - bin/*
       - test
       - collect_coverage_data
-      - run:
-          name: "Upgrade codecov"
-          command: sudo pip3 install --upgrade --quiet --no-cache-dir codecov
-      - run:
-          name: "Upload to Codecov"
-          command: |
-            # Convert to relative paths
-            sed -i 's|$(pwd)/||' ~/build/fizzy.lcov
-
-            counter=1
-            until codecov --required --file ~/build/fizzy.lcov -X gcov || [ $counter = 5 ]; do
-              counter=$((counter+1))
-              sleep 1
-              echo "Try #$counter..."
-            done
 
   coverage-gcc:
     executor: linux-gcc-latest
@@ -294,6 +297,7 @@ jobs:
       - store_artifacts:
           path: ~/build/coverage
           destination: coverage
+      - upload_coverage_data
 
   sanitizers:
     executor: linux-clang-latest
@@ -422,8 +426,7 @@ jobs:
           destination: artifacts
 
   spectest:
-    docker:
-      - image: ethereum/cpp-build-env:14-clang-10
+    executor: linux-clang-latest
     steps:
       - checkout
       - attach_workspace:

--- a/circle.yml
+++ b/circle.yml
@@ -8,10 +8,10 @@ parameters:
 executors:
   linux-gcc-9:
     docker:
-      - image: ethereum/cpp-build-env:14-gcc-9
+      - image: ethereum/cpp-build-env:15-gcc-9
   linux-gcc-latest:
     docker:
-      - image: ethereum/cpp-build-env:14-gcc-10
+      - image: ethereum/cpp-build-env:15-gcc-10
   linux-clang-latest:
     docker:
       - image: ethereum/cpp-build-env:15-clang-10
@@ -107,7 +107,6 @@ commands:
             llvm-cov show -format=html -instr-profile fizzy.profdata -Xdemangler llvm-cxxfilt -region-coverage-lt=100 $binaries > coverage/missing.html
             llvm-cov show -format=html -instr-profile fizzy.profdata -Xdemangler llvm-cxxfilt $binaries > coverage/full.html
             llvm-cov export -instr-profile fizzy.profdata -format=lcov $binaries > fizzy.lcov
-            genhtml fizzy.lcov -o coverage -t Fizzy
       - store_artifacts:
           path: ~/build/coverage
           destination: coverage
@@ -250,7 +249,7 @@ jobs:
           cmake_options: -DNATIVE=ON
       - test
 
-  coverage:
+  coverage-clang:
     docker:
       - image: ethereum/cpp-build-env:14-clang-10
     steps:
@@ -279,6 +278,22 @@ jobs:
               echo "Try #$counter..."
             done
 
+  coverage-gcc:
+    executor: linux-gcc-latest
+    steps:
+      - checkout
+      - build:
+          build_type: Coverage
+      - test
+      - run:
+          name: "Create coverage report"
+          working_directory: ~/build
+          command: |
+            lcov -c -d . -o coverage.lcov --exclude='/usr/include/*' --exclude="$HOME/.hunter/*" --exclude="$PWD/_deps/*"
+            genhtml coverage.lcov -o coverage -t Fizzy
+      - store_artifacts:
+          path: ~/build/coverage
+          destination: coverage
 
   sanitizers:
     executor: linux-clang-latest
@@ -433,13 +448,14 @@ workflows:
       - release-native-macos:
           requires:
             - sanitizers-macos
-      - coverage
+      - coverage-gcc
+      - coverage-clang
       - sanitizers
       - sanitizers-macos
       - fuzzing
       - spectest:
           requires:
-            - coverage
+            - coverage-clang
 
   benchmarking:
     when: <<pipeline.parameters.benchmark>>


### PR DESCRIPTION
I'd like to switch to using GCC for line-based coverage. The Clang source-based coverage will stay but will not be used on codecov.

There are two issues with Clang: it has some bugs (e.g. https://codecov.io/gh/wasmx/fizzy/src/3b19fb019b2d204ebe4cb7256d0cfb5db318b78e/lib/fizzy/parser.cpp#L155) and in the source-based coverage to line-based coverage conversion the comments are also marked as executed. The later screws the line count stats.

The plan is to prepare LCOV summary of the coverage on CI and only upload this single file (similarly to what we currently do with Clang).