### PR TITLE
ci: run Rust build in release mode too

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -531,10 +531,13 @@ jobs:
             rustfmt --version
             cargo fmt --all -- --check
       - run:
-          name: Build
+          name: Build (debug mode)
           command: cargo build
       - run:
-          name: Test
+          name: Build (release mode)
+          command: cargo build --release
+      - run:
+          name: Test (debug mode)
           command: cargo test
       - run:
           name: Package
@@ -556,10 +559,10 @@ jobs:
             apt -yq install llvm-8-dev clang-8 --no-install-recommends
             rustup toolchain install nightly-x86_64-unknown-linux-gnu
       - run:
-          name: Build
+          name: Build (debug mode)
           command: RUSTFLAGS="-Z sanitizer=address" ASAN_OPTIONS=detect_leaks=1 cargo +nightly build --target x86_64-unknown-linux-gnu
       - run:
-          name: Test
+          name: Test (debug mode)
           command: RUSTFLAGS="-Z sanitizer=address -C opt-level=0" ASAN_OPTIONS=detect_leaks=1 cargo +nightly test --target x86_64-unknown-linux-gnu
 
 workflows:


### PR DESCRIPTION
`cargo build` will build Fizzy in Debug profile, while `cargo build --release` will do with Release in cmake, see https://docs.rs/cmake/0.1.44/cmake/struct.Config.html#method.profile. The more specific translation rules can be seen in https://docs.rs/cmake/0.1.44/src/cmake/lib.rs.html#553-558 (it can use `Release`, `RelWithDebInfo`, `MinSizeRel` depending on settings).

We could also decide to force Release mode if we want.

Furthermore it seems PIC is used in both modes, we may want to investigate this (see https://docs.rs/cmake/0.1.44/cmake/struct.Config.html#method.pic).