### PR TITLE
api: resolving imported globals

### DIFF
--- a/lib/fizzy/instantiate.cpp
+++ b/lib/fizzy/instantiate.cpp
@@ -375,7 +375,7 @@ std::unique_ptr<Instance> instantiate(std::unique_ptr<const Module> module,
 }
 
 std::vector<ExternalFunction> resolve_imported_functions(
-    const Module& module, std::vector<ImportedFunction> imported_functions)
+    const Module& module, const std::vector<ImportedFunction>& imported_functions)
 {
     std::vector<ExternalFunction> external_functions;
     for (const auto& import : module.importsec)

--- a/lib/fizzy/instantiate.cpp
+++ b/lib/fizzy/instantiate.cpp
@@ -233,6 +233,37 @@ Value eval_constant_expression(ConstantExpression expr,
         return globals[global_idx - imported_globals.size()];
 }
 
+ExternalFunction find_imported_function(const std::string& module, const std::string& name,
+    const FuncType& module_func_type, const std::vector<ImportedFunction>& imported_functions)
+{
+    const auto it = std::find_if(imported_functions.begin(), imported_functions.end(),
+        [module, name](const auto& func) { return module == func.module && name == func.name; });
+
+    if (it == imported_functions.end())
+    {
+        throw instantiate_error{"imported function " + module + "." + name + " is required"};
+    }
+
+    if (module_func_type.inputs != it->inputs)
+    {
+        throw instantiate_error{"function " + module + "." + name +
+                                " input types don't match imported function in module"};
+    }
+    if (module_func_type.outputs.empty() && it->output.has_value())
+    {
+        throw instantiate_error{
+            "function " + module + "." + name + " has output but is defined void in module"};
+    }
+    if (!module_func_type.outputs.empty() &&
+        (!it->output.has_value() || module_func_type.outputs[0] != *it->output))
+    {
+        throw instantiate_error{"function " + module + "." + name +
+                                " output type doesn't match imported function in module"};
+    }
+
+    return {it->function, module_func_type};
+}
+
 std::optional<uint32_t> find_export(const Module& module, ExternalKind kind, std::string_view name)
 {
     const auto it = std::find_if(module.exportsec.begin(), module.exportsec.end(),
@@ -383,40 +414,12 @@ std::vector<ExternalFunction> resolve_imported_functions(
         if (import.kind != ExternalKind::Function)
             continue;
 
-        const auto it = std::find_if(
-            imported_functions.begin(), imported_functions.end(), [&import](const auto& func) {
-                return import.module == func.module && import.name == func.name;
-            });
-
-        if (it == imported_functions.end())
-        {
-            throw instantiate_error{
-                "imported function " + import.module + "." + import.name + " is required"};
-        }
-
         assert(import.desc.function_type_index < module.typesec.size());
         const auto& module_func_type = module.typesec[import.desc.function_type_index];
 
-        if (module_func_type.inputs != it->inputs)
-        {
-            throw instantiate_error{"function " + import.module + "." + import.name +
-                                    " input types don't match imported function in module"};
-        }
-        if (module_func_type.outputs.empty() && it->output.has_value())
-        {
-            throw instantiate_error{"function " + import.module + "." + import.name +
-                                    " has output but is defined void in module"};
-        }
-        if (!module_func_type.outputs.empty() &&
-            (!it->output.has_value() || module_func_type.outputs[0] != *it->output))
-        {
-            throw instantiate_error{"function " + import.module + "." + import.name +
-                                    " output type doesn't match imported function in module"};
-        }
-
-        external_functions.emplace_back(ExternalFunction{it->function, module_func_type});
+        external_functions.emplace_back(find_imported_function(
+            import.module, import.name, module_func_type, imported_functions));
     }
-
     return external_functions;
 }
 

--- a/lib/fizzy/instantiate.hpp
+++ b/lib/fizzy/instantiate.hpp
@@ -137,6 +137,22 @@ struct ImportedFunction
 std::vector<ExternalFunction> resolve_imported_functions(
     const Module& module, const std::vector<ImportedFunction>& imported_functions);
 
+// Global that should be used by instantiate as import, identified by module and global name.
+struct ImportedGlobal
+{
+    std::string module;
+    std::string name;
+    Value* value = nullptr;
+    ValType type = ValType::i32;
+    bool is_mutable = false;
+};
+
+// Create vector of ExternalGlobals ready to be passed to instantiate.
+// imported_globals may be in any order, but must contain globals for all of the imported global
+// names defined in the module.
+std::vector<ExternalGlobal> resolve_imported_globals(
+    const Module& module, const std::vector<ImportedGlobal>& imported_globals);
+
 /// Find exported function index by name.
 std::optional<FuncIdx> find_exported_function(const Module& module, std::string_view name);
 

--- a/lib/fizzy/instantiate.hpp
+++ b/lib/fizzy/instantiate.hpp
@@ -121,7 +121,7 @@ std::unique_ptr<Instance> instantiate(std::unique_ptr<const Module> module,
     std::vector<ExternalGlobal> imported_globals = {},
     uint32_t memory_pages_limit = DefaultMemoryPagesLimit);
 
-/// Function that should be used by instantiate as imports, identified by module and function name.
+/// Function that should be used by instantiate as import, identified by module and function name.
 struct ImportedFunction
 {
     std::string module;
@@ -135,7 +135,7 @@ struct ImportedFunction
 /// @a imported_functions may be in any order, but must contain functions for all of the imported
 /// function names defined in the module.
 std::vector<ExternalFunction> resolve_imported_functions(
-    const Module& module, std::vector<ImportedFunction> imported_functions);
+    const Module& module, const std::vector<ImportedFunction>& imported_functions);
 
 /// Find exported function index by name.
 std::optional<FuncIdx> find_exported_function(const Module& module, std::string_view name);

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -82,15 +82,14 @@ TEST(api, resolve_imported_functions)
         "04666f6f320001046d6f643204666f6f310001046d6f643204666f6f320002046d6f64310167037f00");
     const auto module = parse(wasm);
 
-    std::vector<ImportedFunction> imported_functions = {
+    const std::vector<ImportedFunction> imported_functions = {
         {"mod1", "foo1", {}, ValType::i32, function_returning_value(0)},
         {"mod1", "foo2", {ValType::i32}, ValType::i32, function_returning_value(1)},
         {"mod2", "foo1", {ValType::i32}, ValType::i32, function_returning_value(2)},
         {"mod2", "foo2", {ValType::i64, ValType::i32}, std::nullopt, function_returning_void},
     };
 
-    const auto external_functions =
-        resolve_imported_functions(*module, std::move(imported_functions));
+    const auto external_functions = resolve_imported_functions(*module, imported_functions);
 
     EXPECT_EQ(external_functions.size(), 4);
 
@@ -105,7 +104,7 @@ TEST(api, resolve_imported_functions)
     EXPECT_THAT(execute(*instance, 3, {0_u64, 0_u32}), Result());
 
 
-    std::vector<ImportedFunction> imported_functions_reordered = {
+    const std::vector<ImportedFunction> imported_functions_reordered = {
         {"mod2", "foo1", {ValType::i32}, ValType::i32, function_returning_value(2)},
         {"mod1", "foo2", {ValType::i32}, ValType::i32, function_returning_value(1)},
         {"mod1", "foo1", {}, ValType::i32, function_returning_value(0)},
@@ -113,11 +112,11 @@ TEST(api, resolve_imported_functions)
     };
 
     const auto external_functions_reordered =
-        resolve_imported_functions(*module, std::move(imported_functions_reordered));
+        resolve_imported_functions(*module, imported_functions_reordered);
     EXPECT_EQ(external_functions_reordered.size(), 4);
 
-    auto instance_reordered = instantiate(*module, external_functions_reordered, {}, {},
-        std::vector<ExternalGlobal>(external_globals));
+    auto instance_reordered =
+        instantiate(*module, external_functions_reordered, {}, {}, external_globals);
 
     EXPECT_THAT(execute(*instance_reordered, 0, {}), Result(0));
     EXPECT_THAT(execute(*instance_reordered, 1, {0_u32}), Result(1));
@@ -125,7 +124,7 @@ TEST(api, resolve_imported_functions)
     EXPECT_THAT(execute(*instance_reordered, 3, {0_u64, 0_u32}), Result());
 
 
-    std::vector<ImportedFunction> imported_functions_extra = {
+    const std::vector<ImportedFunction> imported_functions_extra = {
         {"mod1", "foo1", {}, ValType::i32, function_returning_value(0)},
         {"mod1", "foo2", {ValType::i32}, ValType::i32, function_returning_value(1)},
         {"mod2", "foo1", {ValType::i32}, ValType::i32, function_returning_value(2)},
@@ -135,11 +134,10 @@ TEST(api, resolve_imported_functions)
     };
 
     const auto external_functions_extra =
-        resolve_imported_functions(*module, std::move(imported_functions_extra));
+        resolve_imported_functions(*module, imported_functions_extra);
     EXPECT_EQ(external_functions_extra.size(), 4);
 
-    auto instance_extra = instantiate(
-        *module, external_functions_extra, {}, {}, std::vector<ExternalGlobal>(external_globals));
+    auto instance_extra = instantiate(*module, external_functions_extra, {}, {}, external_globals);
 
     EXPECT_THAT(execute(*instance_extra, 0, {}), Result(0));
     EXPECT_THAT(execute(*instance_extra, 1, {0_u32}), Result(1));
@@ -147,48 +145,45 @@ TEST(api, resolve_imported_functions)
     EXPECT_THAT(execute(*instance_extra, 3, {0_u64, 0_u32}), Result());
 
 
-    std::vector<ImportedFunction> imported_functions_missing = {
+    const std::vector<ImportedFunction> imported_functions_missing = {
         {"mod1", "foo1", {}, ValType::i32, function_returning_value(0)},
         {"mod1", "foo2", {ValType::i32}, ValType::i32, function_returning_value(1)},
         {"mod2", "foo1", {ValType::i32}, ValType::i32, function_returning_value(2)},
     };
 
-    EXPECT_THROW_MESSAGE(resolve_imported_functions(*module, std::move(imported_functions_missing)),
+    EXPECT_THROW_MESSAGE(resolve_imported_functions(*module, imported_functions_missing),
         instantiate_error, "imported function mod2.foo2 is required");
 
 
-    std::vector<ImportedFunction> imported_functions_invalid_type1 = {
+    const std::vector<ImportedFunction> imported_functions_invalid_type1 = {
         {"mod1", "foo1", {ValType::i32}, ValType::i32, function_returning_value(0)},
         {"mod1", "foo2", {ValType::i32}, ValType::i32, function_returning_value(1)},
         {"mod2", "foo1", {ValType::i32}, ValType::i32, function_returning_value(2)},
         {"mod2", "foo2", {ValType::i64, ValType::i32}, std::nullopt, function_returning_void},
     };
 
-    EXPECT_THROW_MESSAGE(
-        resolve_imported_functions(*module, std::move(imported_functions_invalid_type1)),
+    EXPECT_THROW_MESSAGE(resolve_imported_functions(*module, imported_functions_invalid_type1),
         instantiate_error,
         "function mod1.foo1 input types don't match imported function in module");
 
-    std::vector<ImportedFunction> imported_functions_invalid_type2 = {
+    const std::vector<ImportedFunction> imported_functions_invalid_type2 = {
         {"mod1", "foo1", {}, ValType::i32, function_returning_value(0)},
         {"mod1", "foo2", {ValType::i32}, ValType::i32, function_returning_value(1)},
         {"mod2", "foo1", {ValType::i32}, ValType::i32, function_returning_value(2)},
         {"mod2", "foo2", {ValType::i64, ValType::i32}, ValType::i64, function_returning_value(3)},
     };
 
-    EXPECT_THROW_MESSAGE(
-        resolve_imported_functions(*module, std::move(imported_functions_invalid_type2)),
+    EXPECT_THROW_MESSAGE(resolve_imported_functions(*module, imported_functions_invalid_type2),
         instantiate_error, "function mod2.foo2 has output but is defined void in module");
 
-    std::vector<ImportedFunction> imported_functions_invalid_type3 = {
+    const std::vector<ImportedFunction> imported_functions_invalid_type3 = {
         {"mod1", "foo1", {}, ValType::i32, function_returning_value(0)},
         {"mod1", "foo2", {ValType::i32}, ValType::i64, function_returning_value(1)},
         {"mod2", "foo1", {ValType::i32}, ValType::i32, function_returning_value(2)},
         {"mod2", "foo2", {ValType::i64, ValType::i32}, std::nullopt, function_returning_void},
     };
 
-    EXPECT_THROW_MESSAGE(
-        resolve_imported_functions(*module, std::move(imported_functions_invalid_type3)),
+    EXPECT_THROW_MESSAGE(resolve_imported_functions(*module, imported_functions_invalid_type3),
         instantiate_error,
         "function mod1.foo2 output type doesn't match imported function in module");
 }
@@ -207,8 +202,7 @@ TEST(api, resolve_imported_function_duplicate)
         {"mod1", "foo1", {ValType::i32}, ValType::i32, function_returning_value(42)},
     };
 
-    const auto external_functions =
-        resolve_imported_functions(*module, std::move(imported_functions));
+    const auto external_functions = resolve_imported_functions(*module, imported_functions);
 
     EXPECT_EQ(external_functions.size(), 2);
 

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -212,6 +212,150 @@ TEST(api, resolve_imported_function_duplicate)
     EXPECT_THAT(execute(*instance, 1, {0_u32}), Result(42));
 }
 
+TEST(api, resolve_imported_globals)
+{
+    /* wat2wasm
+      (global (import "mod1" "g1") i32)
+      (global (import "mod1" "g2") (mut i32))
+      (global (import "mod2" "g1") i64)
+      (global (import "mod2" "g2") (mut i64))
+      (func (import "mod1" "foo1")
+        (param i32) (result i32)) ;; just to test combination with other import types
+      (func (result i32) (global.get 0))
+      (func (result i32) (global.get 1))
+      (func (result i64) (global.get 2))
+      (func (result i64) (global.get 3))
+   */
+    const auto wasm = from_hex(
+        "0061736d01000000010e0360017f017f6000017f6000017e023905046d6f6431026731037f00046d6f64310267"
+        "32037f01046d6f6432026731037e00046d6f6432026732037e01046d6f643104666f6f31000003050401010202"
+        "0a1504040023000b040023010b040023020b040023030b");
+    const auto module = parse(wasm);
+
+    std::vector<ImportedFunction> imported_functions = {
+        {"mod1", "foo1", {ValType::i32}, ValType::i32, function_returning_value(1)},
+    };
+    const auto external_functions = resolve_imported_functions(*module, imported_functions);
+    EXPECT_EQ(external_functions.size(), 1);
+
+    Value global1{42};
+    Value global2{43};
+    Value global3{44};
+    Value global4{45};
+    const std::vector<ImportedGlobal> imported_globals = {
+        {"mod1", "g1", &global1, ValType::i32, false},
+        {"mod1", "g2", &global2, ValType::i32, true},
+        {"mod2", "g1", &global3, ValType::i64, false},
+        {"mod2", "g2", &global4, ValType::i64, true},
+    };
+
+    const auto external_globals = resolve_imported_globals(*module, imported_globals);
+    EXPECT_EQ(external_globals.size(), 4);
+
+    auto instance = instantiate(*module, external_functions, {}, {}, external_globals);
+
+    EXPECT_THAT(execute(*instance, 1, {}), Result(42));
+    EXPECT_THAT(execute(*instance, 2, {}), Result(43));
+    EXPECT_THAT(execute(*instance, 3, {}), Result(44));
+    EXPECT_THAT(execute(*instance, 4, {}), Result(45));
+
+    const std::vector<ImportedGlobal> imported_globals_reordered = {
+        {"mod2", "g1", &global3, ValType::i64, false},
+        {"mod1", "g2", &global2, ValType::i32, true},
+        {"mod1", "g1", &global1, ValType::i32, false},
+        {"mod2", "g2", &global4, ValType::i64, true},
+    };
+    const auto external_globals_reordered =
+        resolve_imported_globals(*module, imported_globals_reordered);
+    EXPECT_EQ(external_globals_reordered.size(), 4);
+
+    auto instance_reordered =
+        instantiate(*module, external_functions, {}, {}, external_globals_reordered);
+
+    EXPECT_THAT(execute(*instance_reordered, 1, {}), Result(42));
+    EXPECT_THAT(execute(*instance_reordered, 2, {}), Result(43));
+    EXPECT_THAT(execute(*instance_reordered, 3, {}), Result(44));
+    EXPECT_THAT(execute(*instance_reordered, 4, {}), Result(45));
+
+    Value global5{46};
+    Value global6{47};
+    const std::vector<ImportedGlobal> imported_globals_extra = {
+        {"mod1", "g1", &global1, ValType::i32, false},
+        {"mod1", "g2", &global2, ValType::i32, true},
+        {"mod2", "g1", &global3, ValType::i64, false},
+        {"mod2", "g2", &global4, ValType::i64, true},
+        {"mod3", "g1", &global5, ValType::i32, false},
+        {"mod3", "g2", &global6, ValType::i32, true},
+    };
+
+    const auto external_globals_extra = resolve_imported_globals(*module, imported_globals_extra);
+    EXPECT_EQ(external_globals_extra.size(), 4);
+
+    auto instance_extra = instantiate(*module, external_functions, {}, {}, external_globals_extra);
+
+    EXPECT_THAT(execute(*instance_reordered, 1, {}), Result(42));
+    EXPECT_THAT(execute(*instance_reordered, 2, {}), Result(43));
+    EXPECT_THAT(execute(*instance_reordered, 3, {}), Result(44));
+    EXPECT_THAT(execute(*instance_reordered, 4, {}), Result(45));
+
+    const std::vector<ImportedGlobal> imported_globals_missing = {
+        {"mod2", "g1", &global3, ValType::i64, false},
+        {"mod1", "g2", &global2, ValType::i32, true},
+        {"mod1", "g1", &global1, ValType::i32, false},
+    };
+
+    EXPECT_THROW_MESSAGE(resolve_imported_globals(*module, imported_globals_missing),
+        instantiate_error, "imported global mod2.g2 is required");
+
+    const std::vector<ImportedGlobal> imported_globals_invalid_type = {
+        {"mod1", "g1", &global1, ValType::i64, false},
+        {"mod1", "g2", &global2, ValType::i32, true},
+        {"mod2", "g1", &global3, ValType::i64, false},
+        {"mod2", "g2", &global4, ValType::i64, true},
+    };
+
+    EXPECT_THROW_MESSAGE(resolve_imported_globals(*module, imported_globals_invalid_type),
+        instantiate_error, "global mod1.g1 value type doesn't match imported global in module");
+
+    const std::vector<ImportedGlobal> imported_globals_invalid_mutability = {
+        {"mod1", "g1", &global1, ValType::i32, true},
+        {"mod1", "g2", &global2, ValType::i32, true},
+        {"mod2", "g1", &global3, ValType::i64, false},
+        {"mod2", "g2", &global4, ValType::i64, true},
+    };
+
+    EXPECT_THROW_MESSAGE(resolve_imported_globals(*module, imported_globals_invalid_mutability),
+        instantiate_error, "global mod1.g1 mutability doesn't match imported global in module");
+}
+
+TEST(api, resolve_imported_global_duplicate)
+{
+    /* wat2wasm
+      (global (import "mod1" "g1") i32)
+      (global (import "mod1" "g1") i32)
+      (func (result i32) (global.get 0))
+      (func (result i32) (global.get 1))
+    */
+    const auto wasm = from_hex(
+        "0061736d010000000105016000017f021702046d6f6431026731037f00046d6f6431026731037f000303020000"
+        "0a0b02040023000b040023010b");
+    const auto module = parse(wasm);
+
+    Value global1{42};
+    const std::vector<ImportedGlobal> imported_globals = {
+        {"mod1", "g1", &global1, ValType::i32, false},
+    };
+
+    const auto external_globals = resolve_imported_globals(*module, imported_globals);
+
+    EXPECT_EQ(external_globals.size(), 2);
+
+    auto instance = instantiate(*module, {}, {}, {}, external_globals);
+
+    EXPECT_THAT(execute(*instance, 0, {}), Result(42));
+    EXPECT_THAT(execute(*instance, 1, {}), Result(42));
+}
+
 TEST(api, find_exported_function_index)
 {
     Module module;


### PR DESCRIPTION
~~This extends `resolve_imported_functions` function into supporting all kinds of imports.~~

I decided to leave here only support for imported globals. Resolving imported table and memory doesn't seem very useful, becasue there's always at most one of each. I suggest to postpone that till we see there's real need to resolve them.

C API part will be in another PR.