### PR TITLE
Use proper feature test for C++20 std::span

### DIFF
--- a/lib/fizzy/cxx20/bit.hpp
+++ b/lib/fizzy/cxx20/bit.hpp
@@ -7,6 +7,10 @@
 #include <cstdint>
 #include <type_traits>
 
+#if __has_include(<version>)
+#include <version>
+#endif
+
 namespace fizzy
 {
 /// The non-constexpr implementation of C++20's std::bit_cast.

--- a/lib/fizzy/cxx20/span.hpp
+++ b/lib/fizzy/cxx20/span.hpp
@@ -4,7 +4,11 @@
 
 #pragma once
 
-#if __cplusplus > 201703L
+#if __has_include(<version>)
+#include <version>
+#endif
+
+#ifdef __cpp_lib_span
 
 #include <span>
 
@@ -63,4 +67,4 @@ public:
 };
 }  // namespace fizzy
 
-#endif /* __cplusplus > 201703L */
+#endif /* __cpp_lib_span */


### PR DESCRIPTION
See https://en.cppreference.com/w/cpp/utility/feature_test which sets `__cpp_lib_span` as an alias to `201902L`, while we were testing for `201703L`.