### PR TITLE
Adjust OperandStack allocation size when no locals

### DIFF
--- a/lib/fizzy/stack.hpp
+++ b/lib/fizzy/stack.hpp
@@ -100,7 +100,8 @@ public:
     OperandStack(
         const Value* args, size_t num_args, size_t num_local_variables, size_t max_stack_height)
     {
-        const auto storage_size_required = num_args + num_local_variables + max_stack_height;
+        const auto num_locals = num_args + num_local_variables;
+        const auto storage_size_required = num_locals + max_stack_height;
 
         if (storage_size_required <= small_storage_size)
         {
@@ -112,7 +113,7 @@ public:
             m_locals = &m_large_storage[0];
         }
 
-        m_bottom = m_locals + num_args + num_local_variables;
+        m_bottom = m_locals + num_locals;
         m_top = m_bottom - 1;
 
         const auto local_variables = std::copy_n(args, num_args, m_locals);

--- a/lib/fizzy/stack.hpp
+++ b/lib/fizzy/stack.hpp
@@ -101,7 +101,10 @@ public:
         const Value* args, size_t num_args, size_t num_local_variables, size_t max_stack_height)
     {
         const auto num_locals = num_args + num_local_variables;
-        const auto storage_size_required = num_locals + max_stack_height;
+        // To avoid potential UB when there are no locals and the stack pointer is set to
+        // m_bottom - 1 (i.e. before storage array), we allocate one additional unused stack item.
+        const auto num_locals_adjusted = num_locals + (num_locals == 0);  // Bump to 1 if 0.
+        const auto storage_size_required = num_locals_adjusted + max_stack_height;
 
         if (storage_size_required <= small_storage_size)
         {
@@ -113,7 +116,7 @@ public:
             m_locals = &m_large_storage[0];
         }
 
-        m_bottom = m_locals + num_locals;
+        m_bottom = m_locals + num_locals_adjusted;
         m_top = m_bottom - 1;
 
         const auto local_variables = std::copy_n(args, num_args, m_locals);

--- a/test/unittests/stack_test.cpp
+++ b/test/unittests/stack_test.cpp
@@ -231,6 +231,7 @@ TEST(operand_stack, large)
     constexpr auto max_height = 33;
     OperandStack stack(nullptr, 0, 0, max_height);
     ASSERT_GT(address_diff(&stack, stack.rbegin()), 100) << "not allocated on the heap";
+    EXPECT_EQ(stack.size(), 0);
 
     for (unsigned i = 0; i < max_height; ++i)
         stack.push(i);
@@ -325,4 +326,18 @@ TEST(operand_stack, to_vector)
     EXPECT_EQ(result[0].i32, 1);
     EXPECT_EQ(result[1].i32, 2);
     EXPECT_EQ(result[2].i32, 3);
+}
+
+TEST(operand_stack, hidden_stack_item)
+{
+    constexpr auto max_height = 33;
+    OperandStack stack(nullptr, 0, 0, max_height);
+    ASSERT_GT(address_diff(&stack, stack.rbegin()), 100) << "not allocated on the heap";
+    EXPECT_EQ(stack.size(), 0);
+    EXPECT_EQ(stack.rbegin(), stack.rend());
+
+    // Even when stack is empty, there exists a single hidden item slot.
+    const_cast<fizzy::Value*>(stack.rbegin())->i64 = 1;
+    EXPECT_EQ(stack.rbegin()->i64, 1);
+    EXPECT_EQ(stack.rend()->i64, 1);
 }


### PR DESCRIPTION
Fixes https://github.com/wasmx/fizzy/issues/583.
