### PR TITLE
Call optimization

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -495,12 +495,11 @@ inline bool invoke_function(const FuncType& func_type, const F& func, Instance& 
 
     stack.drop(num_args);
 
-    const auto num_outputs = func_type.outputs.size();
     // NOTE: we can assume these two from validation
-    assert(num_outputs <= 1);
-    assert(ret.has_value == (num_outputs == 1));
+    assert(func_type.outputs.size() <= 1);
+    assert(ret.has_value == !func_type.outputs.empty());
     // Push back the result
-    if (num_outputs != 0)
+    if (ret.has_value != 0)
         stack.push(ret.value);
 
     return true;

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -509,10 +509,26 @@ inline bool invoke_function(const FuncType& func_type, const F& func, Instance& 
 inline bool invoke_function(const FuncType& func_type, uint32_t func_idx, Instance& instance,
     OperandStack& stack, int depth) noexcept
 {
-    const auto func = [func_idx](Instance& _instance, span<const Value> args, int _depth) noexcept {
-        return execute(_instance, func_idx, args.data(), _depth);
-    };
-    return invoke_function(func_type, func, instance, stack, depth);
+    const auto num_args = func_type.inputs.size();
+    assert(stack.size() >= num_args);
+    span<const Value> call_args{stack.rend() - num_args, num_args};
+
+    const auto ret = execute(instance, func_idx, call_args.data(), depth + 1);
+    // Bubble up traps
+    if (ret.trapped)
+        return false;
+
+    stack.drop(num_args);
+
+    const auto num_outputs = func_type.outputs.size();
+    // NOTE: we can assume these two from validation
+    assert(num_outputs <= 1);
+    assert(ret.has_value == (num_outputs == 1));
+    // Push back the result
+    if (num_outputs != 0)
+        stack.push(ret.value);
+
+    return true;
 }
 }  // namespace
 

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -510,9 +510,8 @@ inline bool invoke_function(const FuncType& func_type, uint32_t func_idx, Instan
 {
     const auto num_args = func_type.inputs.size();
     assert(stack.size() >= num_args);
-    span<const Value> call_args{stack.rend() - num_args, num_args};
 
-    const auto ret = execute(instance, func_idx, call_args.data(), depth + 1);
+    const auto ret = execute(instance, func_idx, stack.rend() - num_args, depth + 1);
     // Bubble up traps
     if (ret.trapped)
         return false;


### PR DESCRIPTION
~~Results may be wrong as some benchmarks don't use calls.~~ Confirmed for GCC10/LTO.

```
fizzy/execute/blake2b/512_bytes_rounds_1_mean                     -0.1128         -0.1128            87            78            87            78                                                                                 
fizzy/execute/blake2b/512_bytes_rounds_16_mean                    -0.1149         -0.1148          1329          1176          1329          1176                                                                                 
fizzy/execute/ecpairing/onepoint_mean                             -0.0918         -0.0918        411770        373976        411774        373980                                                                                 
fizzy/execute/keccak256/512_bytes_rounds_1_mean                   -0.0856         -0.0856           105            96           105            96                                                                                 
fizzy/execute/keccak256/512_bytes_rounds_16_mean                  -0.0999         -0.0999          1548          1393          1548          1393                                                                                 
fizzy/execute/memset/256_bytes_mean                               -0.1481         -0.1481             7             6             7             6                                                                                 
fizzy/execute/memset/60000_bytes_mean                             -0.1510         -0.1510          1623          1378          1623          1378                                                                                 
fizzy/execute/mul256_opt0/input0_mean                             -0.1334         -0.1334            29            25            29            25                                                                                 
fizzy/execute/mul256_opt0/input1_mean                             -0.1338         -0.1338            29            25            29            25                                                                                 
fizzy/execute/ramanujan_pi/33_runs_mean                           -0.1255         -0.1255           138           120           138           120                                                                                 
fizzy/execute/sha1/512_bytes_rounds_1_mean                        -0.1141         -0.1141            94            84            94            84                                                                                 
fizzy/execute/sha1/512_bytes_rounds_16_mean                       -0.1163         -0.1163          1318          1164          1318          1164                                                                                 
fizzy/execute/sha256/512_bytes_rounds_1_mean                      -0.1193         -0.1193            96            84            96            84                                                                                 
fizzy/execute/sha256/512_bytes_rounds_16_mean                     -0.1228         -0.1228          1326          1163          1326          1163                                                                                 
fizzy/execute/taylor_pi/pi_1000000_runs_mean                      -0.0392         -0.0392         41668         40036         41669         40036                                                                                 
fizzy/execute/micro/eli_interpreter/halt_mean                     -0.1528         -0.1528             0             0             0             0                                                                                 
fizzy/execute/micro/eli_interpreter/exec105_mean                  -0.1269         -0.1269             5             4             5             4                                                                                 
fizzy/execute/micro/factorial/10_mean                             -0.1033         -0.1032             0             0             0             0                                                                                 
fizzy/execute/micro/factorial/20_mean                             -0.1066         -0.1066             1             0             1             0                                                                                 
fizzy/execute/micro/fibonacci/24_mean                             -0.0947         -0.0947          5230          4735          5230          4735                                                                                 
fizzy/execute/micro/host_adler32/1_mean                           -0.0603         -0.0603             0             0             0             0
fizzy/execute/micro/host_adler32/100_mean                         -0.0753         -0.0753             3             3             3             3
fizzy/execute/micro/host_adler32/1000_mean                        -0.0549         -0.0549            31            29            31            29
fizzy/execute/micro/spinner/1_mean                                -0.1555         -0.1555             0             0             0             0
fizzy/execute/micro/spinner/1000_mean                             -0.1487         -0.1487            10             9            10             9
```