### PR TITLE
Emit vtables once

### DIFF
--- a/lib/fizzy/CMakeLists.txt
+++ b/lib/fizzy/CMakeLists.txt
@@ -9,6 +9,8 @@ target_sources(
     fizzy PRIVATE
     bytes.hpp
     constexpr_vector.hpp
+    exceptions.cpp
+    exceptions.hpp
     execute.cpp
     execute.hpp
     instructions.cpp

--- a/lib/fizzy/exceptions.cpp
+++ b/lib/fizzy/exceptions.cpp
@@ -1,0 +1,12 @@
+// Fizzy: A fast WebAssembly interpreter
+// Copyright 2020 The Fizzy Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "exceptions.hpp"
+
+namespace fizzy
+{
+parser_error::~parser_error() noexcept = default;
+validation_error::~validation_error() noexcept = default;
+instantiate_error::~instantiate_error() noexcept = default;
+}  // namespace fizzy

--- a/lib/fizzy/exceptions.hpp
+++ b/lib/fizzy/exceptions.hpp
@@ -11,16 +11,22 @@ namespace fizzy
 struct parser_error : public std::runtime_error
 {
     using runtime_error::runtime_error;
+
+    ~parser_error() noexcept override;
 };
 
 struct validation_error : public std::runtime_error
 {
     using runtime_error::runtime_error;
+
+    ~validation_error() noexcept override;
 };
 
 struct instantiate_error : public std::runtime_error
 {
     using runtime_error::runtime_error;
+
+    ~instantiate_error() noexcept override;
 };
 
 }  // namespace fizzy

--- a/test/utils/wasm_engine.cpp
+++ b/test/utils/wasm_engine.cpp
@@ -2,11 +2,14 @@
 // Copyright 2020 The Fizzy Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "wasm_engine.hpp"
 #include <stdexcept>
 #include <string>
 
 namespace fizzy::test
 {
+WasmEngine::~WasmEngine() noexcept = default;
+
 void validate_function_signature(std::string_view signature)
 {
     if (signature.find_first_of(":") == std::string::npos)

--- a/test/utils/wasm_engine.hpp
+++ b/test/utils/wasm_engine.hpp
@@ -24,7 +24,7 @@ public:
         std::optional<uint64_t> value;
     };
 
-    virtual ~WasmEngine() noexcept = default;
+    virtual ~WasmEngine() noexcept;
 
     /// Parses input wasm binary. The created module is discarded.
     /// Returns false on parsing error.


### PR DESCRIPTION
This fixes -Wweak-vtable warnings, helpful for #508.

The effect in fizzy library is the following: vtables and typeinfos (**V**) are generates once in the `exceptions.cpp.o` instead of all files they were used. And the destructors are not `inline` any more (**W** -> **T**). This is good change as they are always cold.

I'm not convinced the impact is worth the trouble.

```diff
diff --git a/names.old b/names.fixed
index da7e6d25..47c47ba0 100644
--- a/names.old
+++ b/names.fixed
@@ -1,0 +2,20 @@
+exceptions.cpp.o:
+0000000000000060 T fizzy::parser_error::~parser_error()
+0000000000000000 T fizzy::parser_error::~parser_error()
+0000000000000000 T fizzy::parser_error::~parser_error()
+0000000000000090 T fizzy::validation_error::~validation_error()
+0000000000000020 T fizzy::validation_error::~validation_error()
+0000000000000020 T fizzy::validation_error::~validation_error()
+00000000000000c0 T fizzy::instantiate_error::~instantiate_error()
+0000000000000040 T fizzy::instantiate_error::~instantiate_error()
+0000000000000040 T fizzy::instantiate_error::~instantiate_error()
+0000000000000000 V typeinfo for fizzy::parser_error
+0000000000000000 V typeinfo for fizzy::validation_error
+0000000000000000 V typeinfo for fizzy::instantiate_error
+0000000000000000 V typeinfo name for fizzy::parser_error
+0000000000000000 V typeinfo name for fizzy::validation_error
+0000000000000000 V typeinfo name for fizzy::instantiate_error
+0000000000000000 V vtable for fizzy::parser_error
+0000000000000000 V vtable for fizzy::validation_error
+0000000000000000 V vtable for fizzy::instantiate_error
+
@@ -8,3 +27,0 @@ execute.cpp.o:
-0000000000000000 W fizzy::instantiate_error::~instantiate_error()
-0000000000000000 W fizzy::instantiate_error::~instantiate_error()
-0000000000000000 W fizzy::instantiate_error::~instantiate_error()
@@ -44 +60,0 @@ execute.cpp.o:
-0000000000000000 V typeinfo for fizzy::instantiate_error
@@ -48 +63,0 @@ execute.cpp.o:
-0000000000000000 V typeinfo name for fizzy::instantiate_error
@@ -53 +67,0 @@ execute.cpp.o:
-0000000000000000 V vtable for fizzy::instantiate_error
@@ -66,3 +79,0 @@ parser.cpp.o:
-0000000000000000 W fizzy::parser_error::~parser_error()
-0000000000000000 W fizzy::parser_error::~parser_error()
-0000000000000000 W fizzy::parser_error::~parser_error()
@@ -73,3 +83,0 @@ parser.cpp.o:
-0000000000000000 W fizzy::validation_error::~validation_error()
-0000000000000000 W fizzy::validation_error::~validation_error()
-0000000000000000 W fizzy::validation_error::~validation_error()
@@ -129,6 +136,0 @@ parser.cpp.o:
-0000000000000000 V typeinfo for fizzy::parser_error
-0000000000000000 V typeinfo for fizzy::validation_error
-0000000000000000 V typeinfo name for fizzy::parser_error
-0000000000000000 V typeinfo name for fizzy::validation_error
-0000000000000000 V vtable for fizzy::parser_error
-0000000000000000 V vtable for fizzy::validation_error
@@ -141,3 +142,0 @@ parser_expr.cpp.o:
-0000000000000000 W fizzy::parser_error::~parser_error()
-0000000000000000 W fizzy::parser_error::~parser_error()
-0000000000000000 W fizzy::parser_error::~parser_error()
@@ -145,3 +143,0 @@ parser_expr.cpp.o:
-0000000000000000 W fizzy::validation_error::~validation_error()
-0000000000000000 W fizzy::validation_error::~validation_error()
-0000000000000000 W fizzy::validation_error::~validation_error()
@@ -153,6 +148,0 @@ parser_expr.cpp.o:
-0000000000000000 V typeinfo for fizzy::parser_error
-0000000000000000 V typeinfo for fizzy::validation_error
-0000000000000000 V typeinfo name for fizzy::parser_error
-0000000000000000 V typeinfo name for fizzy::validation_error
-0000000000000000 V vtable for fizzy::parser_error
-0000000000000000 V vtable for fizzy::validation_error
```