### PR TITLE
refactor: Allocate module dynamically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ if(WEVERYTHING)
         -Wno-double-promotion
         -Wno-float-equal
         -Wno-padded
+        -Wno-return-std-move-in-c++11
         -Wno-switch-enum
     )
 endif()

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -43,7 +43,7 @@ ExecutionResult execute(
 inline ExecutionResult execute(
     Instance& instance, FuncIdx func_idx, std::initializer_list<Value> args) noexcept
 {
-    assert(args.size() == instance.module.get_function_type(func_idx).inputs.size());
+    assert(args.size() == instance.module->get_function_type(func_idx).inputs.size());
     return execute(instance, func_idx, args.begin());
 }
 }  // namespace fizzy

--- a/lib/fizzy/instantiate.hpp
+++ b/lib/fizzy/instantiate.hpp
@@ -54,7 +54,7 @@ using bytes_ptr = std::unique_ptr<bytes, void (*)(bytes*)>;
 // The module instance.
 struct Instance
 {
-    Module module;
+    std::unique_ptr<const Module> module;
     // Memory is either allocated and owned by the instance or imported as already allocated bytes
     // and owned externally.
     // For these cases unique_ptr would either have a normal deleter or noop deleter respectively
@@ -70,9 +70,9 @@ struct Instance
     std::vector<ExternalFunction> imported_functions;
     std::vector<ExternalGlobal> imported_globals;
 
-    Instance(Module _module, bytes_ptr _memory, Limits _memory_limits, uint32_t _memory_pages_limit,
-        table_ptr _table, Limits _table_limits, std::vector<Value> _globals,
-        std::vector<ExternalFunction> _imported_functions,
+    Instance(std::unique_ptr<const Module> _module, bytes_ptr _memory, Limits _memory_limits,
+        uint32_t _memory_pages_limit, table_ptr _table, Limits _table_limits,
+        std::vector<Value> _globals, std::vector<ExternalFunction> _imported_functions,
         std::vector<ExternalGlobal> _imported_globals)
       : module(std::move(_module)),
         memory(std::move(_memory)),
@@ -87,13 +87,12 @@ struct Instance
 };
 
 // Instantiate a module.
-std::unique_ptr<Instance> instantiate(Module module,
+std::unique_ptr<Instance> instantiate(std::unique_ptr<const Module> module,
     std::vector<ExternalFunction> imported_functions = {},
     std::vector<ExternalTable> imported_tables = {},
     std::vector<ExternalMemory> imported_memories = {},
     std::vector<ExternalGlobal> imported_globals = {},
     uint32_t memory_pages_limit = DefaultMemoryPagesLimit);
-
 
 // Function that should be used by instantiate as imports, identified by module and function name.
 struct ImportedFunction

--- a/lib/fizzy/parser.cpp
+++ b/lib/fizzy/parser.cpp
@@ -658,7 +658,7 @@ std::unique_ptr<const Module> parse(bytes_view input)
         module->codesec.emplace_back(
             parse_code(code_binaries[i], static_cast<FuncIdx>(i), *module));
 
-    return std::unique_ptr<const Module>(module.release());
+    return module;
 }
 
 parser_result<std::vector<uint32_t>> parse_vec_i32(const uint8_t* pos, const uint8_t* end)

--- a/lib/fizzy/parser.hpp
+++ b/lib/fizzy/parser.hpp
@@ -7,6 +7,7 @@
 #include "exceptions.hpp"
 #include "leb128.hpp"
 #include "module.hpp"
+#include <memory>
 
 namespace fizzy
 {
@@ -16,7 +17,7 @@ constexpr bytes_view wasm_prefix{wasm_prefix_data, sizeof(wasm_prefix_data)};
 template <typename T>
 using parser_result = std::pair<T, const uint8_t*>;
 
-Module parse(bytes_view input);
+std::unique_ptr<const Module> parse(bytes_view input);
 
 inline parser_result<uint8_t> parse_byte(const uint8_t* pos, const uint8_t* end)
 {

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -8,6 +8,7 @@
 #include <lib/fizzy/limits.hpp>
 #include <test/utils/asserts.hpp>
 #include <test/utils/hex.hpp>
+#include <test/utils/instantiate_helpers.hpp>
 
 using namespace fizzy;
 using namespace fizzy::test;
@@ -89,14 +90,14 @@ TEST(api, resolve_imported_functions)
     };
 
     const auto external_functions =
-        resolve_imported_functions(module, std::move(imported_functions));
+        resolve_imported_functions(*module, std::move(imported_functions));
 
     EXPECT_EQ(external_functions.size(), 4);
 
     Value global = 0;
     const std::vector<ExternalGlobal> external_globals{{&global, {ValType::i32, false}}};
     auto instance = instantiate(
-        module, external_functions, {}, {}, std::vector<ExternalGlobal>(external_globals));
+        *module, external_functions, {}, {}, std::vector<ExternalGlobal>(external_globals));
 
     EXPECT_THAT(execute(*instance, 0, {}), Result(0));
     EXPECT_THAT(execute(*instance, 1, {Value{0}}), Result(1));
@@ -112,10 +113,10 @@ TEST(api, resolve_imported_functions)
     };
 
     const auto external_functions_reordered =
-        resolve_imported_functions(module, std::move(imported_functions_reordered));
+        resolve_imported_functions(*module, std::move(imported_functions_reordered));
     EXPECT_EQ(external_functions_reordered.size(), 4);
 
-    auto instance_reordered = instantiate(module, external_functions_reordered, {}, {},
+    auto instance_reordered = instantiate(*module, external_functions_reordered, {}, {},
         std::vector<ExternalGlobal>(external_globals));
 
     EXPECT_THAT(execute(*instance_reordered, 0, {}), Result(0));
@@ -134,11 +135,11 @@ TEST(api, resolve_imported_functions)
     };
 
     const auto external_functions_extra =
-        resolve_imported_functions(module, std::move(imported_functions_extra));
+        resolve_imported_functions(*module, std::move(imported_functions_extra));
     EXPECT_EQ(external_functions_extra.size(), 4);
 
     auto instance_extra = instantiate(
-        module, external_functions_extra, {}, {}, std::vector<ExternalGlobal>(external_globals));
+        *module, external_functions_extra, {}, {}, std::vector<ExternalGlobal>(external_globals));
 
     EXPECT_THAT(execute(*instance_extra, 0, {}), Result(0));
     EXPECT_THAT(execute(*instance_extra, 1, {Value{0}}), Result(1));
@@ -152,7 +153,7 @@ TEST(api, resolve_imported_functions)
         {"mod2", "foo1", {ValType::i32}, ValType::i32, function_returning_value(2)},
     };
 
-    EXPECT_THROW_MESSAGE(resolve_imported_functions(module, std::move(imported_functions_missing)),
+    EXPECT_THROW_MESSAGE(resolve_imported_functions(*module, std::move(imported_functions_missing)),
         instantiate_error, "imported function mod2.foo2 is required");
 
 
@@ -164,7 +165,7 @@ TEST(api, resolve_imported_functions)
     };
 
     EXPECT_THROW_MESSAGE(
-        resolve_imported_functions(module, std::move(imported_functions_invalid_type1)),
+        resolve_imported_functions(*module, std::move(imported_functions_invalid_type1)),
         instantiate_error,
         "function mod1.foo1 input types don't match imported function in module");
 
@@ -176,7 +177,7 @@ TEST(api, resolve_imported_functions)
     };
 
     EXPECT_THROW_MESSAGE(
-        resolve_imported_functions(module, std::move(imported_functions_invalid_type2)),
+        resolve_imported_functions(*module, std::move(imported_functions_invalid_type2)),
         instantiate_error, "function mod2.foo2 has output but is defined void in module");
 
     std::vector<ImportedFunction> imported_functions_invalid_type3 = {
@@ -187,7 +188,7 @@ TEST(api, resolve_imported_functions)
     };
 
     EXPECT_THROW_MESSAGE(
-        resolve_imported_functions(module, std::move(imported_functions_invalid_type3)),
+        resolve_imported_functions(*module, std::move(imported_functions_invalid_type3)),
         instantiate_error,
         "function mod1.foo2 output type doesn't match imported function in module");
 }

--- a/test/unittests/end_to_end_test.cpp
+++ b/test/unittests/end_to_end_test.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 #include <test/utils/asserts.hpp>
 #include <test/utils/hex.hpp>
+#include <test/utils/instantiate_helpers.hpp>
 
 using namespace fizzy;
 using namespace fizzy::test;
@@ -30,8 +31,7 @@ TEST(end_to_end, milestone1)
     */
     const auto wasm = from_hex(
         "0061736d0100000001070160027f7f017f030201000a13011101017f200020016a20026a220220006a0b");
-    const auto module = parse(wasm);
-    auto instance = instantiate(module);
+    auto instance = instantiate(parse(wasm));
 
     EXPECT_THAT(execute(*instance, 0, {20, 22}), Result(20 + 22 + 20));
 }
@@ -69,9 +69,7 @@ TEST(end_to_end, milestone2)
         "2053742154204f20546a21552055204e3602002005280228215641012157"
         "205620576a2158200520583602280c00000b000b0b");
 
-    const auto module = parse(bin);
-
-    auto instance = instantiate(module);
+    auto instance = instantiate(parse(bin));
 
     auto& memory = *instance->memory;
     // This performs uint256 x uint256 -> uint512 multiplication.
@@ -126,10 +124,10 @@ TEST(end_to_end, nested_loops_in_c)
 
     const auto module = parse(bin);
 
-    const auto func_idx = find_exported_function(module, "test");
+    const auto func_idx = find_exported_function(*module, "test");
     ASSERT_TRUE(func_idx);
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(*module);
     EXPECT_THAT(execute(*instance, *func_idx, {10, 2, 5}), Result(4));
 }
 
@@ -168,10 +166,10 @@ TEST(end_to_end, memset)
 
     const auto module = parse(wasm);
 
-    const auto func_idx = find_exported_function(module, "test");
+    const auto func_idx = find_exported_function(*module, "test");
     ASSERT_TRUE(func_idx);
 
-    auto instance = instantiate(module);
+    auto instance = instantiate(*module);
     EXPECT_THAT(execute(*instance, *func_idx, {0, 2}), Result());
     EXPECT_EQ(hex(instance->memory->substr(0, 2 * sizeof(int))), "d2040000d2040000");
 }

--- a/test/unittests/execute_control_test.cpp
+++ b/test/unittests/execute_control_test.cpp
@@ -668,7 +668,7 @@ TEST(execute_control, br_1_out_of_function_and_imported_function)
                                                 int) noexcept -> ExecutionResult { return Void; };
 
     const auto module = parse(bin);
-    auto instance = instantiate(module, {{fake_imported_function, module.typesec[0]}});
+    auto instance = instantiate(*module, {{fake_imported_function, module->typesec[0]}});
     EXPECT_THAT(execute(*instance, 1, {}), Result(1));
 }
 

