### PR TITLE
C API tests cleanup

### DIFF
--- a/test/unittests/capi_test.cpp
+++ b/test/unittests/capi_test.cpp
@@ -47,7 +47,7 @@ TEST(capi, find_exported_function)
         "6f00000267310300037461620100036d656d02000a06010400412a0b");
 
     auto module = fizzy_parse(wasm.data(), wasm.size());
-    EXPECT_NE(module, nullptr);
+    ASSERT_NE(module, nullptr);
 
     uint32_t func_idx;
     EXPECT_TRUE(fizzy_find_exported_function(module, "foo", &func_idx));
@@ -65,7 +65,7 @@ TEST(capi, instantiate)
 {
     uint8_t wasm_prefix[]{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00};
     auto module = fizzy_parse(wasm_prefix, sizeof(wasm_prefix));
-    EXPECT_NE(module, nullptr);
+    ASSERT_NE(module, nullptr);
 
     auto instance = fizzy_instantiate(module, nullptr, 0);
     EXPECT_NE(instance, nullptr);
@@ -80,12 +80,12 @@ TEST(capi, instantiate_imported_function)
     */
     const auto wasm = from_hex("0061736d010000000105016000017f020d01046d6f643104666f6f310000");
     auto module = fizzy_parse(wasm.data(), wasm.size());
-    EXPECT_NE(module, nullptr);
+    ASSERT_NE(module, nullptr);
 
     EXPECT_EQ(fizzy_instantiate(module, nullptr, 0), nullptr);
 
     module = fizzy_parse(wasm.data(), wasm.size());
-    EXPECT_NE(module, nullptr);
+    ASSERT_NE(module, nullptr);
 
     FizzyExternalFunction host_funcs[] = {
         {[](void*, FizzyInstance*, const FizzyValue*, size_t, int) {
@@ -111,10 +111,10 @@ TEST(capi, memory_access_no_memory)
     */
     const auto wasm = from_hex("0061736d01000000");
     auto module = fizzy_parse(wasm.data(), wasm.size());
-    EXPECT_NE(module, nullptr);
+    ASSERT_NE(module, nullptr);
 
     auto instance = fizzy_instantiate(module, nullptr, 0);
-    EXPECT_NE(instance, nullptr);
+    ASSERT_NE(instance, nullptr);
 
     EXPECT_EQ(fizzy_get_instance_memory_data(instance), nullptr);
     EXPECT_EQ(fizzy_get_instance_memory_size(instance), 0);
@@ -136,13 +136,13 @@ TEST(capi, memory_access)
         "0061736d010000000105016000017f0302010005030100010a0901070041002802000b0b08010041010b02112"
         "2");
     auto module = fizzy_parse(wasm.data(), wasm.size());
-    EXPECT_NE(module, nullptr);
+    ASSERT_NE(module, nullptr);
 
     auto instance = fizzy_instantiate(module, nullptr, 0);
-    EXPECT_NE(instance, nullptr);
+    ASSERT_NE(instance, nullptr);
 
     uint8_t* memory = fizzy_get_instance_memory_data(instance);
-    EXPECT_NE(memory, nullptr);
+    ASSERT_NE(memory, nullptr);
     EXPECT_EQ(memory[0], 0);
     EXPECT_EQ(memory[1], 0x11);
     EXPECT_EQ(memory[2], 0x22);
@@ -163,7 +163,7 @@ TEST(capi, imported_memory_access)
     */
     const auto wasm = from_hex("0061736d01000000020c01036d6f64036d656d020001");
     auto module = fizzy_parse(wasm.data(), wasm.size());
-    EXPECT_NE(module, nullptr);
+    ASSERT_NE(module, nullptr);
 
     auto instance = fizzy_instantiate(module, nullptr, 0);
     EXPECT_EQ(instance, nullptr);
@@ -184,10 +184,10 @@ TEST(capi, execute)
         "0020016e0b0300000b");
 
     auto module = fizzy_parse(wasm.data(), wasm.size());
-    EXPECT_NE(module, nullptr);
+    ASSERT_NE(module, nullptr);
 
     auto instance = fizzy_instantiate(module, nullptr, 0);
-    EXPECT_NE(instance, nullptr);
+    ASSERT_NE(instance, nullptr);
 
     EXPECT_THAT(fizzy_execute(instance, 0, nullptr, 0), Result());
     EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), Result(42));
