### PR TITLE
ci: Use libc++ for sanitizers-clang job

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,13 +70,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
     endif()
 endif()
 
-if(SANITIZE MATCHES address)
-    # Enables ASan-powered checks in std::vector in libstdc++.
-    # For sanity, this may be applied for libstdc++ builds, but it is not easy to detect
-    # what standard library implementation is being used.
-    add_compile_definitions(_GLIBCXX_SANITIZE_VECTOR)
-endif()
-
 # An option to enable assertions in non-Debug build types.
 # Disabling assertions in Debug build type has no effect (assertions are still enabled).
 option(ENABLE_ASSERTIONS "Enable NDEBUG based assertions" OFF)

--- a/circle.yml
+++ b/circle.yml
@@ -381,7 +381,7 @@ jobs:
       - checkout
       - build:
           build_type: RelWithDebInfo
-          cmake_options: -DENABLE_ASSERTIONS=ON -DSANITIZE=address,undefined,nullability,implicit-unsigned-integer-truncation,implicit-signed-integer-truncation
+          cmake_options: -DCMAKE_TOOLCHAIN_FILE=~/project/cmake/toolchains/libc++.cmake -DENABLE_ASSERTIONS=ON -DSANITIZE=address,undefined,nullability,implicit-unsigned-integer-truncation,implicit-signed-integer-truncation
       - test
       - benchmark:
           min_time: "0.01"

--- a/cmake/ProjectWabt.cmake
+++ b/cmake/ProjectWabt.cmake
@@ -21,7 +21,6 @@ endif()
 if(SANITIZE MATCHES address)
     # Instrument WABT with ASan - required for container-overflow checks.
     set(CPPFLAGS "-fsanitize=address ${CPPFLAGS}")
-    set(CXXFLAGS "-D_GLIBCXX_SANITIZE_VECTOR ${CXXFLAGS}")
 endif()
 
 set(CXXFLAGS "${CPPFLAGS} ${CXXFLAGS}")


### PR DESCRIPTION
- ci: Use libc++ for sanitizers-clang job
   This should enable container-overflow checks.
- cmake: Drop _GLIBCXX_SANITIZE_VECTOR instrumentation
   This conflicts with pointer-subtract and pointer-compare ASAn checks. Container-overflow checks are performed by Clang ASan + libc++ builds.
