### PR TITLE
Improve and expose bit_cast implementation

### DIFF
--- a/lib/fizzy/CMakeLists.txt
+++ b/lib/fizzy/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(fizzy::fizzy ALIAS fizzy)
 
 target_sources(
     fizzy PRIVATE
+    cxx20/bit.hpp
     bytes.hpp
     constexpr_vector.hpp
     exceptions.cpp

--- a/lib/fizzy/cxx20/bit.hpp
+++ b/lib/fizzy/cxx20/bit.hpp
@@ -1,0 +1,26 @@
+// Fizzy: A fast WebAssembly interpreter
+// Copyright 2020 The Fizzy Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <type_traits>
+
+namespace fizzy
+{
+/// The non-constexpr implementation of C++20's std::bit_cast.
+/// See https://en.cppreference.com/w/cpp/numeric/bit_cast.
+template <class To, class From>
+[[nodiscard]] inline
+    typename std::enable_if_t<sizeof(To) == sizeof(From) && std::is_trivially_copyable_v<From> &&
+                                  std::is_trivially_copyable_v<To>,
+        To>
+    bit_cast(const From& src) noexcept
+{
+    static_assert(std::is_trivially_constructible_v<To>);  // Additional, non-standard requirement.
+
+    To dst;
+    __builtin_memcpy(&dst, &src, sizeof(To));
+    return dst;
+}
+}  // namespace fizzy

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(fizzy-unittests PRIVATE fizzy::fizzy fizzy::test-utils GTe
 target_sources(
     fizzy-unittests PRIVATE
     api_test.cpp
+    bit_cast_test.cpp
     constexpr_vector_test.cpp
     end_to_end_test.cpp
     execute_call_test.cpp

--- a/test/unittests/bit_cast_test.cpp
+++ b/test/unittests/bit_cast_test.cpp
@@ -1,0 +1,46 @@
+// Fizzy: A fast WebAssembly interpreter
+// Copyright 2020 The Fizzy Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "cxx20/bit.hpp"
+#include <gtest/gtest.h>
+#include <array>
+
+using namespace fizzy;
+using namespace testing;
+
+
+TEST(bit_cast, double_to_uint64)
+{
+    // A test case from https://en.cppreference.com/w/cpp/numeric/bit_cast#Example.
+    EXPECT_EQ(bit_cast<uint64_t>(19880124.0), 0x4172f58bc0000000);
+}
+
+TEST(bit_cast, uint64_to_double)
+{
+    // A test case from https://en.cppreference.com/w/cpp/numeric/bit_cast#Example.
+    EXPECT_EQ(bit_cast<double>(uint64_t{0x3fe9000000000000}), 0.781250);
+}
+
+TEST(bit_cast, uint32_to_int32)
+{
+    EXPECT_EQ(bit_cast<int32_t>(uint32_t{0x80000000}), -2147483648);
+    EXPECT_EQ(bit_cast<int32_t>(uint32_t{0xffffffff}), -1);
+}
+
+TEST(bit_cast, int32_to_uint32)
+{
+    EXPECT_EQ(bit_cast<uint32_t>(int32_t{-2}), 0xfffffffe);
+    EXPECT_EQ(bit_cast<uint32_t>(int32_t{1}), 1);
+}
+
+TEST(bit_cast, uint32_to_array)
+{
+    // Uses "byte-symmetric" value to avoid handling endianness.
+    std::array<uint8_t, 4> bytes;
+    bytes = bit_cast<decltype(bytes)>(uint32_t{0xaabbbbaa});
+    EXPECT_EQ(bytes[0], 0xaa);
+    EXPECT_EQ(bytes[1], 0xbb);
+    EXPECT_EQ(bytes[2], 0xbb);
+    EXPECT_EQ(bytes[3], 0xaa);
+}

--- a/test/utils/floating_point_utils.hpp
+++ b/test/utils/floating_point_utils.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "cxx20/bit.hpp"
 #include <cmath>
 #include <cstdint>
 #include <limits>
@@ -11,16 +12,6 @@
 
 namespace fizzy::test
 {
-/// Simple implementation of C++20's std::bit_cast.
-template <typename DstT, typename SrcT>
-DstT bit_cast(SrcT x) noexcept
-{
-    DstT z;
-    static_assert(sizeof(x) == sizeof(z));
-    __builtin_memcpy(&z, &x, sizeof(x));
-    return z;
-}
-
 /// A wrapper for floating-point types with inspection/construction/comparison utilities.
 template <typename T>
 struct FP


### PR DESCRIPTION
Improve the bit_cast implementation to be as close as the C++20 spec.
Move it to lib/fizzy/cxx20/bit.hpp to match the <bit> header in C++20
and be available in the fizzy library.