@@ -208,7 +208,7 @@ TEST(capi, execute_with_host_function)
         "0061736d01000000010b026000017f60027f7f017f021902046d6f643104666f6f310000046d6f643104666f6f"
         "320001");
     auto module = fizzy_parse(wasm.data(), wasm.size());
-    EXPECT_NE(module, nullptr);
+    ASSERT_NE(module, nullptr);
 
     FizzyExternalFunction host_funcs[] = {
         {[](void*, FizzyInstance*, const FizzyValue*, size_t, int) {
@@ -221,7 +221,7 @@ TEST(capi, execute_with_host_function)
             nullptr}};
 
     auto instance = fizzy_instantiate(module, host_funcs, 2);
-    EXPECT_NE(instance, nullptr);
+    ASSERT_NE(instance, nullptr);
 
     EXPECT_THAT(fizzy_execute(instance, 0, nullptr, 0), Result(42));
 
@@ -242,7 +242,7 @@ TEST(capi, imported_function_traps)
     const auto wasm =
         from_hex("0061736d010000000105016000017f020901016d03666f6f0000030201000a0601040010000b");
     auto module = fizzy_parse(wasm.data(), wasm.size());
-    EXPECT_NE(module, nullptr);
+    ASSERT_NE(module, nullptr);
 
     FizzyExternalFunction host_funcs[] = {
         {[](void*, FizzyInstance*, const FizzyValue*, size_t, int) {
@@ -251,7 +251,7 @@ TEST(capi, imported_function_traps)
             nullptr}};
 
     auto instance = fizzy_instantiate(module, host_funcs, 1);
-    EXPECT_NE(instance, nullptr);
+    ASSERT_NE(instance, nullptr);
 
     EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), Traps());
 
@@ -269,7 +269,7 @@ TEST(capi, imported_function_void)
     const auto wasm =
         from_hex("0061736d01000000010401600000020901016d03666f6f0000030201000a0601040010000b");
     auto module = fizzy_parse(wasm.data(), wasm.size());
-    EXPECT_NE(module, nullptr);
+    ASSERT_NE(module, nullptr);
 
     bool called = false;
     FizzyExternalFunction host_funcs[] = {
@@ -280,7 +280,7 @@ TEST(capi, imported_function_void)
             &called}};
 
     auto instance = fizzy_instantiate(module, host_funcs, 1);
-    EXPECT_NE(instance, nullptr);
+    ASSERT_NE(instance, nullptr);
 
     EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), Result());
     EXPECT_TRUE(called);
@@ -302,9 +302,9 @@ TEST(capi, imported_function_from_another_module)
     const auto bin1 = from_hex(
         "0061736d0100000001070160027f7f017f030201000707010373756200000a09010700200020016b0b");
     auto module1 = fizzy_parse(bin1.data(), bin1.size());
-    EXPECT_NE(module1, nullptr);
+    ASSERT_NE(module1, nullptr);
     auto instance1 = fizzy_instantiate(module1, nullptr, 0);
-    EXPECT_NE(instance1, nullptr);
+    ASSERT_NE(instance1, nullptr);
 
     /* wat2wasm
     (module
@@ -321,7 +321,7 @@ TEST(capi, imported_function_from_another_module)
         "0061736d0100000001070160027f7f017f020a01026d31037375620000030201000a0a0108002000200110000"
         "b");
     auto module2 = fizzy_parse(bin2.data(), bin2.size());
-    EXPECT_NE(module2, nullptr);
+    ASSERT_NE(module2, nullptr);
 
     // TODO fizzy_find_exported_function
 
@@ -333,7 +333,7 @@ TEST(capi, imported_function_from_another_module)
     FizzyExternalFunction host_funcs[] = {{sub, instance1}};
 
     auto instance2 = fizzy_instantiate(module2, host_funcs, 1);
-    EXPECT_NE(instance2, nullptr);
+    ASSERT_NE(instance2, nullptr);
 
     FizzyValue args[] = {{44}, {2}};
     EXPECT_THAT(fizzy_execute(instance2, 1, args, 0), Result(42));


### PR DESCRIPTION
This changes some `EXPECT_NE` to `ASSERT_NE` and resolves one TODO.