### PR TITLE
Update spectests with backports

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -210,13 +210,13 @@ commands:
         default: false
       expected_passed:
         type: integer
-        default: 18900
+        default: 18975
       expected_failed:
         type: integer
-        default: 2
+        default: 4
       expected_skipped:
         type: integer
-        default: 477
+        default: 499
 
     steps:
       - install_wabt
@@ -225,7 +225,7 @@ commands:
           working_directory: ~/build
           command: |
             if [ ! -d wasm-spec ]; then
-              git clone https://github.com/wasmx/wasm-spec --branch w3c-1.0-jsontests-20200813 --depth 1 wasm-spec
+              git clone https://github.com/wasmx/wasm-spec --branch w3c-1.0-tests-backported-20201113 --depth 1 wasm-spec
               mkdir json && cd json
               options='--disable-saturating-float-to-int --disable-sign-extension --disable-multi-value'
               find ../wasm-spec/test/core -name '*.wast' -exec wast2json $options {} \;

--- a/circle.yml
+++ b/circle.yml
@@ -35,7 +35,7 @@ commands:
             else
               [[ $OSTYPE = darwin* ]] && os=macos || os=ubuntu
               cd /usr/local
-              curl -L https://github.com/WebAssembly/wabt/releases/download/1.0.19/wabt-1.0.19-$os.tar.gz | sudo tar xz --strip 1
+              curl -L https://github.com/WebAssembly/wabt/releases/download/1.0.20/wabt-1.0.20-$os.tar.gz | sudo tar xz --strip 1
             fi
 
   install_testfloat:


### PR DESCRIPTION
At this stage, it has 5 spectests failures.

- FIXED: One of the tests that we failed (and reported as invalid), was deleted https://github.com/WebAssembly/spec/pull/1205
- 4 tests are going to be fixed by #546.
- FIXED: 1 failure old failure is "validation-error-before-decoding-error", and it fixed upstream by https://github.com/WebAssembly/spec/pull/1261.
- FIXED: 2 new failures in `func.wast`, the reason is wast2json generates incorrect local index in the module. It still happens in wabt 1.0.19, but is fixed on master. Related issues/PRs:
   - https://github.com/WebAssembly/wabt/issues/1551
   - https://github.com/WebAssembly/spec/pull/1213
   - https://github.com/WebAssembly/wabt/pull/1466
   - https://github.com/WebAssembly/wabt/pull/1494

TODO:
- [x] Rename the wasm-spec branch from `w3c-1.0-backport-tests` to `w3c-1.0-tests-backported`.
- [x] Tag the version we are going to use with this PR as `w3c-1.0-tests-backported-20201113`.
- [x] Backport https://github.com/WebAssembly/spec/pull/1261 if merged.