### PR TITLE
Introduce UNREACHABLE macro

### DIFF
--- a/lib/fizzy/CMakeLists.txt
+++ b/lib/fizzy/CMakeLists.txt
@@ -10,6 +10,8 @@ target_include_directories(fizzy PUBLIC ${FIZZY_INCLUDE_DIR})
 target_sources(
     fizzy PRIVATE
     ${FIZZY_INCLUDE_DIR}/fizzy/fizzy.h
+    asserts.cpp
+    asserts.hpp
     cxx20/bit.hpp
     cxx20/span.hpp
     bytes.hpp
@@ -36,6 +38,10 @@ target_sources(
     utf8.hpp
     value.hpp
 )
+
+if(CMAKE_BUILD_TYPE STREQUAL Coverage AND CMAKE_CXX_COMPILER_ID MATCHES GNU)
+    set_source_files_properties(asserts.cpp PROPERTIES COMPILE_DEFINITIONS GCOV)
+endif()
 
 # The fizzy::fizzy-internal links fizzy::fizzy library with access to internal headers.
 add_library(fizzy-internal INTERFACE)

--- a/lib/fizzy/asserts.cpp
+++ b/lib/fizzy/asserts.cpp
@@ -1,0 +1,20 @@
+// Fizzy: A fast WebAssembly interpreter
+// Copyright 2020 The Fizzy Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "asserts.hpp"
+
+#ifdef GCOV
+extern "C" void __gcov_flush();
+#endif
+
+namespace fizzy
+{
+bool unreachable() noexcept
+{
+#ifdef GCOV
+    __gcov_flush();
+#endif
+    return false;  // LCOV_EXCL_LINE
+}
+}  // namespace fizzy

--- a/lib/fizzy/asserts.hpp
+++ b/lib/fizzy/asserts.hpp
@@ -1,0 +1,28 @@
+// Fizzy: A fast WebAssembly interpreter
+// Copyright 2020 The Fizzy Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cassert>
+
+#ifndef __has_builtin
+#define __has_builtin(name) 0
+#endif
+
+#ifndef __has_feature
+#define __has_feature(name) 0
+#endif
+
+
+namespace fizzy
+{
+/// A helper for assert(unreachable()). Always returns false. Also flushes coverage data.
+bool unreachable() noexcept;
+}  // namespace fizzy
+
+#ifndef NDEBUG
+#define FIZZY_UNREACHABLE() assert(fizzy::unreachable())
+#elif __has_builtin(__builtin_unreachable)
+#define FIZZY_UNREACHABLE() __builtin_unreachable()
+#else
+#define FIZZY_UNREACHABLE() (void)0
+#endif

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "execute.hpp"
+#include "asserts.hpp"
 #include "cxx20/bit.hpp"
 #include "stack.hpp"
 #include "trunc_boundaries.hpp"
@@ -1554,8 +1555,7 @@ ExecutionResult execute(Instance& instance, FuncIdx func_idx, const Value* args,
         }
 
         default:
-            assert(false);
-            break;
+            FIZZY_UNREACHABLE();
         }
     }
 

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "parser.hpp"
+#include "asserts.hpp"
 #include "leb128.hpp"
 #include "limits.hpp"
 #include "types.hpp"
@@ -532,8 +533,8 @@ std::unique_ptr<const Module> parse(bytes_view input)
         case ExternalKind::Global:
             module->imported_global_types.emplace_back(import.desc.global);
             break;
-        default:
-            assert(false);
+        default:                  // LCOV_EXCL_LINE
+            FIZZY_UNREACHABLE();  // LCOV_EXCL_LINE
         }
     }
 
@@ -635,8 +636,8 @@ std::unique_ptr<const Module> parse(bytes_view input)
             if (export_.index >= total_global_count)
                 throw validation_error{"invalid index of an exported global"};
             break;
-        default:
-            assert(false);
+        default:                  // LCOV_EXCL_LINE
+            FIZZY_UNREACHABLE();  // LCOV_EXCL_LINE
         }
         if (!export_names.emplace(export_.name).second)
             throw validation_error{"duplicate export name " + export_.name};

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(
     end_to_end_test.cpp
     execute_call_test.cpp
     execute_control_test.cpp
+    execute_death_test.cpp
     execute_floating_point_test.cpp
     execute_numeric_test.cpp
     execute_test.cpp

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(fizzy-unittests PRIVATE fizzy::fizzy-internal fizzy::test-
 target_sources(
     fizzy-unittests PRIVATE
     api_test.cpp
+    asserts_test.cpp
     capi_test.cpp
     constexpr_vector_test.cpp
     cxx20_bit_test.cpp

--- a/test/unittests/asserts_test.cpp
+++ b/test/unittests/asserts_test.cpp
@@ -1,0 +1,14 @@
+// Fizzy: A fast WebAssembly interpreter
+// Copyright 2020 The Fizzy Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "asserts.hpp"
+#include <gtest/gtest.h>
+
+#if !defined(NDEBUG) || __has_feature(undefined_behavior_sanitizer)
+TEST(asserts_death, unreachable)
+{
+    static constexpr auto unreachable = []() noexcept { FIZZY_UNREACHABLE(); };
+    EXPECT_DEATH(unreachable(), "unreachable");
+}
+#endif

--- a/test/unittests/execute_death_test.cpp
+++ b/test/unittests/execute_death_test.cpp
@@ -1,0 +1,28 @@
+// Fizzy: A fast WebAssembly interpreter
+// Copyright 2020 The Fizzy Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "asserts.hpp"
+#include "execute.hpp"
+#include <gtest/gtest.h>
+
+using namespace fizzy;
+
+#if !defined(NDEBUG) || __has_feature(undefined_behavior_sanitizer)
+TEST(execute_death, malformed_instruction_opcode)
+{
+    constexpr auto malformed_opcode = static_cast<Instr>(6);
+
+    Code code;
+    code.instructions.emplace_back(malformed_opcode);
+    code.instructions.emplace_back(Instr::end);
+
+    auto module = std::make_unique<Module>();
+    module->typesec.emplace_back(FuncType{});
+    module->funcsec.emplace_back(TypeIdx{0});
+    module->codesec.emplace_back(std::move(code));
+
+    auto instance = instantiate(std::move(module));
+    EXPECT_DEATH(execute(*instance, 0, nullptr), "unreachable");
+}
+#endif


### PR DESCRIPTION
Add macro FIZZY_UNREACHABLE to mark unreachable code.
It fails a standard assert in build with asserts enabled.
It fails in UBSan.
It is an optimization hint for optimized builds.

Replaces `assert(false` with `FIZZY_UNREACHABLE`.

Introduces "death tests". They are very expensive (single death test runs longer than all execution tests), so limited to single case.

We cannot use death tests to reach the unreachable code in parser because parsing and validation is done in single go and there is no way to inject malformed module to verification procedure.