--- a/test/unittests/execute_floating_point_test.cpp
+++ b/test/unittests/execute_floating_point_test.cpp
@@ -10,6 +10,7 @@
 #include <test/utils/asserts.hpp>
 #include <test/utils/floating_point_utils.hpp>
 #include <test/utils/hex.hpp>
+#include <test/utils/instantiate_helpers.hpp>
 #include <array>
 #include <cfenv>
 #include <cmath>
@@ -2016,7 +2017,7 @@ TEST(execute_floating_point, f32_store)
 
     for (const auto& [arg, expected] : test_cases)
     {
-        auto instance = instantiate(module);
+        auto instance = instantiate(*module);
 
         EXPECT_THAT(execute(*instance, 0, {arg, 1}), Result());
         EXPECT_EQ(instance->memory->substr(0, 6), expected);
@@ -2093,7 +2094,7 @@ TEST(execute_floating_point, f64_store)
 
     for (const auto& [arg, expected] : test_cases)
     {
-        auto instance = instantiate(module);
+        auto instance = instantiate(*module);
 
         EXPECT_THAT(execute(*instance, 0, {arg, 1}), Result());
         EXPECT_EQ(instance->memory->substr(0, 10), expected);

--- a/test/unittests/execute_numeric_test.cpp
+++ b/test/unittests/execute_numeric_test.cpp
@@ -16,25 +16,25 @@ namespace
 {
 ExecutionResult execute_unary_operation(Instr instr, uint64_t arg)
 {
-    Module module;
+    auto module{std::make_unique<Module>()};
     // type is currently needed only to get arity of function, so exact value types don't matter
-    module.typesec.emplace_back(FuncType{{ValType::i32}, {ValType::i32}});
-    module.funcsec.emplace_back(TypeIdx{0});
-    module.codesec.emplace_back(Code{1, 0, {Instr::local_get, instr, Instr::end}, {0, 0, 0, 0}});
+    module->typesec.emplace_back(FuncType{{ValType::i32}, {ValType::i32}});
+    module->funcsec.emplace_back(TypeIdx{0});
+    module->codesec.emplace_back(Code{1, 0, {Instr::local_get, instr, Instr::end}, {0, 0, 0, 0}});
 
-    return execute(module, 0, {arg});
+    return execute(*instantiate(std::move(module)), 0, {arg});
 }
 
 ExecutionResult execute_binary_operation(Instr instr, uint64_t lhs, uint64_t rhs)
 {
-    Module module;
+    auto module{std::make_unique<Module>()};
     // type is currently needed only to get arity of function, so exact value types don't matter
-    module.typesec.emplace_back(FuncType{{ValType::i32, ValType::i32}, {ValType::i32}});
-    module.funcsec.emplace_back(TypeIdx{0});
-    module.codesec.emplace_back(Code{
+    module->typesec.emplace_back(FuncType{{ValType::i32, ValType::i32}, {ValType::i32}});
+    module->funcsec.emplace_back(TypeIdx{0});
+    module->codesec.emplace_back(Code{
         2, 0, {Instr::local_get, Instr::local_get, instr, Instr::end}, {0, 0, 0, 0, 1, 0, 0, 0}});
 
-    return execute(module, 0, {lhs, rhs});
+    return execute(*instantiate(std::move(module)), 0, {lhs, rhs});
 }
 }  // namespace
 

--- a/test/unittests/module_test.cpp
+++ b/test/unittests/module_test.cpp
@@ -23,19 +23,19 @@ TEST(module, functions)
         "110302000b0401017f0b070043000000000b");
     const auto module = parse(bin);
 
-    ASSERT_EQ(module.get_function_count(), 4);
+    ASSERT_EQ(module->get_function_count(), 4);
     EXPECT_EQ(
-        module.get_function_type(0), (FuncType{{ValType::i32, ValType::i32}, {ValType::i32}}));
-    EXPECT_EQ(module.get_function_type(1), (FuncType{}));
-    EXPECT_EQ(module.get_function_type(2), (FuncType{{ValType::i64}, {}}));
-    EXPECT_EQ(module.get_function_type(3), (FuncType{{}, {ValType::f32}}));
+        module->get_function_type(0), (FuncType{{ValType::i32, ValType::i32}, {ValType::i32}}));
+    EXPECT_EQ(module->get_function_type(1), (FuncType{}));
+    EXPECT_EQ(module->get_function_type(2), (FuncType{{ValType::i64}, {}}));
+    EXPECT_EQ(module->get_function_type(3), (FuncType{{}, {ValType::f32}}));
 
-    EXPECT_EQ(module.get_code(1).instructions.size(), 1);
-    EXPECT_EQ(module.get_code(1).local_count, 0);
-    EXPECT_EQ(module.get_code(2).instructions.size(), 1);
-    EXPECT_EQ(module.get_code(2).local_count, 1);
-    EXPECT_EQ(module.get_code(3).instructions.size(), 2);
-    EXPECT_EQ(module.get_code(3).local_count, 0);
+    EXPECT_EQ(module->get_code(1).instructions.size(), 1);
+    EXPECT_EQ(module->get_code(1).local_count, 0);
+    EXPECT_EQ(module->get_code(2).instructions.size(), 1);
+    EXPECT_EQ(module->get_code(2).local_count, 1);
+    EXPECT_EQ(module->get_code(3).instructions.size(), 2);
+    EXPECT_EQ(module->get_code(3).local_count, 0);
 }
 
 TEST(module, globals)
@@ -51,15 +51,15 @@ TEST(module, globals)
         "0000f03f0b");
     const auto module = parse(bin);
 
-    ASSERT_EQ(module.get_global_count(), 4);
-    EXPECT_EQ(module.get_global_type(0).value_type, ValType::i32);
-    EXPECT_TRUE(module.get_global_type(0).is_mutable);
-    EXPECT_EQ(module.get_global_type(1).value_type, ValType::i64);
-    EXPECT_FALSE(module.get_global_type(1).is_mutable);
-    EXPECT_EQ(module.get_global_type(2).value_type, ValType::f32);
-    EXPECT_FALSE(module.get_global_type(2).is_mutable);
-    EXPECT_EQ(module.get_global_type(3).value_type, ValType::f64);
-    EXPECT_TRUE(module.get_global_type(3).is_mutable);
+    ASSERT_EQ(module->get_global_count(), 4);
+    EXPECT_EQ(module->get_global_type(0).value_type, ValType::i32);
+    EXPECT_TRUE(module->get_global_type(0).is_mutable);
+    EXPECT_EQ(module->get_global_type(1).value_type, ValType::i64);
+    EXPECT_FALSE(module->get_global_type(1).is_mutable);
+    EXPECT_EQ(module->get_global_type(2).value_type, ValType::f32);
+    EXPECT_FALSE(module->get_global_type(2).is_mutable);
+    EXPECT_EQ(module->get_global_type(3).value_type, ValType::f64);
+    EXPECT_TRUE(module->get_global_type(3).is_mutable);
 }
 
 TEST(module, table)
@@ -70,7 +70,7 @@ TEST(module, table)
     const auto bin1 = from_hex("0061736d01000000040401700001");
     const auto module1 = parse(bin1);
 
