### PR TITLE
CI: Coverage flags

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -170,6 +170,9 @@ commands:
 
   upload_coverage:
     description: "Upload coverage data"
+    parameters:
+      flags:
+        type: string
     steps:
       - run:
           name: "Upgrade codecov"
@@ -181,7 +184,7 @@ commands:
             sed -i 's|$(pwd)/||' ~/build/coverage.lcov
 
             counter=1
-            until codecov --required --file ~/build/coverage.lcov -X gcov || [ $counter = 5 ]; do
+            until codecov --flags <<parameters.flags>> --required --file ~/build/coverage.lcov -X gcov || [ $counter = 5 ]; do
               counter=$((counter+1))
               sleep 1
               echo "Try #$counter..."
@@ -377,7 +380,8 @@ jobs:
       - store_artifacts:
           path: ~/build/coverage
           destination: coverage
-      - upload_coverage
+      - upload_coverage:
+          flags: unittests
 
   sanitizers-clang:
     executor: linux-clang-latest

--- a/circle.yml
+++ b/circle.yml
@@ -138,6 +138,18 @@ commands:
           working_directory: ~/build
           command: ctest -E 'unittests|smoketests' -j4 --schedule-random --output-on-failure
 
+  collect_coverage_gcc:
+    description: "Collect coverage data (GCC)"
+    steps:
+      - run:
+          name: "Collect coverage data (GCC)"
+          working_directory: ~/build
+          command: |
+            lcov --capture --directory . --output-file coverage.lcov --exclude='/usr/include/*' --exclude="$HOME/.hunter/*" --exclude="$PWD/_deps/*"
+            lcov --zerocounters --directory .
+            rm -rf coverage
+            genhtml coverage.lcov --output-directory coverage --title Fizzy
+
   collect_coverage_clang:
     description: "Collect coverage data (Clang)"
     parameters:
@@ -371,17 +383,19 @@ jobs:
           configuration_name: "Coverage"
           build_type: Coverage
       - test
-      - run:
-          name: "Create coverage report"
-          working_directory: ~/build
-          command: |
-            lcov -c -d . -o coverage.lcov --exclude='/usr/include/*' --exclude="$HOME/.hunter/*" --exclude="$PWD/_deps/*"
-            genhtml coverage.lcov -o coverage -t Fizzy
+      - collect_coverage_gcc
       - store_artifacts:
           path: ~/build/coverage
-          destination: coverage
+          destination: coverage-unittests
       - upload_coverage:
           flags: unittests
+      - spectest
+      - collect_coverage_gcc
+      - store_artifacts:
+          path: ~/build/coverage
+          destination: coverage-spectests
+      - upload_coverage:
+          flags: spectests
 
   sanitizers-clang:
     executor: linux-clang-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,14 @@
 codecov:
-  require_ci_to_pass: yes
+  require_ci_to_pass: false
 
 coverage:
   status:
-    project: no
-    patch: no
+    project: false
+    patch: false
 
 comment:
-  layout: "diff"
+  layout: "diff, flags, files"
+
+flags:
+  spectests:
+    joined: false


### PR DESCRIPTION
- Upload coverage from internal tests with "unittests" flag.
- Upload coverage from spectests with "spectests" flag.
- Show the coverage for each flag in the Codecov Report comment.
See #644.