### PR TITLE
Fix bounds checking pattern in parser

### DIFF
--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -260,7 +260,7 @@ parser_result<std::string> parse_string(const uint8_t* pos, const uint8_t* end)
     uint32_t size;
     std::tie(size, pos) = leb128u_decode<uint32_t>(pos, end);
 
-    if ((pos + size) > end)
+    if ((end - pos) < size)
         throw parser_error{"unexpected EOF"};
 
     if (!utf8_validate(pos, pos + size))
@@ -421,7 +421,7 @@ inline parser_result<Data> parse(const uint8_t* pos, const uint8_t* end)
     uint32_t size;
     std::tie(size, pos) = leb128u_decode<uint32_t>(pos, end);
 
-    if ((pos + size) > end)
+    if ((end - pos) < size)
         throw parser_error{"unexpected EOF"};
 
     auto init = bytes(pos, pos + size);
@@ -453,10 +453,10 @@ Module parse(bytes_view input)
         uint32_t size;
         std::tie(size, it) = leb128u_decode<uint32_t>(it, input.end());
 
-        const auto expected_section_end = it + size;
-        if (expected_section_end > input.end())
+        if ((input.end() - it) < size)
             throw parser_error{"unexpected EOF"};
 
+        const auto expected_section_end = it + size;
         switch (id)
         {
         case SectionId::type:

--- a/lib/fizzy/parser.hpp
+++ b/lib/fizzy/parser.hpp
@@ -29,8 +29,8 @@ inline parser_result<uint8_t> parse_byte(const uint8_t* pos, const uint8_t* end)
 template <typename T>
 inline parser_result<T> parse_value(const uint8_t* pos, const uint8_t* end)
 {
-    constexpr auto size = sizeof(T);
-    if (pos + size > end)
+    constexpr ptrdiff_t size = sizeof(T);
+    if ((end - pos) < size)
         throw parser_error{"unexpected EOF"};
 
     T value;

--- a/lib/fizzy/utf8.cpp
+++ b/lib/fizzy/utf8.cpp
@@ -105,11 +105,12 @@ bool utf8_validate(const uint8_t* pos, const uint8_t* end) noexcept
         else
             return false;
 
-        // At this point need to read at least one more byte
-        if ((pos + required_bytes - 1) > end)
+
+        // At this point need to read at least one more byte.
+        assert(required_bytes > 1);
+        if ((end - pos) < required_bytes - 1)
             return false;
 
-        assert(required_bytes > 1);
 
         // Byte2 may have exceptional encodings
         const uint8_t byte2 = *pos++;

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -1370,11 +1370,19 @@ TEST(parser, data_section_without_memory)
 
 TEST(parser, data_section_out_of_bounds)
 {
+    // Expected data of length 1, 0 bytes given.
     const auto wasm1 = bytes{wasm_prefix} + make_section(11, make_vec({"0041000b01"_bytes}));
     EXPECT_THROW_MESSAGE(parse(wasm1), parser_error, "unexpected EOF");
+
+    // Expected data of length 9, 8 bytes given.
     const auto wasm2 =
         bytes{wasm_prefix} + make_section(11, make_vec({"0041000b09d0d1d2d3d4d5d6d7"_bytes}));
     EXPECT_THROW_MESSAGE(parse(wasm2), parser_error, "unexpected EOF");
+
+    // Expected data of length 127 (0x7f), 1 byte given. This detects invalid pointer comparison
+    // with ASan pointer-compare,pointer-subtract.
+    const auto wasm3 = bytes{wasm_prefix} + make_section(11, make_vec({"0041000b7fd0"_bytes}));
+    EXPECT_THROW_MESSAGE(parse(wasm3), parser_error, "unexpected EOF");
 }
 
 TEST(parser, unknown_section_empty)

--- a/test/unittests/utf8_test.cpp
+++ b/test/unittests/utf8_test.cpp
@@ -4,7 +4,6 @@
 
 #include "utf8.hpp"
 #include <gtest/gtest.h>
-#include <test/utils/asserts.hpp>
 #include <test/utils/hex.hpp>
 
 using namespace fizzy;
@@ -132,4 +131,34 @@ TEST(utf8, validate)
     };
     for (const auto& testcase : testcases)
         EXPECT_EQ(utf8_validate(testcase.first), testcase.second);
+}
+
+TEST(utf8, missing_second_byte)
+{
+    constexpr uint8_t first_bytes[]{0xDF, 0xE0, 0xEC, 0xED, 0xEF, 0xF0, 0xF3, 0xF4};
+    for (const auto b : first_bytes)
+    {
+        const uint8_t input[]{b};
+        EXPECT_FALSE(utf8_validate({input, std::size(input)}));
+    }
+}
+
+TEST(utf8, missing_third_byte)
+{
+    constexpr uint8_t first_bytes[]{0xE0, 0xEC, 0xED, 0xEF, 0xF0, 0xF3, 0xF4};
+    for (const auto b : first_bytes)
+    {
+        const uint8_t input[]{b, 0xA0};
+        EXPECT_FALSE(utf8_validate({input, std::size(input)}));
+    }
+}
+
+TEST(utf8, missing_forth_byte)
+{
+    constexpr uint8_t first_bytes[]{0xF0, 0xF3, 0xF4};
+    for (const auto b : first_bytes)
+    {
+        const uint8_t input[]{b, 0xA0, 0xA0};
+        EXPECT_FALSE(utf8_validate({input, std::size(input)}));
+    }
 }


### PR DESCRIPTION
The previous pattern `pos + size < end` was incorrect leading to
possible undefined behavior and potential addition overflow allowing
the check bypass. The correct check is to compute the remaining size
and compare with the declared size. This way invalid pointer comparison
is replaced with correct pointer subtraction (pos and end are from the
same memory buffer) and integer comparison: `(end - pos) < size`.

This will be additionally check with extended ASan options in #469.