-    EXPECT_TRUE(module1.has_table());
+    EXPECT_TRUE(module1->has_table());
 
     /* wat2wasm
       (table (import "m" "t") 1 funcref)
@@ -78,7 +78,7 @@ TEST(module, table)
     const auto bin2 = from_hex("0061736d01000000020901016d017401700001");
     const auto module2 = parse(bin2);
 
-    EXPECT_TRUE(module2.has_table());
+    EXPECT_TRUE(module2->has_table());
 
     /* wat2wasm
       (module)
@@ -86,7 +86,7 @@ TEST(module, table)
     const auto bin3 = from_hex("0061736d01000000");
     const auto module3 = parse(bin3);
 
-    EXPECT_FALSE(module3.has_table());
+    EXPECT_FALSE(module3->has_table());
 }
 
 TEST(module, memory)
@@ -97,7 +97,7 @@ TEST(module, memory)
     const auto bin1 = from_hex("0061736d010000000503010001");
     const auto module1 = parse(bin1);
 
-    EXPECT_TRUE(module1.has_memory());
+    EXPECT_TRUE(module1->has_memory());
 
     /* wat2wasm
       (memory (import "m" "m") 1)
@@ -105,7 +105,7 @@ TEST(module, memory)
     const auto bin2 = from_hex("0061736d01000000020801016d016d020001");
     const auto module2 = parse(bin2);
 
-    EXPECT_TRUE(module2.has_memory());
+    EXPECT_TRUE(module2->has_memory());
 
     /* wat2wasm
       (module)
@@ -113,5 +113,5 @@ TEST(module, memory)
     const auto bin3 = from_hex("0061736d01000000");
     const auto module3 = parse(bin3);
 
-    EXPECT_FALSE(module3.has_memory());
+    EXPECT_FALSE(module3->has_memory());
 }

--- a/test/unittests/parser_expr_test.cpp
+++ b/test/unittests/parser_expr_test.cpp
@@ -99,9 +99,9 @@ TEST(parser_expr, loop_br)
     const auto wasm = from_hex("0061736d01000000010401600000030201000a0901070003400c000b0b");
     const auto module = parse(wasm);
 
-    EXPECT_EQ(module.codesec[0].instructions,
+    EXPECT_EQ(module->codesec[0].instructions,
         (std::vector{Instr::loop, Instr::br, Instr::end, Instr::end}));
-    EXPECT_EQ(module.codesec[0].immediates,
+    EXPECT_EQ(module->codesec[0].immediates,
         "00000000"          // code_offset
         "00000000"          // imm_offset
         "00000000"          // stack_drop
@@ -118,10 +118,10 @@ TEST(parser_expr, loop_br)
         from_hex("0061736d01000000010401600000030201000a0c010a00410003400c000b1a0b");
     const auto module_parent_stack = parse(wasm_parent_stack);
 
-    EXPECT_EQ(module_parent_stack.codesec[0].instructions,
+    EXPECT_EQ(module_parent_stack->codesec[0].instructions,
         (std::vector{
             Instr::i32_const, Instr::loop, Instr::br, Instr::end, Instr::drop, Instr::end}));
-    EXPECT_EQ(module_parent_stack.codesec[0].immediates,
+    EXPECT_EQ(module_parent_stack->codesec[0].immediates,
         "00000000"          // i32.const
         "00000000"          // arity
         "01000000"          // code_offset
@@ -141,10 +141,10 @@ TEST(parser_expr, loop_br)
         from_hex("0061736d01000000010401600000030201000a0c010a00037f41000c000b1a0b");
     const auto module_arity = parse(wasm_arity);
 
-    EXPECT_EQ(
-        module_arity.codesec[0].instructions, (std::vector{Instr::loop, Instr::i32_const, Instr::br,
-                                                  Instr::end, Instr::drop, Instr::end}));
-    EXPECT_EQ(module_arity.codesec[0].immediates,
+    EXPECT_EQ(module_arity->codesec[0].instructions,
+        (std::vector{
+            Instr::loop, Instr::i32_const, Instr::br, Instr::end, Instr::drop, Instr::end}));
+    EXPECT_EQ(module_arity->codesec[0].immediates,
         "00000000"          // i32.const
         "00000000"          // arity - always 0 for loop
         "00000000"          // code_offset
@@ -160,9 +160,9 @@ TEST(parser_expr, loop_return)
     const auto wasm = from_hex("0061736d01000000010401600000030201000a0801060003400f0b0b");
     const auto module = parse(wasm);
 
-    EXPECT_EQ(module.codesec[0].instructions,
+    EXPECT_EQ(module->codesec[0].instructions,
         (std::vector{Instr::loop, Instr::return_, Instr::end, Instr::end}));
-    EXPECT_EQ(module.codesec[0].immediates,
+    EXPECT_EQ(module->codesec[0].immediates,
         "00000000"          // arity
         "03000000"          // code_offset
         "10000000"          // imm_offset
@@ -212,10 +212,10 @@ TEST(parser_expr, block_br)
         from_hex("0061736d01000000010401600000030201000a0c010a00410002400c000b1a0b");
     const auto module_parent_stack = parse(wasm_parent_stack);
 
-    EXPECT_EQ(module_parent_stack.codesec[0].instructions,
+    EXPECT_EQ(module_parent_stack->codesec[0].instructions,
         (std::vector{
             Instr::i32_const, Instr::block, Instr::br, Instr::end, Instr::drop, Instr::end}));
-    EXPECT_EQ(module_parent_stack.codesec[0].immediates,
+    EXPECT_EQ(module_parent_stack->codesec[0].immediates,
         "00000000"          // i32.const
         "00000000"          // arity
         "04000000"          // code_offset
@@ -235,10 +235,10 @@ TEST(parser_expr, block_br)
         from_hex("0061736d01000000010401600000030201000a0c010a00027f41000c000b1a0b");
     const auto module_arity = parse(wasm_arity);
 
-    EXPECT_EQ(
-        module_arity.codesec[0].instructions, (std::vector{Instr::block, Instr::i32_const,
-                                                  Instr::br, Instr::end, Instr::drop, Instr::end}));
-    EXPECT_EQ(module_arity.codesec[0].immediates,
+    EXPECT_EQ(module_arity->codesec[0].instructions,
+        (std::vector{
+            Instr::block, Instr::i32_const, Instr::br, Instr::end, Instr::drop, Instr::end}));
+    EXPECT_EQ(module_arity->codesec[0].immediates,
         "00000000"          // i32.const
         "01000000"          // arity
         "04000000"          // code_offset
@@ -254,9 +254,9 @@ TEST(parser_expr, block_return)
     const auto wasm = from_hex("0061736d01000000010401600000030201000a0801060002400f0b0b");
     const auto module = parse(wasm);
 
-    EXPECT_EQ(module.codesec[0].instructions,
+    EXPECT_EQ(module->codesec[0].instructions,
         (std::vector{Instr::block, Instr::return_, Instr::end, Instr::end}));
-    EXPECT_EQ(module.codesec[0].immediates,
+    EXPECT_EQ(module->codesec[0].immediates,
         "00000000"          // arity
         "03000000"          // code_offset
         "10000000"          // imm_offset
@@ -274,9 +274,9 @@ TEST(parser_expr, if_br)
     const auto wasm = from_hex("0061736d01000000010401600000030201000a0b010900410004400c000b0b");
     const auto module = parse(wasm);
 
-    EXPECT_EQ(module.codesec[0].instructions,
+    EXPECT_EQ(module->codesec[0].instructions,
         (std::vector{Instr::i32_const, Instr::if_, Instr::br, Instr::end, Instr::end}));
-    EXPECT_EQ(module.codesec[0].immediates,
+    EXPECT_EQ(module->codesec[0].immediates,
         "00000000"          // i32.const
         "04000000"          // else code offset
         "1c000000"          // else imm offset
@@ -297,10 +297,10 @@ TEST(parser_expr, if_br)
         from_hex("0061736d01000000010401600000030201000a0e010c004100410004400c000b1a0b");
     const auto module_parent_stack = parse(wasm_parent_stack);
 
-    EXPECT_EQ(module_parent_stack.codesec[0].instructions,
+    EXPECT_EQ(module_parent_stack->codesec[0].instructions,
         (std::vector{Instr::i32_const, Instr::i32_const, Instr::if_, Instr::br, Instr::end,
             Instr::drop, Instr::end}));
-    EXPECT_EQ(module_parent_stack.codesec[0].immediates,
+    EXPECT_EQ(module_parent_stack->codesec[0].immediates,
         "00000000"          // i32.const
         "00000000"          // i32.const
         "05000000"          // else code offset
@@ -339,8 +339,8 @@ TEST(parser_expr, instr_br_table)
         "e3000f0b41e4000f0b41e5000f0b41e6000f0b41e7000f0b41e8000b");
 
     const auto module = parse(wasm);
-    ASSERT_EQ(module.codesec.size(), 1);
-    const auto& code = module.codesec[0];
+    ASSERT_EQ(module->codesec.size(), 1);
+    const auto& code = module->codesec[0];
 
     EXPECT_EQ(code.instructions,
         (std::vector{Instr::block, Instr::block, Instr::block, Instr::block, Instr::block,
@@ -401,8 +401,8 @@ TEST(parser_expr, instr_br_table_empty_vector)
         "0061736d0100000001060160017f017f030201000a13011100024020000e000041e3000f0b41e4000b");
 
     const auto module = parse(wasm);
-    ASSERT_EQ(module.codesec.size(), 1);
-    const auto& code = module.codesec[0];
+    ASSERT_EQ(module->codesec.size(), 1);
+    const auto& code = module->codesec[0];
 
     EXPECT_EQ(code.instructions,
         (std::vector{Instr::block, Instr::local_get, Instr::br_table, Instr::i32_const,
@@ -575,9 +575,9 @@ TEST(parser_expr, call_0args_1result)
         from_hex("0061736d010000000105016000017f03030200000a0b02040041000b040010000b");
 
     const auto module = parse(wasm);
-    ASSERT_EQ(module.codesec.size(), 2);
-    EXPECT_EQ(module.codesec[0].max_stack_height, 1);
-    EXPECT_EQ(module.codesec[1].max_stack_height, 1);
+    ASSERT_EQ(module->codesec.size(), 2);
+    EXPECT_EQ(module->codesec[0].max_stack_height, 1);
+    EXPECT_EQ(module->codesec[1].max_stack_height, 1);
 }
 
 TEST(parser_expr, call_1arg_1result)
@@ -590,9 +590,9 @@ TEST(parser_expr, call_1arg_1result)
         "0061736d01000000010a0260017f017f6000017f03030200010a0d02040020000b0600410010000b");
 
     const auto module = parse(wasm);
-    ASSERT_EQ(module.codesec.size(), 2);
-    EXPECT_EQ(module.codesec[0].max_stack_height, 1);
-    EXPECT_EQ(module.codesec[1].max_stack_height, 1);
+    ASSERT_EQ(module->codesec.size(), 2);
+    EXPECT_EQ(module->codesec[0].max_stack_height, 1);
+    EXPECT_EQ(module->codesec[1].max_stack_height, 1);
 }
 TEST(parser_expr, call_nonexisting_typeidx)
 {

--- a/test/unittests/parser_test.cpp
+++ b/test/unittests/parser_test.cpp
@@ -37,13 +37,13 @@ TEST(parser, valtype)
     auto& valtype_bin = wasm_bin.back();
 
     valtype_bin = 0x7e;
-    EXPECT_EQ(parse(wasm_bin).typesec.front().outputs.front(), ValType::i64);
+    EXPECT_EQ(parse(wasm_bin)->typesec.front().outputs.front(), ValType::i64);
     valtype_bin = 0x7f;
-    EXPECT_EQ(parse(wasm_bin).typesec.front().outputs.front(), ValType::i32);
+    EXPECT_EQ(parse(wasm_bin)->typesec.front().outputs.front(), ValType::i32);
     valtype_bin = 0x7c;
-    EXPECT_EQ(parse(wasm_bin).typesec.front().outputs.front(), ValType::f64);
+    EXPECT_EQ(parse(wasm_bin)->typesec.front().outputs.front(), ValType::f64);
     valtype_bin = 0x7d;
-    EXPECT_EQ(parse(wasm_bin).typesec.front().outputs.front(), ValType::f32);
+    EXPECT_EQ(parse(wasm_bin)->typesec.front().outputs.front(), ValType::f32);
     valtype_bin = 0x7a;
     EXPECT_THROW_MESSAGE(parse(wasm_bin), parser_error, "invalid valtype 122");
 }
@@ -60,7 +60,7 @@ TEST(parser, limits_min)
 {
     const auto wasm = bytes{wasm_prefix} + make_section(5, make_vec({"007f"_bytes}));
     const auto module = parse(wasm);
-    const auto& limits = module.memorysec[0].limits;
+    const auto& limits = module->memorysec[0].limits;
     EXPECT_EQ(limits.min, 0x7f);
     EXPECT_FALSE(limits.max.has_value());
 }
@@ -69,7 +69,7 @@ TEST(parser, limits_minmax)
 {
     const auto wasm = bytes{wasm_prefix} + make_section(5, make_vec({"01207f"_bytes}));
     const auto module = parse(wasm);
-    const auto& limits = module.memorysec[0].limits;
+    const auto& limits = module->memorysec[0].limits;
     EXPECT_EQ(limits.min, 0x20);
     EXPECT_TRUE(limits.max.has_value());
     EXPECT_EQ(*limits.max, 0x7f);
@@ -96,9 +96,9 @@ TEST(parser, limits_invalid)
 TEST(parser, module_empty)
 {
     const auto module = parse(wasm_prefix);
-    EXPECT_EQ(module.typesec.size(), 0);
-    EXPECT_EQ(module.funcsec.size(), 0);
-    EXPECT_EQ(module.codesec.size(), 0);
+    EXPECT_EQ(module->typesec.size(), 0);
+    EXPECT_EQ(module->funcsec.size(), 0);
+    EXPECT_EQ(module->codesec.size(), 0);
 }
 
 TEST(parser, module_with_wrong_prefix)
@@ -126,9 +126,9 @@ TEST(parser, custom_section_empty)
     // Section consists of an empty name
     const auto bin = bytes{wasm_prefix} + make_section(0, "00"_bytes);
     const auto module = parse(bin);
-    EXPECT_EQ(module.typesec.size(), 0);
-    EXPECT_EQ(module.funcsec.size(), 0);
-    EXPECT_EQ(module.codesec.size(), 0);
+    EXPECT_EQ(module->typesec.size(), 0);
+    EXPECT_EQ(module->funcsec.size(), 0);
+    EXPECT_EQ(module->codesec.size(), 0);
 }
 
 TEST(parser, custom_section_nonempty_name_only)
@@ -136,9 +136,9 @@ TEST(parser, custom_section_nonempty_name_only)
     // Section consists of only the name "abc"
     const auto bin = bytes{wasm_prefix} + make_section(0, "03616263"_bytes);
     const auto module = parse(bin);
-    EXPECT_EQ(module.typesec.size(), 0);
-    EXPECT_EQ(module.funcsec.size(), 0);
-    EXPECT_EQ(module.codesec.size(), 0);
+    EXPECT_EQ(module->typesec.size(), 0);
+    EXPECT_EQ(module->funcsec.size(), 0);
+    EXPECT_EQ(module->codesec.size(), 0);
 }
 
 TEST(parser, custom_section_name_not_ascii)
@@ -146,9 +146,9 @@ TEST(parser, custom_section_name_not_ascii)
     // Section consists of only the name with some non-ascii characters.
     const auto bin = bytes{wasm_prefix} + make_section(0, "0670617765c582"_bytes);
     const auto module = parse(bin);
-    EXPECT_EQ(module.typesec.size(), 0);
-    EXPECT_EQ(module.funcsec.size(), 0);
-    EXPECT_EQ(module.codesec.size(), 0);
+    EXPECT_EQ(module->typesec.size(), 0);
+    EXPECT_EQ(module->funcsec.size(), 0);
+    EXPECT_EQ(module->codesec.size(), 0);
 }
 
 TEST(parser, custom_section_nonempty)
@@ -157,9 +157,9 @@ TEST(parser, custom_section_nonempty)
     const auto bin =
         bytes{wasm_prefix} + make_section(0, "036162630000112233445566778899000099"_bytes);
     const auto module = parse(bin);
-    EXPECT_EQ(module.typesec.size(), 0);
-    EXPECT_EQ(module.funcsec.size(), 0);
-    EXPECT_EQ(module.codesec.size(), 0);
+    EXPECT_EQ(module->typesec.size(), 0);
+    EXPECT_EQ(module->funcsec.size(), 0);
+    EXPECT_EQ(module->codesec.size(), 0);
 }
 
 TEST(parser, custom_section_size_out_of_bounds)
@@ -197,7 +197,7 @@ TEST(parser, type_section_empty)
 {
     const auto bin = bytes{wasm_prefix} + make_section(1, make_vec({}));
     const auto module = parse(bin);
-    EXPECT_EQ(module.typesec.size(), 0);
+    EXPECT_EQ(module->typesec.size(), 0);
 }
 
 TEST(parser, type_section_wrong_prefix)
@@ -235,12 +235,12 @@ TEST(parser, type_section_with_single_functype)
     const auto section_contents = make_vec({make_functype({}, {})});
     const auto bin = bytes{wasm_prefix} + make_section(1, section_contents);
     const auto module = parse(bin);
-    ASSERT_EQ(module.typesec.size(), 1);
-    const auto functype = module.typesec[0];
+    ASSERT_EQ(module->typesec.size(), 1);
+    const auto functype = module->typesec[0];
     EXPECT_EQ(functype.inputs.size(), 0);
     EXPECT_EQ(functype.outputs.size(), 0);
-    EXPECT_EQ(module.funcsec.size(), 0);
-    EXPECT_EQ(module.codesec.size(), 0);
+    EXPECT_EQ(module->funcsec.size(), 0);
+    EXPECT_EQ(module->codesec.size(), 0);
 }
 
 TEST(parser, type_section_with_single_functype_params)
@@ -249,16 +249,16 @@ TEST(parser, type_section_with_single_functype_params)
     const auto section_contents = make_vec({make_functype({i32, i64, i32}, {i32})});
     const auto bin = bytes{wasm_prefix} + make_section(1, section_contents);
     const auto module = parse(bin);
-    ASSERT_EQ(module.typesec.size(), 1);
-    const auto functype = module.typesec[0];
+    ASSERT_EQ(module->typesec.size(), 1);
+    const auto functype = module->typesec[0];
     ASSERT_EQ(functype.inputs.size(), 3);
     EXPECT_EQ(functype.inputs[0], ValType::i32);
     EXPECT_EQ(functype.inputs[1], ValType::i64);
     EXPECT_EQ(functype.inputs[2], ValType::i32);
     ASSERT_EQ(functype.outputs.size(), 1);
     EXPECT_EQ(functype.outputs[0], ValType::i32);
-    EXPECT_EQ(module.funcsec.size(), 0);
-    EXPECT_EQ(module.codesec.size(), 0);
+    EXPECT_EQ(module->funcsec.size(), 0);
+    EXPECT_EQ(module->codesec.size(), 0);
 }
 
 TEST(parser, type_section_with_multiple_functypes)
@@ -271,22 +271,22 @@ TEST(parser, type_section_with_multiple_functypes)
     const auto bin = bytes{wasm_prefix} + make_section(1, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.typesec.size(), 3);
-    const auto functype0 = module.typesec[0];
+    ASSERT_EQ(module->typesec.size(), 3);
+    const auto functype0 = module->typesec[0];
     EXPECT_EQ(functype0.inputs.size(), 0);
     EXPECT_EQ(functype0.outputs.size(), 0);
-    const auto functype1 = module.typesec[1];
+    const auto functype1 = module->typesec[1];
     EXPECT_EQ(functype1.inputs.size(), 2);
     EXPECT_EQ(functype1.inputs[0], ValType::i32);
     EXPECT_EQ(functype1.inputs[1], ValType::i64);
     EXPECT_EQ(functype1.outputs.size(), 1);
     EXPECT_EQ(functype1.outputs[0], ValType::i32);
-    const auto functype2 = module.typesec[2];
+    const auto functype2 = module->typesec[2];
     EXPECT_EQ(functype2.inputs.size(), 1);
     EXPECT_EQ(functype2.inputs[0], ValType::i32);
     EXPECT_EQ(functype2.outputs.size(), 0);
-    EXPECT_EQ(module.funcsec.size(), 0);
-    EXPECT_EQ(module.codesec.size(), 0);
+    EXPECT_EQ(module->funcsec.size(), 0);
+    EXPECT_EQ(module->codesec.size(), 0);
 }
 
 TEST(parser, type_section_functype_out_of_bounds)
@@ -299,7 +299,7 @@ TEST(parser, import_section_empty)
 {
     const auto bin = bytes{wasm_prefix} + make_section(2, make_vec({}));
     const auto module = parse(bin);
-    EXPECT_EQ(module.importsec.size(), 0);
+    EXPECT_EQ(module->importsec.size(), 0);
 }
 
 TEST(parser, import_single_function)
@@ -310,11 +310,11 @@ TEST(parser, import_single_function)
         bytes{wasm_prefix} + make_section(1, type_section) + make_section(2, import_section);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.importsec.size(), 1);
-    EXPECT_EQ(module.importsec[0].module, "mod");
-    EXPECT_EQ(module.importsec[0].name, "foo");
-    EXPECT_EQ(module.importsec[0].kind, ExternalKind::Function);
-    EXPECT_EQ(module.importsec[0].desc.function_type_index, 1);
+    ASSERT_EQ(module->importsec.size(), 1);
+    EXPECT_EQ(module->importsec[0].module, "mod");
+    EXPECT_EQ(module->importsec[0].name, "foo");
+    EXPECT_EQ(module->importsec[0].kind, ExternalKind::Function);
+    EXPECT_EQ(module->importsec[0].desc.function_type_index, 1);
 }
 
 TEST(parser, import_multiple)
@@ -328,27 +328,27 @@ TEST(parser, import_multiple)
         bytes{wasm_prefix} + make_section(1, type_section) + make_section(2, import_section);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.importsec.size(), 4);
-    EXPECT_EQ(module.importsec[0].module, "m1");
-    EXPECT_EQ(module.importsec[0].name, "abc");
-    EXPECT_EQ(module.importsec[0].kind, ExternalKind::Function);
-    EXPECT_EQ(module.importsec[0].desc.function_type_index, 0x01);
-    EXPECT_EQ(module.importsec[1].module, "m2");
-    EXPECT_EQ(module.importsec[1].name, "foo");
-    EXPECT_EQ(module.importsec[1].kind, ExternalKind::Memory);
-    EXPECT_EQ(module.importsec[1].desc.memory.limits.min, 0x7f);
-    EXPECT_FALSE(module.importsec[1].desc.memory.limits.max);
-    EXPECT_EQ(module.importsec[2].module, "m3");
-    EXPECT_EQ(module.importsec[2].name, "bar");
-    EXPECT_EQ(module.importsec[2].kind, ExternalKind::Global);
-    EXPECT_FALSE(module.importsec[2].desc.global.is_mutable);
-    EXPECT_EQ(module.importsec[2].desc.global.value_type, ValType::i32);
-    EXPECT_EQ(module.importsec[3].module, "m4");
-    EXPECT_EQ(module.importsec[3].name, "tab");
-    EXPECT_EQ(module.importsec[3].kind, ExternalKind::Table);
-    EXPECT_EQ(module.importsec[3].desc.table.limits.min, 1);
-    ASSERT_TRUE(module.importsec[3].desc.table.limits.max.has_value());
-    EXPECT_EQ(*module.importsec[3].desc.table.limits.max, 0x42);
+    ASSERT_EQ(module->importsec.size(), 4);
+    EXPECT_EQ(module->importsec[0].module, "m1");
+    EXPECT_EQ(module->importsec[0].name, "abc");
+    EXPECT_EQ(module->importsec[0].kind, ExternalKind::Function);
+    EXPECT_EQ(module->importsec[0].desc.function_type_index, 0x01);
+    EXPECT_EQ(module->importsec[1].module, "m2");
+    EXPECT_EQ(module->importsec[1].name, "foo");
+    EXPECT_EQ(module->importsec[1].kind, ExternalKind::Memory);
+    EXPECT_EQ(module->importsec[1].desc.memory.limits.min, 0x7f);
+    EXPECT_FALSE(module->importsec[1].desc.memory.limits.max);
+    EXPECT_EQ(module->importsec[2].module, "m3");
+    EXPECT_EQ(module->importsec[2].name, "bar");
+    EXPECT_EQ(module->importsec[2].kind, ExternalKind::Global);
+    EXPECT_FALSE(module->importsec[2].desc.global.is_mutable);
+    EXPECT_EQ(module->importsec[2].desc.global.value_type, ValType::i32);
+    EXPECT_EQ(module->importsec[3].module, "m4");
+    EXPECT_EQ(module->importsec[3].name, "tab");
+    EXPECT_EQ(module->importsec[3].kind, ExternalKind::Table);
+    EXPECT_EQ(module->importsec[3].desc.table.limits.min, 1);
+    ASSERT_TRUE(module->importsec[3].desc.table.limits.max.has_value());
+    EXPECT_EQ(*module->importsec[3].desc.table.limits.max, 0x42);
 }
 
 TEST(parser, import_invalid_kind)
@@ -383,7 +383,7 @@ TEST(parser, function_section_empty)
 {
     const auto bin = bytes{wasm_prefix} + make_section(3, make_vec({}));
     const auto module = parse(bin);
-    EXPECT_EQ(module.funcsec.size(), 0);
+    EXPECT_EQ(module->funcsec.size(), 0);
 }
 
 TEST(parser, function_section_with_single_function)
@@ -394,8 +394,8 @@ TEST(parser, function_section_with_single_function)
     const auto bin = bytes{wasm_prefix} + make_section(1, type_section) +
                      make_section(3, function_section) + make_section(10, code_section);
     const auto module = parse(bin);
-    ASSERT_EQ(module.funcsec.size(), 1);
-    EXPECT_EQ(module.funcsec[0], 0);
+    ASSERT_EQ(module->funcsec.size(), 1);
+    EXPECT_EQ(module->funcsec[0], 0);
 }
 
 TEST(parser, function_section_with_multiple_functions)
@@ -409,11 +409,11 @@ TEST(parser, function_section_with_multiple_functions)
     const auto bin = bytes{wasm_prefix} + make_section(1, type_section) +
                      make_section(3, function_section) + make_section(10, code_section);
     const auto module = parse(bin);
-    ASSERT_EQ(module.funcsec.size(), 4);
-    EXPECT_EQ(module.funcsec[0], 0);
-    EXPECT_EQ(module.funcsec[1], 1);
-    EXPECT_EQ(module.funcsec[2], 3);
-    EXPECT_EQ(module.funcsec[3], 4);
+    ASSERT_EQ(module->funcsec.size(), 4);
+    EXPECT_EQ(module->funcsec[0], 0);
+    EXPECT_EQ(module->funcsec[1], 1);
+    EXPECT_EQ(module->funcsec[2], 3);
+    EXPECT_EQ(module->funcsec[3], 4);
 }
 
 TEST(parser, function_section_size_128)
@@ -427,7 +427,7 @@ TEST(parser, function_section_size_128)
     const auto wasm_bin = bytes{wasm_prefix} + make_section(1, type_section) +
                           make_section(3, function_section) + make_section(10, code_section);
     const auto module = parse(wasm_bin);
-    ASSERT_EQ(module.funcsec.size(), size);
+    ASSERT_EQ(module->funcsec.size(), size);
 }
 
 TEST(parser, function_section_end_out_of_bounds)
@@ -466,7 +466,7 @@ TEST(parser, table_section_empty)
 {
     const auto bin = bytes{wasm_prefix} + make_section(4, make_vec({}));
     const auto module = parse(bin);
-    EXPECT_EQ(module.tablesec.size(), 0);
+    EXPECT_EQ(module->tablesec.size(), 0);
 }
 
 TEST(parser, table_single_min_limit)
@@ -475,8 +475,8 @@ TEST(parser, table_single_min_limit)
     const auto bin = bytes{wasm_prefix} + make_section(4, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.tablesec.size(), 1);
-    EXPECT_EQ(module.tablesec[0].limits.min, 0x7f);
+    ASSERT_EQ(module->tablesec.size(), 1);
+    EXPECT_EQ(module->tablesec[0].limits.min, 0x7f);
 }
 
 TEST(parser, table_single_minmax_limit)
@@ -485,9 +485,9 @@ TEST(parser, table_single_minmax_limit)
     const auto bin = bytes{wasm_prefix} + make_section(4, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.tablesec.size(), 1);
-    EXPECT_EQ(module.tablesec[0].limits.min, 0x12);
-    EXPECT_EQ(module.tablesec[0].limits.max, 0x7f);
+    ASSERT_EQ(module->tablesec.size(), 1);
+    EXPECT_EQ(module->tablesec[0].limits.min, 0x12);
+    EXPECT_EQ(module->tablesec[0].limits.max, 0x7f);
 }
 
 // Where minimum exceeds maximum
@@ -516,7 +516,7 @@ TEST(parser, memory_section_empty)
 {
     const auto bin = bytes{wasm_prefix} + make_section(5, make_vec({}));
     const auto module = parse(bin);
-    EXPECT_EQ(module.memorysec.size(), 0);
+    EXPECT_EQ(module->memorysec.size(), 0);
 }
 
 TEST(parser, memory_single_min_limit)
@@ -525,8 +525,8 @@ TEST(parser, memory_single_min_limit)
     const auto bin = bytes{wasm_prefix} + make_section(5, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.memorysec.size(), 1);
-    EXPECT_EQ(module.memorysec[0].limits.min, 0x7f);
+    ASSERT_EQ(module->memorysec.size(), 1);
+    EXPECT_EQ(module->memorysec[0].limits.min, 0x7f);
 }
 
 TEST(parser, memory_single_minmax_limit)
@@ -535,9 +535,9 @@ TEST(parser, memory_single_minmax_limit)
     const auto bin = bytes{wasm_prefix} + make_section(5, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.memorysec.size(), 1);
-    EXPECT_EQ(module.memorysec[0].limits.min, 0x12);
-    EXPECT_EQ(module.memorysec[0].limits.max, 0x7f);
+    ASSERT_EQ(module->memorysec.size(), 1);
+    EXPECT_EQ(module->memorysec[0].limits.min, 0x12);
+    EXPECT_EQ(module->memorysec[0].limits.max, 0x7f);
 }
 
 // Where minimum exceeds maximum
@@ -578,7 +578,7 @@ TEST(parser, global_section_empty)
 {
     const auto bin = bytes{wasm_prefix} + make_section(6, make_vec({}));
     const auto module = parse(bin);
-    EXPECT_EQ(module.globalsec.size(), 0);
+    EXPECT_EQ(module->globalsec.size(), 0);
 }
 
 TEST(parser, global_single_mutable_const_inited)
@@ -587,11 +587,11 @@ TEST(parser, global_single_mutable_const_inited)
     const auto bin = bytes{wasm_prefix} + make_section(6, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.globalsec.size(), 1);
-    EXPECT_TRUE(module.globalsec[0].type.is_mutable);
-    EXPECT_EQ(module.globalsec[0].type.value_type, ValType::i32);
-    EXPECT_EQ(module.globalsec[0].expression.kind, ConstantExpression::Kind::Constant);
-    EXPECT_EQ(as_uint32(module.globalsec[0].expression.value.constant), 0x10);
+    ASSERT_EQ(module->globalsec.size(), 1);
+    EXPECT_TRUE(module->globalsec[0].type.is_mutable);
+    EXPECT_EQ(module->globalsec[0].type.value_type, ValType::i32);
+    EXPECT_EQ(module->globalsec[0].expression.kind, ConstantExpression::Kind::Constant);
+    EXPECT_EQ(as_uint32(module->globalsec[0].expression.value.constant), 0x10);
 }
 
 TEST(parser, global_multi_global_inited)
@@ -605,11 +605,11 @@ TEST(parser, global_multi_global_inited)
         from_hex("0061736d01000000021102016d026731037f00016d026732037f000606017f0023010b");
     const auto module = parse(bin);
 
-    ASSERT_EQ(module.globalsec.size(), 1);
-    EXPECT_FALSE(module.globalsec[0].type.is_mutable);
-    EXPECT_EQ(module.globalsec[0].type.value_type, ValType::i32);
-    EXPECT_EQ(module.globalsec[0].expression.kind, ConstantExpression::Kind::GlobalGet);
-    EXPECT_EQ(module.globalsec[0].expression.value.global_index, 0x01);
+    ASSERT_EQ(module->globalsec.size(), 1);
+    EXPECT_FALSE(module->globalsec[0].type.is_mutable);
+    EXPECT_EQ(module->globalsec[0].type.value_type, ValType::i32);
+    EXPECT_EQ(module->globalsec[0].expression.kind, ConstantExpression::Kind::GlobalGet);
+    EXPECT_EQ(module->globalsec[0].expression.value.global_index, 0x01);
 }
 
 TEST(parser, global_multi_const_inited)
@@ -620,15 +620,15 @@ TEST(parser, global_multi_const_inited)
     const auto bin = bytes{wasm_prefix} + make_section(6, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.globalsec.size(), 2);
-    EXPECT_FALSE(module.globalsec[0].type.is_mutable);
-    EXPECT_EQ(module.globalsec[0].type.value_type, ValType::i32);
-    EXPECT_EQ(module.globalsec[0].expression.kind, ConstantExpression::Kind::Constant);
-    EXPECT_EQ(as_uint32(module.globalsec[0].expression.value.constant), 1);
-    EXPECT_TRUE(module.globalsec[1].type.is_mutable);
-    EXPECT_EQ(module.globalsec[1].type.value_type, ValType::i32);
-    EXPECT_EQ(module.globalsec[1].expression.kind, ConstantExpression::Kind::Constant);
-    EXPECT_EQ(as_uint32(module.globalsec[1].expression.value.constant), uint32_t(-1));
+    ASSERT_EQ(module->globalsec.size(), 2);
+    EXPECT_FALSE(module->globalsec[0].type.is_mutable);
+    EXPECT_EQ(module->globalsec[0].type.value_type, ValType::i32);
+    EXPECT_EQ(module->globalsec[0].expression.kind, ConstantExpression::Kind::Constant);
+    EXPECT_EQ(as_uint32(module->globalsec[0].expression.value.constant), 1);
+    EXPECT_TRUE(module->globalsec[1].type.is_mutable);
+    EXPECT_EQ(module->globalsec[1].type.value_type, ValType::i32);
+    EXPECT_EQ(module->globalsec[1].expression.kind, ConstantExpression::Kind::Constant);
+    EXPECT_EQ(as_uint32(module->globalsec[1].expression.value.constant), uint32_t(-1));
 }
 
 TEST(parser, global_float)
@@ -645,31 +645,31 @@ TEST(parser, global_float)
         "33330b400b7c0023010b");
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.importsec.size(), 2);
-    EXPECT_EQ(module.importsec[0].kind, ExternalKind::Global);
-    EXPECT_EQ(module.importsec[0].module, "m");
-    EXPECT_EQ(module.importsec[0].name, "g1");
-    EXPECT_TRUE(module.importsec[0].desc.global.is_mutable);
-    EXPECT_EQ(module.importsec[0].desc.global.value_type, ValType::f32);
-    EXPECT_EQ(module.importsec[1].kind, ExternalKind::Global);
-    EXPECT_EQ(module.importsec[1].module, "m");
-    EXPECT_EQ(module.importsec[1].name, "g2");
-    EXPECT_FALSE(module.importsec[1].desc.global.is_mutable);
-    EXPECT_EQ(module.importsec[1].desc.global.value_type, ValType::f64);
+    ASSERT_EQ(module->importsec.size(), 2);
+    EXPECT_EQ(module->importsec[0].kind, ExternalKind::Global);
+    EXPECT_EQ(module->importsec[0].module, "m");
+    EXPECT_EQ(module->importsec[0].name, "g1");
+    EXPECT_TRUE(module->importsec[0].desc.global.is_mutable);
+    EXPECT_EQ(module->importsec[0].desc.global.value_type, ValType::f32);
+    EXPECT_EQ(module->importsec[1].kind, ExternalKind::Global);
+    EXPECT_EQ(module->importsec[1].module, "m");
+    EXPECT_EQ(module->importsec[1].name, "g2");
+    EXPECT_FALSE(module->importsec[1].desc.global.is_mutable);
+    EXPECT_EQ(module->importsec[1].desc.global.value_type, ValType::f64);
 
-    ASSERT_EQ(module.globalsec.size(), 3);
-    EXPECT_FALSE(module.globalsec[0].type.is_mutable);
-    EXPECT_EQ(module.globalsec[0].type.value_type, ValType::f32);
-    EXPECT_EQ(module.globalsec[0].expression.kind, ConstantExpression::Kind::Constant);
-    EXPECT_EQ(module.globalsec[0].expression.value.constant.f32, 1.2f);
-    EXPECT_TRUE(module.globalsec[1].type.is_mutable);
-    EXPECT_EQ(module.globalsec[1].type.value_type, ValType::f64);
-    EXPECT_EQ(module.globalsec[1].expression.kind, ConstantExpression::Kind::Constant);
-    EXPECT_EQ(module.globalsec[1].expression.value.constant.f64, 3.4);
-    EXPECT_FALSE(module.globalsec[2].type.is_mutable);
-    EXPECT_EQ(module.globalsec[2].type.value_type, ValType::f64);
-    EXPECT_EQ(module.globalsec[2].expression.kind, ConstantExpression::Kind::GlobalGet);
-    EXPECT_EQ(module.globalsec[2].expression.value.global_index, 1);
+    ASSERT_EQ(module->globalsec.size(), 3);
+    EXPECT_FALSE(module->globalsec[0].type.is_mutable);
+    EXPECT_EQ(module->globalsec[0].type.value_type, ValType::f32);
+    EXPECT_EQ(module->globalsec[0].expression.kind, ConstantExpression::Kind::Constant);
+    EXPECT_EQ(module->globalsec[0].expression.value.constant.f32, 1.2f);
+    EXPECT_TRUE(module->globalsec[1].type.is_mutable);
+    EXPECT_EQ(module->globalsec[1].type.value_type, ValType::f64);
+    EXPECT_EQ(module->globalsec[1].expression.kind, ConstantExpression::Kind::Constant);
+    EXPECT_EQ(module->globalsec[1].expression.value.constant.f64, 3.4);
+    EXPECT_FALSE(module->globalsec[2].type.is_mutable);
+    EXPECT_EQ(module->globalsec[2].type.value_type, ValType::f64);
+    EXPECT_EQ(module->globalsec[2].expression.kind, ConstantExpression::Kind::GlobalGet);
+    EXPECT_EQ(module->globalsec[2].expression.value.global_index, 1);
 }
 
 TEST(parser, global_invalid_mutability)
@@ -730,7 +730,7 @@ TEST(parser, export_section_empty)
 {
     const auto bin = bytes{wasm_prefix} + make_section(7, make_vec({}));
     const auto module = parse(bin);
-    EXPECT_EQ(module.exportsec.size(), 0);
+    EXPECT_EQ(module->exportsec.size(), 0);
 }
 
 TEST(parser, export_single_function)
@@ -745,10 +745,10 @@ TEST(parser, export_single_function)
                      make_section(10, code_section);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.exportsec.size(), 1);
-    EXPECT_EQ(module.exportsec[0].name, "abc");
-    EXPECT_EQ(module.exportsec[0].kind, ExternalKind::Function);
-    EXPECT_EQ(module.exportsec[0].index, 0);
+    ASSERT_EQ(module->exportsec.size(), 1);
+    EXPECT_EQ(module->exportsec[0].name, "abc");
+    EXPECT_EQ(module->exportsec[0].kind, ExternalKind::Function);
+    EXPECT_EQ(module->exportsec[0].index, 0);
 }
 
 TEST(parser, export_multiple)
@@ -764,19 +764,19 @@ TEST(parser, export_multiple)
         "0003666f6f01000362617202000378797a03000a05010300010b");
 
     const auto module = parse(wasm);
-    ASSERT_EQ(module.exportsec.size(), 4);
-    EXPECT_EQ(module.exportsec[0].name, "abc");
-    EXPECT_EQ(module.exportsec[0].kind, ExternalKind::Function);
-    EXPECT_EQ(module.exportsec[0].index, 0);
-    EXPECT_EQ(module.exportsec[1].name, "foo");
-    EXPECT_EQ(module.exportsec[1].kind, ExternalKind::Table);
-    EXPECT_EQ(module.exportsec[1].index, 0);
-    EXPECT_EQ(module.exportsec[2].name, "bar");
-    EXPECT_EQ(module.exportsec[2].kind, ExternalKind::Memory);
-    EXPECT_EQ(module.exportsec[2].index, 0);
-    EXPECT_EQ(module.exportsec[3].name, "xyz");
-    EXPECT_EQ(module.exportsec[3].kind, ExternalKind::Global);
-    EXPECT_EQ(module.exportsec[3].index, 0);
+    ASSERT_EQ(module->exportsec.size(), 4);
+    EXPECT_EQ(module->exportsec[0].name, "abc");
+    EXPECT_EQ(module->exportsec[0].kind, ExternalKind::Function);
+    EXPECT_EQ(module->exportsec[0].index, 0);
+    EXPECT_EQ(module->exportsec[1].name, "foo");
+    EXPECT_EQ(module->exportsec[1].kind, ExternalKind::Table);
+    EXPECT_EQ(module->exportsec[1].index, 0);
+    EXPECT_EQ(module->exportsec[2].name, "bar");
+    EXPECT_EQ(module->exportsec[2].kind, ExternalKind::Memory);
+    EXPECT_EQ(module->exportsec[2].index, 0);
+    EXPECT_EQ(module->exportsec[3].name, "xyz");
+    EXPECT_EQ(module->exportsec[3].kind, ExternalKind::Global);
+    EXPECT_EQ(module->exportsec[3].index, 0);
 }
 
 TEST(parser, export_invalid_kind)
@@ -818,8 +818,8 @@ TEST(parser, start)
                      make_section(10, code_section);
 
     const auto module = parse(bin);
-    EXPECT_TRUE(module.startfunc);
-    EXPECT_EQ(*module.startfunc, 1);
+    EXPECT_TRUE(module->startfunc);
+    EXPECT_EQ(*module->startfunc, 1);
 }
 
 TEST(parser, start_invalid_index)
@@ -856,8 +856,8 @@ TEST(parser, start_module_with_imports)
                      make_section(8, start_section) + make_section(10, code_section);
 
     const auto module = parse(bin);
-    EXPECT_TRUE(module.startfunc);
-    EXPECT_EQ(*module.startfunc, 2);
+    EXPECT_TRUE(module->startfunc);
+    EXPECT_EQ(*module->startfunc, 2);
 }
 
 TEST(parser, start_module_with_imports_invalid_index)
@@ -885,7 +885,7 @@ TEST(parser, element_section_empty)
 {
     const auto bin = bytes{wasm_prefix} + make_section(9, make_vec({}));
     const auto module = parse(bin);
-    EXPECT_EQ(module.elementsec.size(), 0);
+    EXPECT_EQ(module->elementsec.size(), 0);
 }
 
 TEST(parser, element_section)
@@ -906,22 +906,22 @@ TEST(parser, element_section)
         "0200010041020b0202030023000b0200030a0d0402000b02000b02000b02000b");
     const auto module = parse(bin);
 
-    ASSERT_EQ(module.elementsec.size(), 3);
-    EXPECT_EQ(module.elementsec[0].offset.kind, ConstantExpression::Kind::Constant);
-    EXPECT_EQ(as_uint32(module.elementsec[0].offset.value.constant), 1);
-    ASSERT_EQ(module.elementsec[0].init.size(), 2);
-    EXPECT_EQ(module.elementsec[0].init[0], 0);
-    EXPECT_EQ(module.elementsec[0].init[1], 1);
-    EXPECT_EQ(module.elementsec[1].offset.kind, ConstantExpression::Kind::Constant);
-    EXPECT_EQ(as_uint32(module.elementsec[1].offset.value.constant), 2);
-    ASSERT_EQ(module.elementsec[1].init.size(), 2);
-    EXPECT_EQ(module.elementsec[1].init[0], 2);
-    EXPECT_EQ(module.elementsec[1].init[1], 3);
-    EXPECT_EQ(module.elementsec[2].offset.kind, ConstantExpression::Kind::GlobalGet);
-    EXPECT_EQ(module.elementsec[2].offset.value.global_index, 0);
-    ASSERT_EQ(module.elementsec[2].init.size(), 2);
-    EXPECT_EQ(module.elementsec[2].init[0], 0);
-    EXPECT_EQ(module.elementsec[2].init[1], 3);
+    ASSERT_EQ(module->elementsec.size(), 3);
+    EXPECT_EQ(module->elementsec[0].offset.kind, ConstantExpression::Kind::Constant);
+    EXPECT_EQ(as_uint32(module->elementsec[0].offset.value.constant), 1);
+    ASSERT_EQ(module->elementsec[0].init.size(), 2);
+    EXPECT_EQ(module->elementsec[0].init[0], 0);
+    EXPECT_EQ(module->elementsec[0].init[1], 1);
+    EXPECT_EQ(module->elementsec[1].offset.kind, ConstantExpression::Kind::Constant);
+    EXPECT_EQ(as_uint32(module->elementsec[1].offset.value.constant), 2);
+    ASSERT_EQ(module->elementsec[1].init.size(), 2);
+    EXPECT_EQ(module->elementsec[1].init[0], 2);
+    EXPECT_EQ(module->elementsec[1].init[1], 3);
+    EXPECT_EQ(module->elementsec[2].offset.kind, ConstantExpression::Kind::GlobalGet);
+    EXPECT_EQ(module->elementsec[2].offset.value.global_index, 0);
+    ASSERT_EQ(module->elementsec[2].init.size(), 2);
+    EXPECT_EQ(module->elementsec[2].init[0], 0);
+    EXPECT_EQ(module->elementsec[2].init[1], 3);
 }
 
 TEST(parser, element_section_tableidx_nonzero)
@@ -952,7 +952,7 @@ TEST(parser, code_section_empty)
 {
     const auto bin = bytes{wasm_prefix} + make_section(10, make_vec({}));
     const auto module = parse(bin);
-    EXPECT_EQ(module.codesec.size(), 0);
+    EXPECT_EQ(module->codesec.size(), 0);
 }
 
 TEST(parser, code_locals)
@@ -964,8 +964,8 @@ TEST(parser, code_locals)
         make_section(10, make_vec({add_size_prefix(make_vec({wasm_locals}) + "0b"_bytes)}));
 
     const auto module = parse(wasm);
-    ASSERT_EQ(module.codesec.size(), 1);
-    EXPECT_EQ(module.codesec[0].local_count, 0x81);
+    ASSERT_EQ(module->codesec.size(), 1);
+    EXPECT_EQ(module->codesec[0].local_count, 0x81);
 }
 
 TEST(parser, code_locals_2)
@@ -982,8 +982,8 @@ TEST(parser, code_locals_2)
                 make_vec({wasm_locals1, wasm_locals2, wasm_locals3, wasm_locals4}) + "0b"_bytes)}));
 
     const auto module = parse(wasm);
-    ASSERT_EQ(module.codesec.size(), 1);
-    EXPECT_EQ(module.codesec[0].local_count, 1 + 2 + 3 + 4);
+    ASSERT_EQ(module->codesec.size(), 1);
+    EXPECT_EQ(module->codesec[0].local_count, 1 + 2 + 3 + 4);
 }
 
 TEST(parser, code_locals_invalid_type)
@@ -1023,8 +1023,8 @@ TEST(parser, code_with_empty_expr_2_locals)
                           make_section(3, "0100"_bytes) + make_section(10, make_vec({code_bin}));
 
     const auto module = parse(wasm_bin);
-    ASSERT_EQ(module.codesec.size(), 1);
-    const auto& code_obj = module.codesec[0];
+    ASSERT_EQ(module->codesec.size(), 1);
+    const auto& code_obj = module->codesec[0];
     EXPECT_EQ(code_obj.local_count, 2);
     ASSERT_EQ(code_obj.instructions.size(), 1);
     EXPECT_EQ(code_obj.instructions[0], Instr::end);
@@ -1040,8 +1040,8 @@ TEST(parser, code_with_empty_expr_5_locals)
                           make_section(3, "0100"_bytes) + make_section(10, make_vec({code_bin}));
 
     const auto module = parse(wasm_bin);
-    ASSERT_EQ(module.codesec.size(), 1);
-    const auto& code_obj = module.codesec[0];
+    ASSERT_EQ(module->codesec.size(), 1);
+    const auto& code_obj = module->codesec[0];
     EXPECT_EQ(code_obj.local_count, 5);
     ASSERT_EQ(code_obj.instructions.size(), 1);
     EXPECT_EQ(code_obj.instructions[0], Instr::end);
@@ -1057,16 +1057,16 @@ TEST(parser, code_section_with_2_trivial_codes)
                      make_section(3, "020000"_bytes) + make_section(10, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.typesec.size(), 1);
-    EXPECT_EQ(module.typesec[0].inputs.size(), 0);
-    EXPECT_EQ(module.typesec[0].outputs.size(), 0);
-    ASSERT_EQ(module.codesec.size(), 2);
-    EXPECT_EQ(module.codesec[0].local_count, 0);
-    ASSERT_EQ(module.codesec[0].instructions.size(), 1);
-    EXPECT_EQ(module.codesec[0].instructions[0], Instr::end);
-    EXPECT_EQ(module.codesec[1].local_count, 0);
-    ASSERT_EQ(module.codesec[1].instructions.size(), 1);
-    EXPECT_EQ(module.codesec[1].instructions[0], Instr::end);
+    ASSERT_EQ(module->typesec.size(), 1);
+    EXPECT_EQ(module->typesec[0].inputs.size(), 0);
+    EXPECT_EQ(module->typesec[0].outputs.size(), 0);
+    ASSERT_EQ(module->codesec.size(), 2);
+    EXPECT_EQ(module->codesec[0].local_count, 0);
+    ASSERT_EQ(module->codesec[0].instructions.size(), 1);
+    EXPECT_EQ(module->codesec[0].instructions[0], Instr::end);
+    EXPECT_EQ(module->codesec[1].local_count, 0);
+    ASSERT_EQ(module->codesec[1].instructions.size(), 1);
+    EXPECT_EQ(module->codesec[1].instructions[0], Instr::end);
 }
 
 TEST(parser, code_section_with_basic_instructions)
@@ -1086,21 +1086,21 @@ TEST(parser, code_section_with_basic_instructions)
                      make_section(3, "0100"_bytes) + make_section(10, section_contents);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.typesec.size(), 1);
-    EXPECT_EQ(module.typesec[0].inputs.size(), 0);
-    EXPECT_EQ(module.typesec[0].outputs.size(), 0);
-    ASSERT_EQ(module.codesec.size(), 1);
-    EXPECT_EQ(module.codesec[0].local_count, 4);
-    ASSERT_EQ(module.codesec[0].instructions.size(), 7);
-    EXPECT_EQ(module.codesec[0].instructions[0], Instr::local_get);
-    EXPECT_EQ(module.codesec[0].instructions[1], Instr::i32_const);
-    EXPECT_EQ(module.codesec[0].instructions[2], Instr::i32_add);
-    EXPECT_EQ(module.codesec[0].instructions[3], Instr::local_set);
-    EXPECT_EQ(module.codesec[0].instructions[4], Instr::nop);
-    EXPECT_EQ(module.codesec[0].instructions[5], Instr::unreachable);
-    EXPECT_EQ(module.codesec[0].instructions[6], Instr::end);
-    ASSERT_EQ(module.codesec[0].immediates.size(), 3 * 4);
-    EXPECT_EQ(module.codesec[0].immediates, "010000000200000003000000"_bytes);
+    ASSERT_EQ(module->typesec.size(), 1);
+    EXPECT_EQ(module->typesec[0].inputs.size(), 0);
+    EXPECT_EQ(module->typesec[0].outputs.size(), 0);
+    ASSERT_EQ(module->codesec.size(), 1);
+    EXPECT_EQ(module->codesec[0].local_count, 4);
+    ASSERT_EQ(module->codesec[0].instructions.size(), 7);
+    EXPECT_EQ(module->codesec[0].instructions[0], Instr::local_get);
+    EXPECT_EQ(module->codesec[0].instructions[1], Instr::i32_const);
+    EXPECT_EQ(module->codesec[0].instructions[2], Instr::i32_add);
+    EXPECT_EQ(module->codesec[0].instructions[3], Instr::local_set);
+    EXPECT_EQ(module->codesec[0].instructions[4], Instr::nop);
+    EXPECT_EQ(module->codesec[0].instructions[5], Instr::unreachable);
+    EXPECT_EQ(module->codesec[0].instructions[6], Instr::end);
+    ASSERT_EQ(module->codesec[0].immediates.size(), 3 * 4);
+    EXPECT_EQ(module->codesec[0].immediates, "010000000200000003000000"_bytes);
 }
 
 TEST(parser, code_section_with_memory_size)
@@ -1114,12 +1114,12 @@ TEST(parser, code_section_with_memory_size)
                      make_section(3, "0100"_bytes) + make_section(5, make_vec({"0000"_bytes})) +
                      make_section(10, section_contents);
     const auto module = parse(bin);
-    ASSERT_EQ(module.codesec.size(), 1);
-    EXPECT_EQ(module.codesec[0].local_count, 0);
-    ASSERT_EQ(module.codesec[0].instructions.size(), 2);
-    EXPECT_EQ(module.codesec[0].instructions[0], Instr::memory_size);
-    EXPECT_EQ(module.codesec[0].instructions[1], Instr::end);
-    EXPECT_TRUE(module.codesec[0].immediates.empty());
+    ASSERT_EQ(module->codesec.size(), 1);
+    EXPECT_EQ(module->codesec[0].local_count, 0);
+    ASSERT_EQ(module->codesec[0].instructions.size(), 2);
+    EXPECT_EQ(module->codesec[0].instructions[0], Instr::memory_size);
+    EXPECT_EQ(module->codesec[0].instructions[1], Instr::end);
+    EXPECT_TRUE(module->codesec[0].immediates.empty());
 
     const auto func_bin_invalid =
         "00"  // vec(locals)
@@ -1144,14 +1144,14 @@ TEST(parser, code_section_with_memory_grow)
                      make_section(10, code_section);
 
     const auto module = parse(bin);
-    ASSERT_EQ(module.codesec.size(), 1);
-    EXPECT_EQ(module.codesec[0].local_count, 0);
-    ASSERT_EQ(module.codesec[0].instructions.size(), 4);
-    EXPECT_EQ(module.codesec[0].instructions[0], Instr::i32_const);
-    EXPECT_EQ(module.codesec[0].instructions[1], Instr::memory_grow);
-    EXPECT_EQ(module.codesec[0].instructions[2], Instr::drop);
-    EXPECT_EQ(module.codesec[0].instructions[3], Instr::end);
-    EXPECT_EQ(module.codesec[0].immediates, "00000000"_bytes);
+    ASSERT_EQ(module->codesec.size(), 1);
+    EXPECT_EQ(module->codesec[0].local_count, 0);
+    ASSERT_EQ(module->codesec[0].instructions.size(), 4);
+    EXPECT_EQ(module->codesec[0].instructions[0], Instr::i32_const);
+    EXPECT_EQ(module->codesec[0].instructions[1], Instr::memory_grow);
+    EXPECT_EQ(module->codesec[0].instructions[2], Instr::drop);
+    EXPECT_EQ(module->codesec[0].instructions[3], Instr::end);
+    EXPECT_EQ(module->codesec[0].immediates, "00000000"_bytes);
 
     const auto func_bin_invalid = "00"_bytes +  // vec(locals)
                                   i32_const(0) + "40011a0b"_bytes;
@@ -1227,7 +1227,7 @@ TEST(parser, code_section_fp_instructions)
                          make_section(5, make_vec({"0000"_bytes})) + make_section(10, code_section);
 
         const auto module = parse(bin);
-        EXPECT_EQ(module.codesec.size(), 1);
+        EXPECT_EQ(module->codesec.size(), 1);
     }
 }
 
@@ -1310,7 +1310,7 @@ TEST(parser, data_section_empty)
     const auto bin = bytes{wasm_prefix} + make_section(5, make_vec({"0000"_bytes})) +
                      make_section(11, make_vec({}));
     const auto module = parse(bin);
-    EXPECT_EQ(module.datasec.size(), 0);
+    EXPECT_EQ(module->datasec.size(), 0);
 }
 
 TEST(parser, data_section)
@@ -1327,16 +1327,16 @@ TEST(parser, data_section)
         "2424");
     const auto module = parse(bin);
 
-    ASSERT_EQ(module.datasec.size(), 3);
-    EXPECT_EQ(module.datasec[0].offset.kind, ConstantExpression::Kind::Constant);
-    EXPECT_EQ(as_uint32(module.datasec[0].offset.value.constant), 1);
-    EXPECT_EQ(module.datasec[0].init, "aaff"_bytes);
-    EXPECT_EQ(module.datasec[1].offset.kind, ConstantExpression::Kind::Constant);
-    EXPECT_EQ(as_uint32(module.datasec[1].offset.value.constant), 2);
-    EXPECT_EQ(module.datasec[1].init, "5555"_bytes);
-    EXPECT_EQ(module.datasec[2].offset.kind, ConstantExpression::Kind::GlobalGet);
-    EXPECT_EQ(module.datasec[2].offset.value.global_index, 0);
-    EXPECT_EQ(module.datasec[2].init, "2424"_bytes);
+    ASSERT_EQ(module->datasec.size(), 3);
+    EXPECT_EQ(module->datasec[0].offset.kind, ConstantExpression::Kind::Constant);
+    EXPECT_EQ(as_uint32(module->datasec[0].offset.value.constant), 1);
+    EXPECT_EQ(module->datasec[0].init, "aaff"_bytes);
+    EXPECT_EQ(module->datasec[1].offset.kind, ConstantExpression::Kind::Constant);
+    EXPECT_EQ(as_uint32(module->datasec[1].offset.value.constant), 2);
+    EXPECT_EQ(module->datasec[1].init, "5555"_bytes);
+    EXPECT_EQ(module->datasec[2].offset.kind, ConstantExpression::Kind::GlobalGet);
+    EXPECT_EQ(module->datasec[2].offset.value.global_index, 0);
+    EXPECT_EQ(module->datasec[2].init, "2424"_bytes);
 }
 
 TEST(parser, data_section_memidx_nonzero)
@@ -1409,9 +1409,9 @@ TEST(parser, interleaved_custom_section)
                      make_section(10, code_section);
 
     const auto module = parse(bin);
-    EXPECT_EQ(module.typesec.size(), 1);
-    EXPECT_EQ(module.funcsec.size(), 1);
-    EXPECT_EQ(module.codesec.size(), 1);
+    EXPECT_EQ(module->typesec.size(), 1);
+    EXPECT_EQ(module->funcsec.size(), 1);
+    EXPECT_EQ(module->codesec.size(), 1);
 }
 
 TEST(parser, wrongly_ordered_sections)
@@ -1464,12 +1464,12 @@ TEST(parser, milestone1)
         "0061736d0100000001070160027f7f017f030201000a13011101017f200020016a20026a220220006a0b");
     const auto m = parse(wasm);
 
-    ASSERT_EQ(m.typesec.size(), 1);
-    EXPECT_EQ(m.typesec[0].inputs, (std::vector{ValType::i32, ValType::i32}));
-    EXPECT_EQ(m.typesec[0].outputs, (std::vector{ValType::i32}));
+    ASSERT_EQ(m->typesec.size(), 1);
+    EXPECT_EQ(m->typesec[0].inputs, (std::vector{ValType::i32, ValType::i32}));
+    EXPECT_EQ(m->typesec[0].outputs, (std::vector{ValType::i32}));
 
-    ASSERT_EQ(m.codesec.size(), 1);
-    const auto& c = m.codesec[0];
+    ASSERT_EQ(m->codesec.size(), 1);
+    const auto& c = m->codesec[0];
     EXPECT_EQ(c.local_count, 1);
     EXPECT_EQ(c.instructions,
         (std::vector{Instr::local_get, Instr::local_get, Instr::i32_add, Instr::local_get,

--- a/test/unittests/validation_stack_test.cpp
+++ b/test/unittests/validation_stack_test.cpp
@@ -144,7 +144,7 @@ TEST(validation_stack, block_with_result)
     */
     const auto wasm = from_hex("0061736d01000000010401600000030201000a0a010800027f417f0b1a0b");
     const auto module = parse(wasm);
