### PR TITLE
cmake: Add fizzy::fizzy-internal INTERFACE library

### DIFF
--- a/lib/fizzy/CMakeLists.txt
+++ b/lib/fizzy/CMakeLists.txt
@@ -36,3 +36,9 @@ target_sources(
     utf8.hpp
     value.hpp
 )
+
+# The fizzy::fizzy-internal links fizzy::fizzy library with access to internal headers.
+add_library(fizzy-internal INTERFACE)
+add_library(fizzy::fizzy-internal ALIAS fizzy-internal)
+target_link_libraries(fizzy-internal INTERFACE fizzy::fizzy)
+target_include_directories(fizzy-internal INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,8 +22,6 @@ if(HUNTER_ENABLED)
 endif()
 find_package(GTest REQUIRED)
 
-set(fizzy_include_dir ${PROJECT_SOURCE_DIR}/lib/fizzy)
-
 add_subdirectory(utils)
 add_subdirectory(bench)
 add_subdirectory(bench_internal)

--- a/test/bench/CMakeLists.txt
+++ b/test/bench/CMakeLists.txt
@@ -4,8 +4,7 @@
 
 add_executable(fizzy-bench bench.cpp)
 target_compile_features(fizzy-bench PRIVATE cxx_std_17)
-target_link_libraries(fizzy-bench PRIVATE fizzy::fizzy fizzy::test-utils benchmark::benchmark)
-target_include_directories(fizzy-bench PRIVATE ${fizzy_include_dir})
+target_link_libraries(fizzy-bench PRIVATE fizzy::fizzy-internal fizzy::test-utils benchmark::benchmark)
 
 if(UNIX AND NOT APPLE)
     # For libstdc++ up to version 8 (included) this is needed for proper <filesystem> support.

--- a/test/bench_internal/CMakeLists.txt
+++ b/test/bench_internal/CMakeLists.txt
@@ -12,5 +12,4 @@ target_sources(fizzy-bench-internal PRIVATE
     parser_benchmarks.cpp
 )
 
-target_link_libraries(fizzy-bench-internal PRIVATE fizzy::fizzy fizzy::test-utils benchmark::benchmark_main)
-target_include_directories(fizzy-bench-internal PRIVATE ${fizzy_include_dir})
+target_link_libraries(fizzy-bench-internal PRIVATE fizzy::fizzy-internal fizzy::test-utils benchmark::benchmark_main)

--- a/test/fuzzer/CMakeLists.txt
+++ b/test/fuzzer/CMakeLists.txt
@@ -4,5 +4,4 @@
 
 add_executable(fizzy-fuzz-parser parser_fuzzer.cpp)
 target_link_options(fizzy-fuzz-parser PRIVATE -fsanitize=fuzzer)
-target_link_libraries(fizzy-fuzz-parser PRIVATE fizzy::fizzy)
-target_include_directories(fizzy-fuzz-parser PRIVATE ${fizzy_include_dir})
+target_link_libraries(fizzy-fuzz-parser PRIVATE fizzy::fizzy-internal)

--- a/test/spectests/CMakeLists.txt
+++ b/test/spectests/CMakeLists.txt
@@ -9,8 +9,7 @@ find_package(nlohmann_json REQUIRED)
 
 add_executable(fizzy-spectests spectests.cpp)
 target_compile_features(fizzy-spectests PRIVATE cxx_std_17)
-target_link_libraries(fizzy-spectests PRIVATE fizzy::fizzy fizzy::test-utils nlohmann_json::nlohmann_json)
-target_include_directories(fizzy-spectests PRIVATE ${fizzy_include_dir})
+target_link_libraries(fizzy-spectests PRIVATE fizzy::fizzy-internal fizzy::test-utils nlohmann_json::nlohmann_json)
 
 if(UNIX AND NOT APPLE)
     # For libstdc++ up to version 8 (included) this is needed for proper <filesystem> support.

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -5,7 +5,7 @@
 include(GoogleTest)
 
 add_executable(fizzy-unittests)
-target_link_libraries(fizzy-unittests PRIVATE fizzy::fizzy fizzy::test-utils GTest::gtest_main GTest::gmock)
+target_link_libraries(fizzy-unittests PRIVATE fizzy::fizzy-internal fizzy::test-utils GTest::gtest_main GTest::gmock)
 
 target_sources(
     fizzy-unittests PRIVATE

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -28,5 +28,5 @@ target_sources(
 )
 
 target_compile_features(test-utils PUBLIC cxx_std_17)
-target_include_directories(test-utils PUBLIC ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/lib/fizzy)
-target_link_libraries(test-utils PRIVATE fizzy::fizzy wabt::wabt wasm3::wasm3 GTest::gtest)
+target_include_directories(test-utils PUBLIC ${PROJECT_SOURCE_DIR})
+target_link_libraries(test-utils PUBLIC fizzy::fizzy-internal PRIVATE wabt::wabt wasm3::wasm3 GTest::gtest)


### PR DESCRIPTION
The fizzy::fizzy-internal links fizzy::fizzy library with access to internal headers. Do not include the directory with internal headers directly in test tools.

The tendency should be to migrate from using `fizzy::fizzy-internal` to `fizzy::fizzy` as we get more public API. Ideally, in the end only `fizzy-unittests` should be using `fizzy::fizzy-internal`.

Dependencies are getting messy.
![fizzy](https://user-images.githubusercontent.com/573380/94702063-a3bea200-033d-11eb-9b1f-13389c7e2c9e.png)
