### PR TITLE
Centralized call depth control

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -481,7 +481,7 @@ inline bool invoke_function(const FuncType& func_type, uint32_t func_idx, Instan
     assert(stack.size() >= num_args);
     const auto call_args = stack.rend() - num_args;
 
-    const auto ret = execute(instance, func_idx, call_args, depth + 1);
+    const auto ret = execute(instance, func_idx, call_args, depth);
     // Bubble up traps
     if (ret.trapped)
         return false;
@@ -503,6 +503,8 @@ inline bool invoke_function(const FuncType& func_type, uint32_t func_idx, Instan
 
 ExecutionResult execute(Instance& instance, FuncIdx func_idx, const Value* args, int depth)
 {
+    depth += 1;
+
     assert(depth >= 0);
     if (depth > CallStackLimit)
         return Trap;

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -37,5 +37,5 @@ constexpr ExecutionResult Void{true};
 constexpr ExecutionResult Trap{false};
 
 // Execute a function on an instance.
-ExecutionResult execute(Instance& instance, FuncIdx func_idx, const Value* args, int depth = -1);
+ExecutionResult execute(Instance& instance, FuncIdx func_idx, const Value* args, int depth = 0);
 }  // namespace fizzy

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -37,5 +37,5 @@ constexpr ExecutionResult Void{true};
 constexpr ExecutionResult Trap{false};
 
 // Execute a function on an instance.
-ExecutionResult execute(Instance& instance, FuncIdx func_idx, const Value* args, int depth = 0);
+ExecutionResult execute(Instance& instance, FuncIdx func_idx, const Value* args, int depth = -1);
 }  // namespace fizzy

--- a/test/unittests/execute_call_test.cpp
+++ b/test/unittests/execute_call_test.cpp
@@ -639,8 +639,8 @@ TEST(execute_call, call_max_depth)
 
     auto instance = instantiate(parse(bin));
 
-    EXPECT_THAT(execute(*instance, 0, {}, MaxDepth - 1), Result(42));
-    EXPECT_THAT(execute(*instance, 1, {}, MaxDepth - 1), Traps());
+    EXPECT_THAT(execute(*instance, 0, {}, MaxDepth), Result(42));
+    EXPECT_THAT(execute(*instance, 1, {}, MaxDepth), Traps());
 }
 
 TEST(execute_call, execute_imported_max_depth)
@@ -662,10 +662,10 @@ TEST(execute_call, execute_imported_max_depth)
 
     auto instance = instantiate(std::move(module), {{host_foo, host_foo_type}});
 
-    EXPECT_THAT(execute(*instance, 0, {}, MaxDepth - 1), Result());
-    EXPECT_THAT(execute(*instance, 1, {}, MaxDepth - 1), Result());
-    EXPECT_THAT(execute(*instance, 0, {}, MaxDepth), Traps());
-    EXPECT_THAT(execute(*instance, 1, {}, MaxDepth), Traps());
+    EXPECT_THAT(execute(*instance, 0, {}, MaxDepth), Result());
+    EXPECT_THAT(execute(*instance, 1, {}, MaxDepth), Result());
+    EXPECT_THAT(execute(*instance, 0, {}, MaxDepth + 1), Traps());
+    EXPECT_THAT(execute(*instance, 1, {}, MaxDepth + 1), Traps());
 }
 
 TEST(execute_call, imported_function_from_another_module_max_depth)
@@ -702,8 +702,8 @@ TEST(execute_call, imported_function_from_another_module_max_depth)
 
     auto instance2 = instantiate(std::move(module2), {{sub, instance1->module->typesec[0]}});
 
-    EXPECT_THAT(execute(*instance2, 2, {}, MaxDepth - 2), Traps());
-    EXPECT_THAT(execute(*instance2, 3, {}, MaxDepth - 2), Result());
+    EXPECT_THAT(execute(*instance2, 2, {}, MaxDepth - 1), Traps());
+    EXPECT_THAT(execute(*instance2, 3, {}, MaxDepth - 1), Result());
 }
 
 // A regression test for incorrect number of arguments passed to a call.
@@ -739,7 +739,7 @@ TEST(execute_call, call_imported_infinite_recursion)
     const auto module = parse(wasm);
     auto host_foo = [](Instance& instance, const Value* args, int depth) -> ExecutionResult {
         EXPECT_LE(depth, MaxDepth);
-        return execute(instance, 0, args, depth);
+        return execute(instance, 0, args, depth + 1);
     };
     const auto host_foo_type = module->typesec[0];
 
@@ -762,7 +762,7 @@ TEST(execute_call, call_via_imported_infinite_recursion)
     const auto module = parse(wasm);
     auto host_foo = [](Instance& instance, const Value* args, int depth) -> ExecutionResult {
         // Function $f will increase depth. This means each iteration goes 2 steps deeper.
-        EXPECT_LE(depth, MaxDepth - 1);
+        EXPECT_LE(depth, MaxDepth);
         return execute(instance, 1, args, depth);
     };
     const auto host_foo_type = module->typesec[0];
@@ -783,7 +783,7 @@ TEST(execute_call, call_imported_max_depth_recursion)
     auto host_foo = [](Instance& instance, const Value* args, int depth) -> ExecutionResult {
         if (depth == MaxDepth)
             return Value{uint32_t{1}};  // Terminate recursion on the max depth.
-        return execute(instance, 0, args, depth);
+        return execute(instance, 0, args, depth + 1);
     };
     const auto host_foo_type = module->typesec[0];
 


### PR DESCRIPTION
The goal is the remove the duty of bumping depth by host functions. It should be bumped only in execute() or any other suitable place.

This change has a defect that host functions now have call depth limit greater by 1. 