### PR TITLE
capi: find_exported_function

### DIFF
--- a/include/fizzy/fizzy.h
+++ b/include/fizzy/fizzy.h
@@ -275,6 +275,29 @@ uint8_t* fizzy_get_instance_memory_data(FizzyInstance* instance);
 /// @note    Function returns memory size regardless of whether memory is exported or not.
 size_t fizzy_get_instance_memory_size(FizzyInstance* instance);
 
+/// Find exported function by name.
+///
+/// @param  instance        Pointer to instance.
+/// @param  name            The function name. NULL-terminated string. Cannot be NULL.
+/// @param  out_function    Pointer to output struct to store the found function. Cannot be NULL.
+///                         If function is found, associated context is allocated, which must exist
+///                         as long as the function can be called by some other instance, and should
+///                         be destroyed with fizzy_free_exported_function afterwards.
+///                         When function is not found (false returned), this out_function is not
+///                         modified, and fizzy_free_exported_function must not be called.
+/// @returns                true if function was found, false otherwise.
+bool fizzy_find_exported_function(
+    FizzyInstance* instance, const char* name, FizzyExternalFunction* out_function);
+
+/// Free resources associated with exported function.
+///
+/// @param  external_function   Pointer to external function struct filled by
+///                             fizzy_find_exported_function. Cannot be NULL.
+///
+/// @note   This function may not be called with external function, which was not returned from
+///         fizzy_find_exported_function.
+void fizzy_free_exported_function(FizzyExternalFunction* external_function);
+
 /// Find exported table by name.
 ///
 /// @param  instance        Pointer to instance.

--- a/include/fizzy/fizzy.h
+++ b/include/fizzy/fizzy.h
@@ -159,7 +159,7 @@ void fizzy_free_module(const FizzyModule* module);
 
 /// Get type of the function defined in the module.
 ///
-/// @param module   Pointer to module.
+/// @param module   Pointer to module. Cannot be NULL.
 /// @param func_idx Function index. Can be either index of an imported function or of a function
 ///                 defined in module. Behaviour is undefined, if index is not valid according to
 ///                 module definition.