-    EXPECT_EQ(module.codesec[0].max_stack_height, 1);
+    EXPECT_EQ(module->codesec[0].max_stack_height, 1);
 }
 
 TEST(validation_stack, block_missing_result)
@@ -215,7 +215,7 @@ TEST(validation_stack, loop_with_result)
     */
     const auto wasm = from_hex("0061736d01000000010401600000030201000a0a010800037f417f0b1a0b");
     const auto module = parse(wasm);
-    EXPECT_EQ(module.codesec[0].max_stack_height, 1);
+    EXPECT_EQ(module->codesec[0].max_stack_height, 1);
 }
 
 TEST(validation_stack, loop_missing_result)
@@ -502,7 +502,7 @@ TEST(validation_stack, unreachable)
     */
     const auto wasm = from_hex("0061736d010000000105016000017f030201000a0601040000450b");
     const auto module = parse(wasm);
-    EXPECT_THAT(module.codesec[0].max_stack_height, 0);
+    EXPECT_THAT(module->codesec[0].max_stack_height, 0);
 }
 
 TEST(validation_stack, unreachable_2)
@@ -518,7 +518,7 @@ TEST(validation_stack, unreachable_2)
     */
     const auto wasm = from_hex("0061736d01000000010401600000030201000a09010700006a6a6a1a0b");
     const auto module = parse(wasm);
