### PR TITLE
benchmarks: allow compiling ecpairing

### DIFF
--- a/test/benchmarks/ecpairing/.gitignore
+++ b/test/benchmarks/ecpairing/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+/Cargo.lock

--- a/test/benchmarks/ecpairing/Cargo.toml
+++ b/test/benchmarks/ecpairing/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "ecpairing"
 version = "0.2.0"


### PR DESCRIPTION
This was broken by #538 introducing the workspace.