@@ -169,7 +169,7 @@ FizzyFunctionType fizzy_get_function_type(const FizzyModule* module, uint32_t fu
 
 /// Find index of exported function by name.
 ///
-/// @param  module          Pointer to module.
+/// @param  module          Pointer to module. Cannot be NULL.
 /// @param  name            The function name. NULL-terminated string. Cannot be NULL.
 /// @param  out_func_idx    Pointer to output where function index will be stored. Cannot be NULL.
 /// @returns                true if function was found, false otherwise.
@@ -184,7 +184,7 @@ bool fizzy_find_exported_function_index(
 /// than once with the same module results in undefined behaviour), but after fizzy_instantiate
 /// functions querying module info can still be called with @p module.
 ///
-/// @param      module                   Pointer to module.
+/// @param      module                   Pointer to module. Cannot be NULL.
 /// @param      imported_functions       Pointer to the imported function array. Can be NULL iff
 ///                                      imported_functions_size equals 0.
 /// @param      imported_functions_size  Size of the imported function array. Can be zero.
@@ -223,7 +223,7 @@ FizzyInstance* fizzy_instantiate(const FizzyModule* module,
 /// than once with the same module results in undefined behaviour), but after fizzy_instantiate
 /// functions querying module info can still be called with @p module.
 ///
-/// @param      module                   Pointer to module.
+/// @param      module                   Pointer to module. Cannot be NULL.
 /// @param      imported_functions       Pointer to the imported function array. Can be NULL iff
 ///                                      imported_functions_size equals 0.
 /// @param      imported_functions_size  Size of the imported function array. Can be zero.
@@ -277,7 +277,7 @@ size_t fizzy_get_instance_memory_size(FizzyInstance* instance);
 
 /// Find exported function by name.
 ///
-/// @param  instance        Pointer to instance.
+/// @param  instance        Pointer to instance. Cannot be NULL.
 /// @param  name            The function name. NULL-terminated string. Cannot be NULL.
 /// @param  out_function    Pointer to output struct to store the found function. Cannot be NULL.
 ///                         If function is found, associated context is allocated, which must exist
@@ -300,7 +300,7 @@ void fizzy_free_exported_function(FizzyExternalFunction* external_function);
 
 /// Find exported table by name.
 ///
-/// @param  instance        Pointer to instance.
+/// @param  instance        Pointer to instance. Cannot be NULL.
 /// @param  name            The table name. NULL-terminated string. Cannot be NULL.
 /// @param  out_table       Pointer to output struct to store found table. Cannot be NULL.
 /// @returns                true if table was found, false otherwise.
@@ -311,7 +311,7 @@ bool fizzy_find_exported_table(
 
 /// Find exported memory by name.
 ///
-/// @param  instance        Pointer to instance.
+/// @param  instance        Pointer to instance. Cannot be NULL.
 /// @param  name            The table name. NULL-terminated string. Cannot be NULL.
 /// @param  out_memory      Pointer to output struct to store found memory. Cannot be NULL.
 /// @returns                true if memory was found, false otherwise.
@@ -322,7 +322,7 @@ bool fizzy_find_exported_memory(
 
 /// Find exported global by name.
 ///
-/// @param  instance        Pointer to instance.
+/// @param  instance        Pointer to instance. Cannot be NULL.
 /// @param  name            The global name. NULL-terminated string. Cannot be NULL.
 /// @param  out_global      Pointer to output struct to store found global. Cannot be NULL.
 /// @returns                true if global was found, false otherwise.
@@ -331,7 +331,7 @@ bool fizzy_find_exported_global(
 
 /// Execute module function.
 ///
-/// @param instance     Pointer to module instance.
+/// @param instance     Pointer to module instance. Cannot be NULL.
 /// @param args         Pointer to the argument array. Can be NULL if function has 0 inputs.
 /// @param depth        Call stack depth.
 ///

--- a/include/fizzy/fizzy.h
+++ b/include/fizzy/fizzy.h
@@ -173,7 +173,7 @@ FizzyFunctionType fizzy_get_function_type(const FizzyModule* module, uint32_t fu
 /// @param  name            The function name. NULL-terminated string. Cannot be NULL.
 /// @param  out_func_idx    Pointer to output where function index will be stored. Cannot be NULL.
 /// @returns                true if function was found, false otherwise.
-bool fizzy_find_exported_function(
+bool fizzy_find_exported_function_index(
     const FizzyModule* module, const char* name, uint32_t* out_func_idx);
 
 /// Instantiate a module.

--- a/lib/fizzy/capi.cpp
+++ b/lib/fizzy/capi.cpp
@@ -120,6 +120,21 @@ inline auto unwrap(FizzyExternalFn func, void* context) noexcept
     };
 }
 
+inline FizzyExternalFunction wrap(fizzy::ExternalFunction external_func)
+{
+    static constexpr FizzyExternalFn c_function = [](void* context, FizzyInstance* instance,
+                                                      const FizzyValue* args,
+                                                      int depth) -> FizzyExecutionResult {
+        auto* func = static_cast<fizzy::ExternalFunction*>(context);
+        return wrap((func->function)(*unwrap(instance), unwrap(args), depth));
+    };
+
+    auto context = std::make_unique<fizzy::ExternalFunction>(std::move(external_func));
+    const auto c_type = wrap(context->type);
+    void* c_context = context.release();
+    return {c_type, c_function, c_context};
+}
+
 inline fizzy::ExternalFunction unwrap(const FizzyExternalFunction& external_func)
 {
     return fizzy::ExternalFunction{
@@ -307,6 +322,22 @@ bool fizzy_find_exported_function_index(
 
     *out_func_idx = *optional_func_idx;
     return true;
+}
+
+bool fizzy_find_exported_function(
+    FizzyInstance* instance, const char* name, FizzyExternalFunction* out_function)
+{
+    auto optional_func = fizzy::find_exported_function(*unwrap(instance), name);
+    if (!optional_func)
+        return false;
+
+    *out_function = wrap(std::move(*optional_func));
+    return true;
+}
+
+void fizzy_free_exported_function(FizzyExternalFunction* external_function)
+{
+    delete static_cast<fizzy::ExternalFunction*>(external_function->context);
 }
 
 bool fizzy_find_exported_table(

--- a/lib/fizzy/capi.cpp
+++ b/lib/fizzy/capi.cpp
@@ -298,7 +298,7 @@ FizzyFunctionType fizzy_get_function_type(const FizzyModule* module, uint32_t fu
     return wrap(unwrap(module)->get_function_type(func_idx));
 }
 
-bool fizzy_find_exported_function(
+bool fizzy_find_exported_function_index(
     const FizzyModule* module, const char* name, uint32_t* out_func_idx)
 {
     const auto optional_func_idx = fizzy::find_exported_function(*unwrap(module), name);

--- a/test/unittests/capi_test.cpp
+++ b/test/unittests/capi_test.cpp
@@ -69,7 +69,7 @@ TEST(capi, get_function_type)
     fizzy_free_module(module);
 }
 
-TEST(capi, find_exported_function)
+TEST(capi, find_exported_function_index)
 {
     /* wat2wasm
     (module
@@ -87,13 +87,13 @@ TEST(capi, find_exported_function)
     ASSERT_NE(module, nullptr);
 
     uint32_t func_idx;
-    EXPECT_TRUE(fizzy_find_exported_function(module, "foo", &func_idx));
+    EXPECT_TRUE(fizzy_find_exported_function_index(module, "foo", &func_idx));
     EXPECT_EQ(func_idx, 0);
 
-    EXPECT_FALSE(fizzy_find_exported_function(module, "bar", &func_idx));
-    EXPECT_FALSE(fizzy_find_exported_function(module, "g1", &func_idx));
-    EXPECT_FALSE(fizzy_find_exported_function(module, "tab", &func_idx));
-    EXPECT_FALSE(fizzy_find_exported_function(module, "mem", &func_idx));
+    EXPECT_FALSE(fizzy_find_exported_function_index(module, "bar", &func_idx));
+    EXPECT_FALSE(fizzy_find_exported_function_index(module, "g1", &func_idx));
+    EXPECT_FALSE(fizzy_find_exported_function_index(module, "tab", &func_idx));
+    EXPECT_FALSE(fizzy_find_exported_function_index(module, "mem", &func_idx));
 
     fizzy_free_module(module);
 }
@@ -731,7 +731,7 @@ TEST(capi, imported_function_from_another_module)
     ASSERT_NE(module2, nullptr);
 
     uint32_t func_idx;
-    ASSERT_TRUE(fizzy_find_exported_function(module1, "sub", &func_idx));
+    ASSERT_TRUE(fizzy_find_exported_function_index(module1, "sub", &func_idx));
 
     auto host_context = std::make_pair(instance1, func_idx);
 

--- a/test/utils/fizzy_c_engine.cpp
+++ b/test/utils/fizzy_c_engine.cpp
@@ -97,7 +97,7 @@ std::optional<WasmEngine::FuncRef> FizzyCEngine::find_function(
     std::string_view name, std::string_view /*signature*/) const
 {
     uint32_t func_idx;
-    if (!fizzy_find_exported_function(
+    if (!fizzy_find_exported_function_index(
             fizzy_get_instance_module(m_instance.get()), std::string{name}.c_str(), &func_idx))
         return std::nullopt;
 


### PR DESCRIPTION
I'm not completely sure it's a good idea to include this, because complications with context can be confusing, but the motivation is 
1. to make it simpler to import exported function into another module - see `capi.imported_function_from_anothe_module` test change.
2. symmetry with C++ API `fizzy::find_exported_*` functions.