-    EXPECT_THAT(module.codesec[0].max_stack_height, 0);
+    EXPECT_THAT(module->codesec[0].max_stack_height, 0);
 }
 
 TEST(validation_stack, unreachable_3)
@@ -530,7 +530,7 @@ TEST(validation_stack, unreachable_3)
     */
     const auto wasm = from_hex("0061736d010000000105016000017f030201000a08010600027f000b0b");
     const auto module = parse(wasm);
-    EXPECT_THAT(module.codesec[0].max_stack_height, 1);
+    EXPECT_THAT(module->codesec[0].max_stack_height, 1);
 }
 
 TEST(validation_stack, unreachable_4)
@@ -544,7 +544,7 @@ TEST(validation_stack, unreachable_4)
     const auto wasm =
         from_hex("0061736d010000000105016000017f030201000a0d010b0000047f41000541010b0b");
     const auto module = parse(wasm);
-    EXPECT_THAT(module.codesec[0].max_stack_height, 1);
+    EXPECT_THAT(module->codesec[0].max_stack_height, 1);
 }
 
 TEST(validation_stack, unreachable_5)
@@ -558,7 +558,7 @@ TEST(validation_stack, unreachable_5)
     */
     const auto wasm = from_hex("0061736d010000000105016000017f030201000a08010600420000450b");
     const auto module = parse(wasm);
