### PR TITLE
Change "unexpected memidx" to validation error

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -210,10 +210,10 @@ commands:
         default: false
       expected_passed:
         type: integer
-        default: 18975
+        default: 18979
       expected_failed:
         type: integer
-        default: 4
+        default: 0
       expected_skipped:
         type: integer
         default: 499

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -341,8 +341,14 @@ inline parser_result<Element> parse(const uint8_t* pos, const uint8_t* end)
 {
     TableIdx table_index;
     std::tie(table_index, pos) = leb128u_decode<uint32_t>(pos, end);
+
+    // TODO: The check should be table_index < num_of_tables (0 or 1),
+    //       but access to the module is needed.
     if (table_index != 0)
-        throw parser_error{"unexpected tableidx value " + std::to_string(table_index)};
+    {
+        throw validation_error{
+            "invalid table index " + std::to_string(table_index) + " (only table 0 is allowed)"};
+    }
 
     ConstantExpression offset;
     // Offset expression is required to have i32 result value
@@ -588,7 +594,10 @@ std::unique_ptr<const Module> parse(bytes_view input)
     }
 
     if (!module->elementsec.empty() && !module->has_table())
-        throw validation_error{"element section encountered without a table section"};
+    {
+        throw validation_error{
+            "invalid table index 0 (element section encountered without a table section)"};
+    }
 
     const auto total_func_count = module->get_function_count();
 

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -930,7 +930,8 @@ TEST(parser, element_section_tableidx_nonzero)
     const auto section_contents = bytes{0x01, 0x01, 0x41, 0x01, 0x0b, 0x01, 0x00};
     const auto bin = bytes{wasm_prefix} + make_section(9, section_contents);
 
-    EXPECT_THROW_MESSAGE(parse(bin), parser_error, "unexpected tableidx value 1");
+    EXPECT_THROW_MESSAGE(
+        parse(bin), validation_error, "invalid table index 1 (only table 0 is allowed)");
 }
 
 TEST(parser, element_section_invalid_initializer)
@@ -945,8 +946,8 @@ TEST(parser, element_section_no_table_section)
 {
     const auto wasm =
         bytes{wasm_prefix} + make_section(9, make_vec({"0041000b"_bytes + make_vec({"00"_bytes})}));
-    EXPECT_THROW_MESSAGE(
-        parse(wasm), validation_error, "element section encountered without a table section");
+    EXPECT_THROW_MESSAGE(parse(wasm), validation_error,
+        "invalid table index 0 (element section encountered without a table section)");
 }
 
 TEST(parser, code_section_empty)

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -1324,7 +1324,8 @@ TEST(parser, data_section_memidx_nonzero)
 {
     const auto section_contents = make_vec({"0141010b0100"_bytes});
     const auto bin = bytes{wasm_prefix} + make_section(11, section_contents);
-    EXPECT_THROW_MESSAGE(parse(bin), parser_error, "unexpected memidx value 1");
+    EXPECT_THROW_MESSAGE(
+        parse(bin), validation_error, "invalid memory index 1 (only memory 0 is allowed)");
 }
 
 TEST(parser, data_section_invalid_initializer)
@@ -1338,15 +1339,15 @@ TEST(parser, data_section_invalid_initializer)
 TEST(parser, data_section_empty_vector_without_memory)
 {
     const auto bin = bytes{wasm_prefix} + make_section(11, make_vec({"0041010b00"_bytes}));
-    EXPECT_THROW_MESSAGE(
-        parse(bin), validation_error, "data section encountered without a memory section");
+    EXPECT_THROW_MESSAGE(parse(bin), validation_error,
+        "invalid memory index 0 (data section encountered without a memory section)");
 }
 
 TEST(parser, data_section_without_memory)
 {
     const auto bin = bytes{wasm_prefix} + make_section(11, make_vec({"0041010b02aaff"_bytes}));
-    EXPECT_THROW_MESSAGE(
-        parse(bin), validation_error, "data section encountered without a memory section");
+    EXPECT_THROW_MESSAGE(parse(bin), validation_error,
+        "invalid memory index 0 (data section encountered without a memory section)");
 }
 
 TEST(parser, data_section_out_of_bounds)


### PR DESCRIPTION
Depends on #534. 

Fizzy fix for the proposed spectests: https://github.com/WebAssembly/spec/pull/1249.
Element section tests correction: https://github.com/WebAssembly/spec/pull/1251.

I also changed the error message.

> Use validation error message "unknown memory N" for both N != 0 and data segments without any memory in the module. Inspired by messages in wasm reference interpreter.