### PR TITLE
Fix invoke: drop args after the call

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -432,12 +432,13 @@ bool invoke_function(const FuncType& func_type, const F& func, Instance& instanc
     const auto num_args = func_type.inputs.size();
     assert(stack.size() >= num_args);
     span<const Value> call_args{stack.rend() - num_args, num_args};
-    stack.drop(num_args);
 
     const auto ret = func(instance, call_args, depth + 1);
     // Bubble up traps
     if (ret.trapped)
         return false;
+
+    stack.drop(num_args);
 
     const auto num_outputs = func_type.outputs.size();
     // NOTE: we can assume these two from validation

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -426,7 +426,7 @@ void branch(const Code& code, OperandStack& stack, const Instr*& pc, const uint8
 }
 
 template <class F>
-bool invoke_function(const FuncType& func_type, const F& func, Instance& instance,
+inline bool invoke_function(const FuncType& func_type, const F& func, Instance& instance,
     OperandStack& stack, int depth) noexcept
 {
     const auto num_args = func_type.inputs.size();


### PR DESCRIPTION
This fixes logical error in `invoke_function()` implementation. The call arguments are now dropped from the stack after the call returns.

Performance difference is not significant.
```
fizzy/execute/blake2b/512_bytes_rounds_1_mean                     -0.0056         -0.0056            77            77            77            77
fizzy/execute/blake2b/512_bytes_rounds_16_mean                    -0.0105         -0.0105          1173          1160          1173          1160
fizzy/execute/ecpairing/onepoint_mean                             +0.0026         +0.0026        389544        390546        389548        390550
fizzy/execute/keccak256/512_bytes_rounds_1_mean                   +0.0067         +0.0067            93            94            93            94
fizzy/execute/keccak256/512_bytes_rounds_16_mean                  +0.0066         +0.0066          1348          1357          1348          1357
fizzy/execute/memset/256_bytes_mean                               -0.0056         -0.0056             6             6             6             6
fizzy/execute/memset/60000_bytes_mean                             -0.0113         -0.0113          1393          1377          1393          1377
fizzy/execute/mul256_opt0/input1_mean                             -0.0191         -0.0191            25            25            25            25
fizzy/execute/ramanujan_pi/33_runs_mean                           -0.0490         -0.0490           122           116           122           116
fizzy/execute/sha1/512_bytes_rounds_1_mean                        -0.0117         -0.0117            84            83            84            83
fizzy/execute/sha1/512_bytes_rounds_16_mean                       -0.0125         -0.0125          1176          1161          1176          1161
fizzy/execute/sha256/512_bytes_rounds_1_mean                      +0.0075         +0.0075            85            85            85            85
fizzy/execute/sha256/512_bytes_rounds_16_mean                     +0.0082         +0.0082          1172          1182          1172          1182
fizzy/execute/taylor_pi/pi_1000000_runs_mean                      -0.0002         -0.0002         40039         40029         40039         40029
fizzy/execute/micro/eli_interpreter/exec105_mean                  +0.0091         +0.0091             4             4             4             4
fizzy/execute/micro/factorial/20_mean                             -0.0099         -0.0099             1             1             1             1
fizzy/execute/micro/fibonacci/24_mean                             -0.0052         -0.0052          4952          4926          4952          4926
fizzy/execute/micro/host_adler32/1_mean                           +0.0052         +0.0052             0             0             0             0
fizzy/execute/micro/host_adler32/1000_mean                        -0.0040         -0.0040            29            29            29            29
fizzy/execute/micro/spinner/1_mean                                +0.0133         +0.0133             0             0             0             0
fizzy/execute/micro/spinner/1000_mean                             +0.0406         +0.0406             9             9             9             9
```