-    EXPECT_THAT(module.codesec[0].max_stack_height, 1);
+    EXPECT_THAT(module->codesec[0].max_stack_height, 1);
 }
 
 
@@ -710,7 +710,7 @@ TEST(validation_stack, br)
     */
     const auto wasm = from_hex("0061736d01000000010401600000030201000a0b01090002400c00451a0b0b");
     const auto module = parse(wasm);
-    EXPECT_THAT(module.codesec[0].max_stack_height, 0);
+    EXPECT_THAT(module->codesec[0].max_stack_height, 0);
 }
 
 TEST(validation_stack, br_table)
@@ -731,7 +731,7 @@ TEST(validation_stack, br_table)
     const auto wasm = from_hex(
         "0061736d0100000001050160017f00030201000a14011200024041e90720000e0100016c6c6c1a0b0b");
     const auto module = parse(wasm);
-    EXPECT_THAT(module.codesec[0].max_stack_height, 2);
+    EXPECT_THAT(module->codesec[0].max_stack_height, 2);
 }
 
 TEST(validation_stack, return_)
@@ -745,7 +745,7 @@ TEST(validation_stack, return_)
     */
     const auto wasm = from_hex("0061736d01000000010401600000030201000a070105000f451a0b");
     const auto module = parse(wasm);
-    EXPECT_THAT(module.codesec[0].max_stack_height, 0);
+    EXPECT_THAT(module->codesec[0].max_stack_height, 0);
 }
 
 TEST(validation_stack, if_stack_underflow)
@@ -984,7 +984,7 @@ TEST(validation_stack, if_else_stack_height)
     const auto wasm =
         from_hex("0061736d01000000010401600000030201000a1201100042014102047e42010542030b1a1a0b");
     const auto module = parse(wasm);
-    EXPECT_EQ(module.codesec[0].max_stack_height, 2);
+    EXPECT_EQ(module->codesec[0].max_stack_height, 2);
 }
 
 TEST(validation_stack, if_invalid_end_stack_height)

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(
     floating_point_utils.hpp
     hex.cpp
     hex.hpp
+    instantiate_helpers.hpp
     leb128_encode.cpp
     leb128_encode.hpp
     wabt_engine.cpp

--- a/test/utils/execute_helpers.hpp
+++ b/test/utils/execute_helpers.hpp
@@ -5,14 +5,15 @@
 #pragma once
 
 #include "execute.hpp"
+#include <test/utils/instantiate_helpers.hpp>
 #include <initializer_list>
 
 namespace fizzy::test
 {
-inline ExecutionResult execute(
-    const Module& module, FuncIdx func_idx, std::initializer_list<Value> args)
+inline ExecutionResult execute(const std::unique_ptr<const Module>& module, FuncIdx func_idx,
+    std::initializer_list<Value> args)
 {
-    auto instance = instantiate(module);
+    auto instance = instantiate(*module);
     return execute(*instance, func_idx, args);
 }
 }  // namespace fizzy::test

--- a/test/utils/instantiate_helpers.hpp
+++ b/test/utils/instantiate_helpers.hpp
@@ -1,0 +1,22 @@
+// Fizzy: A fast WebAssembly interpreter
+// Copyright 2020 The Fizzy Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "instantiate.hpp"
+
+namespace fizzy::test
+{
+inline std::unique_ptr<Instance> instantiate(Module module,
+    std::vector<ExternalFunction> imported_functions = {},
+    std::vector<ExternalTable> imported_tables = {},
+    std::vector<ExternalMemory> imported_memories = {},
+    std::vector<ExternalGlobal> imported_globals = {},
+    uint32_t memory_pages_limit = DefaultMemoryPagesLimit)
+{
+    return instantiate(std::make_unique<Module>(std::move(module)), std::move(imported_functions),
+        std::move(imported_tables), std::move(imported_memories), std::move(imported_globals),
+        memory_pages_limit);
+}
+}  // namespace fizzy::test

--- a/tools/wasi/wasi.cpp
+++ b/tools/wasi/wasi.cpp
@@ -156,12 +156,12 @@ bool run(int argc, const char** argv)
         fizzy::bytes(std::istreambuf_iterator<char>{wasm_file}, std::istreambuf_iterator<char>{});
 
     auto module = fizzy::parse(wasm_binary);
-    auto imports = fizzy::resolve_imported_functions(module, wasi_functions);
+    auto imports = fizzy::resolve_imported_functions(*module, wasi_functions);
     auto instance = fizzy::instantiate(
         std::move(module), std::move(imports), {}, {}, {}, fizzy::MemoryPagesValidationLimit);
     assert(instance != nullptr);
 
-    const auto start_function = fizzy::find_exported_function(instance->module, "_start");
+    const auto start_function = fizzy::find_exported_function(*instance->module, "_start");
     if (!start_function.has_value())
     {
         std::cerr << "File is not WASI compatible (_start not found)\n";
@@ -170,7 +170,7 @@ bool run(int argc, const char** argv)
 
     // Manually validate type signature here
     // TODO: do this in find_exported_function
-    if (instance->module.get_function_type(*start_function) != fizzy::FuncType{})
+    if (instance->module->get_function_type(*start_function) != fizzy::FuncType{})
     {
         std::cerr << "File is not WASI compatible (_start has invalid signature)\n";
         return false;


### PR DESCRIPTION
This will simplify C API implementation part, allowing to handle modules and instances in the same manner.