### PR TITLE
test: Check the types of execution arguments

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -296,6 +296,7 @@ jobs:
             ./wat2wasm4cpp.py test/unittests/execute_call_test.cpp
             ./wat2wasm4cpp.py test/unittests/execute_control_test.cpp
             ./wat2wasm4cpp.py test/unittests/execute_floating_point_test.cpp
+            ./wat2wasm4cpp.py test/unittests/execute_invalid_test.cpp
             ./wat2wasm4cpp.py test/unittests/execute_numeric_test.cpp
             ./wat2wasm4cpp.py test/unittests/execute_test.cpp
             ./wat2wasm4cpp.py test/unittests/instantiate_test.cpp

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(
     execute_floating_point_conversion_test.cpp
     execute_floating_point_test.cpp
     execute_floating_point_test.hpp
+    execute_invalid_test.cpp
     execute_numeric_test.cpp
     execute_test.cpp
     floating_point_utils_test.cpp

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -102,7 +102,7 @@ TEST(api, resolve_imported_functions)
     EXPECT_THAT(execute(*instance, 0, {}), Result(0));
     EXPECT_THAT(execute(*instance, 1, {0_u32}), Result(1));
     EXPECT_THAT(execute(*instance, 2, {0_u32}), Result(2));
-    EXPECT_THAT(execute(*instance, 3, {0, 0}), Result());
+    EXPECT_THAT(execute(*instance, 3, {0_u64, 0_u32}), Result());
 
 
     std::vector<ImportedFunction> imported_functions_reordered = {
@@ -122,7 +122,7 @@ TEST(api, resolve_imported_functions)
     EXPECT_THAT(execute(*instance_reordered, 0, {}), Result(0));
     EXPECT_THAT(execute(*instance_reordered, 1, {0_u32}), Result(1));
     EXPECT_THAT(execute(*instance_reordered, 2, {0_u32}), Result(2));
-    EXPECT_THAT(execute(*instance_reordered, 3, {0, 0}), Result());
+    EXPECT_THAT(execute(*instance_reordered, 3, {0_u64, 0_u32}), Result());
 
 
     std::vector<ImportedFunction> imported_functions_extra = {
@@ -144,7 +144,7 @@ TEST(api, resolve_imported_functions)
     EXPECT_THAT(execute(*instance_extra, 0, {}), Result(0));
     EXPECT_THAT(execute(*instance_extra, 1, {0_u32}), Result(1));
     EXPECT_THAT(execute(*instance_extra, 2, {0_u32}), Result(2));
-    EXPECT_THAT(execute(*instance_extra, 3, {0, 0}), Result());
+    EXPECT_THAT(execute(*instance_extra, 3, {0_u64, 0_u32}), Result());
 
 
     std::vector<ImportedFunction> imported_functions_missing = {

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -100,8 +100,8 @@ TEST(api, resolve_imported_functions)
         *module, external_functions, {}, {}, std::vector<ExternalGlobal>(external_globals));
 
     EXPECT_THAT(execute(*instance, 0, {}), Result(0));
-    EXPECT_THAT(execute(*instance, 1, {Value{0}}), Result(1));
-    EXPECT_THAT(execute(*instance, 2, {Value{0}}), Result(2));
+    EXPECT_THAT(execute(*instance, 1, {0_u32}), Result(1));
+    EXPECT_THAT(execute(*instance, 2, {0_u32}), Result(2));
     EXPECT_THAT(execute(*instance, 3, {0, 0}), Result());
 
 
@@ -120,8 +120,8 @@ TEST(api, resolve_imported_functions)
         std::vector<ExternalGlobal>(external_globals));
 
     EXPECT_THAT(execute(*instance_reordered, 0, {}), Result(0));
-    EXPECT_THAT(execute(*instance_reordered, 1, {Value{0}}), Result(1));
-    EXPECT_THAT(execute(*instance_reordered, 2, {Value{0}}), Result(2));
+    EXPECT_THAT(execute(*instance_reordered, 1, {0_u32}), Result(1));
+    EXPECT_THAT(execute(*instance_reordered, 2, {0_u32}), Result(2));
     EXPECT_THAT(execute(*instance_reordered, 3, {0, 0}), Result());
 
 
@@ -142,8 +142,8 @@ TEST(api, resolve_imported_functions)
         *module, external_functions_extra, {}, {}, std::vector<ExternalGlobal>(external_globals));
 
     EXPECT_THAT(execute(*instance_extra, 0, {}), Result(0));
-    EXPECT_THAT(execute(*instance_extra, 1, {Value{0}}), Result(1));
-    EXPECT_THAT(execute(*instance_extra, 2, {Value{0}}), Result(2));
+    EXPECT_THAT(execute(*instance_extra, 1, {0_u32}), Result(1));
+    EXPECT_THAT(execute(*instance_extra, 2, {0_u32}), Result(2));
     EXPECT_THAT(execute(*instance_extra, 3, {0, 0}), Result());
 
 
@@ -214,8 +214,8 @@ TEST(api, resolve_imported_function_duplicate)
 
     auto instance = instantiate(*module, external_functions, {}, {}, {});
 
-    EXPECT_THAT(execute(*instance, 0, {Value{0}}), Result(42));
-    EXPECT_THAT(execute(*instance, 1, {Value{0}}), Result(42));
+    EXPECT_THAT(execute(*instance, 0, {0_u32}), Result(42));
+    EXPECT_THAT(execute(*instance, 1, {0_u32}), Result(42));
 }
 
 TEST(api, find_exported_function_index)

--- a/test/unittests/execute_control_test.cpp
+++ b/test/unittests/execute_control_test.cpp
@@ -66,7 +66,7 @@ TEST(execute_control, loop_void)
     */
     const auto wasm =
         from_hex("0061736d0100000001070160027e7e017e030201000a0d010b000340200021010b20010b");
-    const auto result = execute(parse(wasm), 0, {1, 0});
+    const auto result = execute(parse(wasm), 0, {1_u64, 0_u64});
     EXPECT_THAT(result, Result(1));
 }
 

--- a/test/unittests/execute_floating_point_test.cpp
+++ b/test/unittests/execute_floating_point_test.cpp
@@ -1049,7 +1049,7 @@ TEST(execute_floating_point, f32_load_overflow)
     auto instance = instantiate(parse(wasm));
 
     // Offset is 0x7fffffff + 0 => 0x7fffffff
-    EXPECT_THAT(execute(*instance, 0, {Value{0}}), Traps());
+    EXPECT_THAT(execute(*instance, 0, {0_u32}), Traps());
     // Offset is 0x7fffffff + 0x80000000 => 0xffffffff
     EXPECT_THAT(execute(*instance, 0, {0x80000000}), Traps());
     // Offset is 0x7fffffff + 0x80000001 => 0x100000000
@@ -1122,7 +1122,7 @@ TEST(execute_floating_point, f64_load_overflow)
     auto instance = instantiate(parse(wasm));
 
     // Offset is 0x7fffffff + 0 => 0x7fffffff
-    EXPECT_THAT(execute(*instance, 0, {Value{0}}), Traps());
+    EXPECT_THAT(execute(*instance, 0, {0_u32}), Traps());
     // Offset is 0x7fffffff + 0x80000000 => 0xffffffff
     EXPECT_THAT(execute(*instance, 0, {0x80000000}), Traps());
     // Offset is 0x7fffffff + 0x80000001 => 0x100000000
@@ -1199,7 +1199,7 @@ TEST(execute_floating_point, f32_store_overflow)
     auto instance = instantiate(parse(wasm));
 
     // Offset is 0x7fffffff + 0 => 0x7fffffff
-    EXPECT_THAT(execute(*instance, 0, {Value{0}}), Traps());
+    EXPECT_THAT(execute(*instance, 0, {0_u32}), Traps());
     // Offset is 0x7fffffff + 0x80000000 => 0xffffffff
     EXPECT_THAT(execute(*instance, 0, {0x80000000}), Traps());
     // Offset is 0x7fffffff + 0x80000001 => 0x100000000
@@ -1276,7 +1276,7 @@ TEST(execute_floating_point, f64_store_overflow)
     auto instance = instantiate(parse(wasm));
 
     // Offset is 0x7fffffff + 0 => 0x7fffffff
-    EXPECT_THAT(execute(*instance, 0, {Value{0}}), Traps());
+    EXPECT_THAT(execute(*instance, 0, {0_u32}), Traps());
     // Offset is 0x7fffffff + 0x80000000 => 0xffffffff
     EXPECT_THAT(execute(*instance, 0, {0x80000000}), Traps());
     // Offset is 0x7fffffff + 0x80000001 => 0x100000000

--- a/test/unittests/execute_invalid_test.cpp
+++ b/test/unittests/execute_invalid_test.cpp
@@ -1,0 +1,63 @@
+// Fizzy: A fast WebAssembly interpreter
+// Copyright 2020 The Fizzy Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "parser.hpp"
+#include <gtest/gtest.h>
+#include <test/utils/asserts.hpp>
+#include <test/utils/execute_helpers.hpp>
+#include <test/utils/hex.hpp>
+
+using namespace fizzy;
+using namespace fizzy::test;
+
+TEST(execute_invalid, invalid_number_of_arguments)
+{
+    /* wat2wasm
+    (func)
+    (func (param i32))
+    (func (param f32 f32))
+    */
+    const auto wasm = from_hex(
+        "0061736d01000000010d0360000060017f0060027d7d000304030001020a0a0302000b02000b02000b");
+
+    auto instance = instantiate(parse(wasm));
+
+    EXPECT_THROW_MESSAGE(
+        execute(*instance, 0, {1_u32}), std::invalid_argument, "too many arguments");
+
+    EXPECT_THROW_MESSAGE(execute(*instance, 1, {}), std::invalid_argument, "too few arguments");
+    EXPECT_THROW_MESSAGE(
+        execute(*instance, 1, {1_u32, 2_u32}), std::invalid_argument, "too many arguments");
+
+    EXPECT_THROW_MESSAGE(execute(*instance, 2, {}), std::invalid_argument, "too few arguments");
+    EXPECT_THROW_MESSAGE(execute(*instance, 2, {0.0f}), std::invalid_argument, "too few arguments");
+    EXPECT_THROW_MESSAGE(
+        execute(*instance, 2, {0.0f, 0.0f, 0.0f}), std::invalid_argument, "too many arguments");
+}
+
+TEST(execute_invalid, wrong_argument_types)
+{
+    /* wat2wasm
+    (func (param i32))
+    (func (param f32 f32))
+    */
+    const auto wasm =
+        from_hex("0061736d01000000010a0260017f0060027d7d0003030200010a070202000b02000b");
+
+    auto instance = instantiate(parse(wasm));
+
+    EXPECT_THROW_MESSAGE(
+        execute(*instance, 0, {0_u64}), std::invalid_argument, "invalid type of the argument 0");
+    EXPECT_THROW_MESSAGE(
+        execute(*instance, 0, {0.0}), std::invalid_argument, "invalid type of the argument 0");
+    EXPECT_THROW_MESSAGE(
+        execute(*instance, 0, {0.0f}), std::invalid_argument, "invalid type of the argument 0");
+
+    EXPECT_THROW_MESSAGE(
+        execute(*instance, 1, {0, 0}), std::invalid_argument, "invalid type of the argument 0");
+    EXPECT_THROW_MESSAGE(execute(*instance, 1, {0.0f, 0.0}), std::invalid_argument,
+        "invalid type of the argument 1");
+    EXPECT_THROW_MESSAGE(
+        execute(*instance, 1, {0, 0.0f}), std::invalid_argument, "invalid type of the argument 0");
+}

--- a/test/unittests/execute_numeric_test.cpp
+++ b/test/unittests/execute_numeric_test.cpp
@@ -33,11 +33,13 @@ ExecutionResult execute_unary_operation(Instr instr, TypedValue arg)
     return execute(*instantiate(std::move(module)), 0, {arg});
 }
 
-ExecutionResult execute_binary_operation(Instr instr, uint64_t lhs, uint64_t rhs)
+ExecutionResult execute_binary_operation(Instr instr, TypedValue lhs, TypedValue rhs)
 {
     const auto& instr_type = get_instruction_type_table()[static_cast<uint8_t>(instr)];
     EXPECT_EQ(instr_type.inputs.size(), 2);
     EXPECT_EQ(instr_type.outputs.size(), 1);
+    EXPECT_EQ(instr_type.inputs[0], lhs.type);
+    EXPECT_EQ(instr_type.inputs[1], rhs.type);
 
     auto module{std::make_unique<Module>()};
     module->typesec.emplace_back(
@@ -163,49 +165,49 @@ TEST(execute_numeric, i64_eqz)
 
 TEST(execute_numeric, i64_eq)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_eq, 22, 20), Result(0));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_eq, 22, 22), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_eq, 22_u64, 20_u64), Result(0));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_eq, 22_u64, 22_u64), Result(1));
 }
 
 TEST(execute_numeric, i64_ne)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_ne, 22, 20), Result(1));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_ne, 22, 22), Result(0));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_ne, 22_u64, 20_u64), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_ne, 22_u64, 22_u64), Result(0));
 }
 
 TEST(execute_numeric, i64_lt_s)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_lt_s, 22, 20), Result(0));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_lt_s, 20, 22), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_lt_s, 22_u64, 20_u64), Result(0));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_lt_s, 20_u64, 22_u64), Result(1));
     EXPECT_THAT(execute_binary_operation(Instr::i64_lt_s, uint64_t(-41), uint64_t(-42)), Result(0));
     EXPECT_THAT(execute_binary_operation(Instr::i64_lt_s, uint64_t(-42), uint64_t(-41)), Result(1));
 }
 
 TEST(execute_numeric, i64_lt_u)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_lt_u, 22, 20), Result(0));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_lt_u, 20, 22), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_lt_u, 22_u64, 20_u64), Result(0));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_lt_u, 20_u64, 22_u64), Result(1));
 }
 
 TEST(execute_numeric, i64_gt_s)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_gt_s, 22, 20), Result(1));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_gt_s, 20, 22), Result(0));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_gt_s, 22_u64, 20_u64), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_gt_s, 20_u64, 22_u64), Result(0));
     EXPECT_THAT(execute_binary_operation(Instr::i64_gt_s, uint64_t(-41), uint64_t(-42)), Result(1));
     EXPECT_THAT(execute_binary_operation(Instr::i64_gt_s, uint64_t(-42), uint64_t(-41)), Result(0));
 }
 
 TEST(execute_numeric, i64_gt_u)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_gt_u, 22, 20), Result(1));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_gt_u, 20, 22), Result(0));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_gt_u, 22_u64, 20_u64), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_gt_u, 20_u64, 22_u64), Result(0));
 }
 
 TEST(execute_numeric, i64_le_s)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_le_s, 22, 20), Result(0));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_le_s, 20, 22), Result(1));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_le_s, 20, 20), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_le_s, 22_u64, 20_u64), Result(0));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_le_s, 20_u64, 22_u64), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_le_s, 20_u64, 20_u64), Result(1));
     EXPECT_THAT(execute_binary_operation(Instr::i64_le_s, uint64_t(-41), uint64_t(-42)), Result(0));
     EXPECT_THAT(execute_binary_operation(Instr::i64_le_s, uint64_t(-42), uint64_t(-41)), Result(1));
     EXPECT_THAT(execute_binary_operation(Instr::i64_le_s, uint64_t(-42), uint64_t(-42)), Result(1));
@@ -213,16 +215,16 @@ TEST(execute_numeric, i64_le_s)
 
 TEST(execute_numeric, i64_le_u)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_le_u, 22, 20), Result(0));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_le_u, 20, 22), Result(1));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_le_u, 20, 20), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_le_u, 22_u64, 20_u64), Result(0));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_le_u, 20_u64, 22_u64), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_le_u, 20_u64, 20_u64), Result(1));
 }
 
 TEST(execute_numeric, i64_ge_s)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_ge_s, 22, 20), Result(1));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_ge_s, 20, 22), Result(0));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_ge_s, 20, 20), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_ge_s, 22_u64, 20_u64), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_ge_s, 20_u64, 22_u64), Result(0));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_ge_s, 20_u64, 20_u64), Result(1));
     EXPECT_THAT(execute_binary_operation(Instr::i64_ge_s, uint64_t(-41), uint64_t(-42)), Result(1));
     EXPECT_THAT(execute_binary_operation(Instr::i64_ge_s, uint64_t(-42), uint64_t(-41)), Result(0));
     EXPECT_THAT(execute_binary_operation(Instr::i64_ge_s, uint64_t(-42), uint64_t(-42)), Result(1));
@@ -230,9 +232,9 @@ TEST(execute_numeric, i64_ge_s)
 
 TEST(execute_numeric, i64_ge_u)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_ge_u, 22, 20), Result(1));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_ge_u, 20, 22), Result(0));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_ge_u, 20, 20), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_ge_u, 22_u64, 20_u64), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_ge_u, 20_u64, 22_u64), Result(0));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_ge_u, 20_u64, 20_u64), Result(1));
 }
 
 TEST(execute_numeric, i32_clz)
@@ -325,7 +327,7 @@ TEST(execute_numeric, i32_rem_s)
 
 TEST(execute_numeric, i32_rem_s_by_zero)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i32_rem_s, uint64_t(-4242), 0), Traps());
+    EXPECT_THAT(execute_binary_operation(Instr::i32_rem_s, uint32_t(-4242), 0), Traps());
 }
 
 TEST(execute_numeric, i32_rem_s_stack_value)
@@ -525,28 +527,28 @@ TEST(execute_numeric, i64_popcnt)
 
 TEST(execute_numeric, i64_add)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_add, 22, 20), Result(42));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_add, 22_u64, 20_u64), Result(42));
 }
 
 TEST(execute_numeric, i64_sub)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_sub, 424242, 424200), Result(42));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_sub, 424242_u64, 424200_u64), Result(42));
 }
 
 TEST(execute_numeric, i64_mul)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_mul, 2, 21), Result(42));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_mul, 2_u64, 21_u64), Result(42));
 }
 
 TEST(execute_numeric, i64_div_s)
 {
     EXPECT_THAT(
-        execute_binary_operation(Instr::i64_div_s, uint64_t(-84), 2), Result(uint64_t(-42)));
+        execute_binary_operation(Instr::i64_div_s, uint64_t(-84), 2_u64), Result(uint64_t(-42)));
 }
 
 TEST(execute_numeric, i64_div_s_by_zero)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_div_s, 84, 0), Traps());
+    EXPECT_THAT(execute_binary_operation(Instr::i64_div_s, 84_u64, 0_u64), Traps());
 }
 
 TEST(execute_numeric, i64_div_s_overflow)
@@ -558,18 +560,18 @@ TEST(execute_numeric, i64_div_s_overflow)
 
 TEST(execute_numeric, i64_div_u)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_div_u, 84, 2), Result(42));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_div_u, 84_u64, 2_u64), Result(42));
 }
 
 TEST(execute_numeric, i64_div_u_by_zero)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_div_u, 84, 0), Traps());
+    EXPECT_THAT(execute_binary_operation(Instr::i64_div_u, 84_u64, 0_u64), Traps());
 }
 
 TEST(execute_numeric, i64_rem_s)
 {
-    EXPECT_THAT(
-        execute_binary_operation(Instr::i64_rem_s, uint64_t(-4242), 4200), Result(uint64_t(-42)));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_rem_s, uint64_t(-4242), 4200_u64),
+        Result(uint64_t(-42)));
     constexpr auto i64_min = std::numeric_limits<int64_t>::min();
     EXPECT_THAT(
         execute_binary_operation(Instr::i64_rem_s, uint64_t(i64_min), uint64_t(-1)), Result(0));
@@ -577,97 +579,100 @@ TEST(execute_numeric, i64_rem_s)
 
 TEST(execute_numeric, i64_rem_s_by_zero)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_rem_s, uint64_t(-4242), 0), Traps());
+    EXPECT_THAT(execute_binary_operation(Instr::i64_rem_s, uint64_t(-4242), 0_u64), Traps());
 }
 
 TEST(execute_numeric, i64_rem_u)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_rem_u, 4242, 4200), Result(42));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_rem_u, 4242_u64, 4200_u64), Result(42));
 }
 
 TEST(execute_numeric, i64_rem_u_by_zero)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_rem_u, 4242, 0), Traps());
+    EXPECT_THAT(execute_binary_operation(Instr::i64_rem_u, 4242_u64, 0_u64), Traps());
 }
 
 TEST(execute_numeric, i64_and)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_and, 0x00ffff, 0xffff00), Result(0xff00));
+    EXPECT_THAT(
+        execute_binary_operation(Instr::i64_and, 0x00ffff_u64, 0xffff00_u64), Result(0xff00));
 }
 
 TEST(execute_numeric, i64_or)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_or, 0x00ffff, 0xffff00), Result(0xffffff));
+    EXPECT_THAT(
+        execute_binary_operation(Instr::i64_or, 0x00ffff_u64, 0xffff00_u64), Result(0xffffff));
 }
 
 TEST(execute_numeric, i64_xor)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_xor, 0x00ffff, 0xffff00), Result(0xff00ff));
+    EXPECT_THAT(
+        execute_binary_operation(Instr::i64_xor, 0x00ffff_u64, 0xffff00_u64), Result(0xff00ff));
 }
 
 TEST(execute_numeric, i64_shl)
 {
     constexpr auto ebo = execute_binary_operation;
-    EXPECT_THAT(ebo(Instr::i64_shl, 21, 1), Result(42));
-    EXPECT_THAT(ebo(Instr::i64_shl, 0xffffffffffffffff, 0), Result(0xffffffffffffffff));
-    EXPECT_THAT(ebo(Instr::i64_shl, 0xffffffffffffffff, 1), Result(0xfffffffffffffffe));
-    EXPECT_THAT(ebo(Instr::i64_shl, 0xffffffffffffffff, 63), Result(0x8000000000000000));
-    EXPECT_THAT(ebo(Instr::i64_shl, 0xffffffffffffffff, 64), Result(0xffffffffffffffff));
-    EXPECT_THAT(ebo(Instr::i64_shl, 0xffffffffffffffff, 65), Result(0xfffffffffffffffe));
-    EXPECT_THAT(ebo(Instr::i64_shl, 0xffffffffffffffff, 127), Result(0x8000000000000000));
+    EXPECT_THAT(ebo(Instr::i64_shl, 21_u64, 1_u64), Result(42));
+    EXPECT_THAT(ebo(Instr::i64_shl, 0xffffffffffffffff_u64, 0_u64), Result(0xffffffffffffffff));
+    EXPECT_THAT(ebo(Instr::i64_shl, 0xffffffffffffffff_u64, 1_u64), Result(0xfffffffffffffffe));
+    EXPECT_THAT(ebo(Instr::i64_shl, 0xffffffffffffffff_u64, 63_u64), Result(0x8000000000000000));
+    EXPECT_THAT(ebo(Instr::i64_shl, 0xffffffffffffffff_u64, 64_u64), Result(0xffffffffffffffff));
+    EXPECT_THAT(ebo(Instr::i64_shl, 0xffffffffffffffff_u64, 65_u64), Result(0xfffffffffffffffe));
+    EXPECT_THAT(ebo(Instr::i64_shl, 0xffffffffffffffff_u64, 127_u64), Result(0x8000000000000000));
 }
 
 TEST(execute_numeric, i64_shr_s)
 {
     constexpr auto ebo = execute_binary_operation;
-    EXPECT_THAT(ebo(Instr::i64_shr_s, uint64_t(-84), 1), Result(uint64_t(-42)));
-    EXPECT_THAT(ebo(Instr::i64_shr_s, 0xffffffffffffffff, 0), Result(0xffffffffffffffff));
-    EXPECT_THAT(ebo(Instr::i64_shr_s, 0xffffffffffffffff, 1), Result(0xffffffffffffffff));
-    EXPECT_THAT(ebo(Instr::i64_shr_s, 0xffffffffffffffff, 63), Result(0xffffffffffffffff));
-    EXPECT_THAT(ebo(Instr::i64_shr_s, 0xffffffffffffffff, 64), Result(0xffffffffffffffff));
-    EXPECT_THAT(ebo(Instr::i64_shr_s, 0xffffffffffffffff, 65), Result(0xffffffffffffffff));
-    EXPECT_THAT(ebo(Instr::i64_shr_s, 0xffffffffffffffff, 127), Result(0xffffffffffffffff));
-    EXPECT_THAT(ebo(Instr::i64_shr_s, 0x7fffffffffffffff, 0), Result(0x7fffffffffffffff));
-    EXPECT_THAT(ebo(Instr::i64_shr_s, 0x7fffffffffffffff, 1), Result(0x3fffffffffffffff));
-    EXPECT_THAT(ebo(Instr::i64_shr_s, 0x7fffffffffffffff, 62), Result(1));
-    EXPECT_THAT(ebo(Instr::i64_shr_s, 0x7fffffffffffffff, 63), Result(0));
-    EXPECT_THAT(ebo(Instr::i64_shr_s, 0x7fffffffffffffff, 64), Result(0x7fffffffffffffff));
-    EXPECT_THAT(ebo(Instr::i64_shr_s, 0x7fffffffffffffff, 65), Result(0x3fffffffffffffff));
-    EXPECT_THAT(ebo(Instr::i64_shr_s, 0x7fffffffffffffff, 126), Result(1));
-    EXPECT_THAT(ebo(Instr::i64_shr_s, 0x7fffffffffffffff, 127), Result(0));
-    EXPECT_THAT(ebo(Instr::i64_shr_s, 1, uint64_t(-1)), Result(0));
+    EXPECT_THAT(ebo(Instr::i64_shr_s, uint64_t(-84), 1_u64), Result(uint64_t(-42)));
+    EXPECT_THAT(ebo(Instr::i64_shr_s, 0xffffffffffffffff_u64, 0_u64), Result(0xffffffffffffffff));
+    EXPECT_THAT(ebo(Instr::i64_shr_s, 0xffffffffffffffff_u64, 1_u64), Result(0xffffffffffffffff));
+    EXPECT_THAT(ebo(Instr::i64_shr_s, 0xffffffffffffffff_u64, 63_u64), Result(0xffffffffffffffff));
+    EXPECT_THAT(ebo(Instr::i64_shr_s, 0xffffffffffffffff_u64, 64_u64), Result(0xffffffffffffffff));
+    EXPECT_THAT(ebo(Instr::i64_shr_s, 0xffffffffffffffff_u64, 65_u64), Result(0xffffffffffffffff));
+    EXPECT_THAT(ebo(Instr::i64_shr_s, 0xffffffffffffffff_u64, 127_u64), Result(0xffffffffffffffff));
+    EXPECT_THAT(ebo(Instr::i64_shr_s, 0x7fffffffffffffff_u64, 0_u64), Result(0x7fffffffffffffff));
+    EXPECT_THAT(ebo(Instr::i64_shr_s, 0x7fffffffffffffff_u64, 1_u64), Result(0x3fffffffffffffff));
+    EXPECT_THAT(ebo(Instr::i64_shr_s, 0x7fffffffffffffff_u64, 62_u64), Result(1));
+    EXPECT_THAT(ebo(Instr::i64_shr_s, 0x7fffffffffffffff_u64, 63_u64), Result(0));
+    EXPECT_THAT(ebo(Instr::i64_shr_s, 0x7fffffffffffffff_u64, 64_u64), Result(0x7fffffffffffffff));
+    EXPECT_THAT(ebo(Instr::i64_shr_s, 0x7fffffffffffffff_u64, 65_u64), Result(0x3fffffffffffffff));
+    EXPECT_THAT(ebo(Instr::i64_shr_s, 0x7fffffffffffffff_u64, 126_u64), Result(1));
+    EXPECT_THAT(ebo(Instr::i64_shr_s, 0x7fffffffffffffff_u64, 127_u64), Result(0));
+    EXPECT_THAT(ebo(Instr::i64_shr_s, 1_u64, uint64_t(-1)), Result(0));
 }
 
 TEST(execute_numeric, i64_shr_u)
 {
     constexpr auto ebo = execute_binary_operation;
-    EXPECT_THAT(ebo(Instr::i64_shr_u, 84, 1), Result(42));
-    EXPECT_THAT(ebo(Instr::i64_shr_u, 0xffffffffffffffff, 0), Result(0xffffffffffffffff));
-    EXPECT_THAT(ebo(Instr::i64_shr_u, 0xffffffffffffffff, 1), Result(0x7fffffffffffffff));
-    EXPECT_THAT(ebo(Instr::i64_shr_u, 0xffffffffffffffff, 63), Result(1));
-    EXPECT_THAT(ebo(Instr::i64_shr_u, 0xffffffffffffffff, 64), Result(0xffffffffffffffff));
-    EXPECT_THAT(ebo(Instr::i64_shr_u, 0xffffffffffffffff, 65), Result(0x7fffffffffffffff));
-    EXPECT_THAT(ebo(Instr::i64_shr_u, 0xffffffffffffffff, 127), Result(1));
+    EXPECT_THAT(ebo(Instr::i64_shr_u, 84_u64, 1_u64), Result(42));
+    EXPECT_THAT(ebo(Instr::i64_shr_u, 0xffffffffffffffff_u64, 0_u64), Result(0xffffffffffffffff));
+    EXPECT_THAT(ebo(Instr::i64_shr_u, 0xffffffffffffffff_u64, 1_u64), Result(0x7fffffffffffffff));
+    EXPECT_THAT(ebo(Instr::i64_shr_u, 0xffffffffffffffff_u64, 63_u64), Result(1));
+    EXPECT_THAT(ebo(Instr::i64_shr_u, 0xffffffffffffffff_u64, 64_u64), Result(0xffffffffffffffff));
+    EXPECT_THAT(ebo(Instr::i64_shr_u, 0xffffffffffffffff_u64, 65_u64), Result(0x7fffffffffffffff));
+    EXPECT_THAT(ebo(Instr::i64_shr_u, 0xffffffffffffffff_u64, 127_u64), Result(1));
 }
 
 TEST(execute_numeric, i64_rotl)
 {
     constexpr auto ebo = execute_binary_operation;
-    EXPECT_THAT(ebo(Instr::i64_rotl, 0xff00000000000000, 0), Result(0xff00000000000000));
-    EXPECT_THAT(ebo(Instr::i64_rotl, 0xff00000000000000, 1), Result(0xfe00000000000001));
-    EXPECT_THAT(ebo(Instr::i64_rotl, 0xff00000000000000, 63), Result(0x7f80000000000000));
-    EXPECT_THAT(ebo(Instr::i64_rotl, 0xff00000000000000, 64), Result(0xff00000000000000));
-    EXPECT_THAT(ebo(Instr::i64_rotl, 0xff00000000000000, 65), Result(0xfe00000000000001));
-    EXPECT_THAT(ebo(Instr::i64_rotl, 0xff00000000000000, 127), Result(0x7f80000000000000));
+    EXPECT_THAT(ebo(Instr::i64_rotl, 0xff00000000000000_u64, 0_u64), Result(0xff00000000000000));
+    EXPECT_THAT(ebo(Instr::i64_rotl, 0xff00000000000000_u64, 1_u64), Result(0xfe00000000000001));
+    EXPECT_THAT(ebo(Instr::i64_rotl, 0xff00000000000000_u64, 63_u64), Result(0x7f80000000000000));
+    EXPECT_THAT(ebo(Instr::i64_rotl, 0xff00000000000000_u64, 64_u64), Result(0xff00000000000000));
+    EXPECT_THAT(ebo(Instr::i64_rotl, 0xff00000000000000_u64, 65_u64), Result(0xfe00000000000001));
+    EXPECT_THAT(ebo(Instr::i64_rotl, 0xff00000000000000_u64, 127_u64), Result(0x7f80000000000000));
 }
 
 TEST(execute_numeric, i64_rotr)
 {
     constexpr auto ebo = execute_binary_operation;
-    EXPECT_THAT(ebo(Instr::i64_rotr, 0x00000000000000ff, 0), Result(0x00000000000000ff));
-    EXPECT_THAT(ebo(Instr::i64_rotr, 0x00000000000000ff, 1), Result(0x800000000000007f));
-    EXPECT_THAT(ebo(Instr::i64_rotr, 0x00000000000000ff, 63), Result(0x00000000000001fe));
-    EXPECT_THAT(ebo(Instr::i64_rotr, 0x00000000000000ff, 64), Result(0x00000000000000ff));
-    EXPECT_THAT(ebo(Instr::i64_rotr, 0x00000000000000ff, 65), Result(0x800000000000007f));
-    EXPECT_THAT(ebo(Instr::i64_rotr, 0x00000000000000ff, 127), Result(0x00000000000001fe));
+    EXPECT_THAT(ebo(Instr::i64_rotr, 0x00000000000000ff_u64, 0_u64), Result(0x00000000000000ff));
+    EXPECT_THAT(ebo(Instr::i64_rotr, 0x00000000000000ff_u64, 1_u64), Result(0x800000000000007f));
+    EXPECT_THAT(ebo(Instr::i64_rotr, 0x00000000000000ff_u64, 63_u64), Result(0x00000000000001fe));
+    EXPECT_THAT(ebo(Instr::i64_rotr, 0x00000000000000ff_u64, 64_u64), Result(0x00000000000000ff));
+    EXPECT_THAT(ebo(Instr::i64_rotr, 0x00000000000000ff_u64, 65_u64), Result(0x800000000000007f));
+    EXPECT_THAT(ebo(Instr::i64_rotr, 0x00000000000000ff_u64, 127_u64), Result(0x00000000000001fe));
 }

--- a/test/unittests/execute_numeric_test.cpp
+++ b/test/unittests/execute_numeric_test.cpp
@@ -9,17 +9,19 @@
 #include <test/utils/asserts.hpp>
 #include <test/utils/execute_helpers.hpp>
 #include <test/utils/hex.hpp>
+#include <test/utils/typed_value.hpp>
 
 using namespace fizzy;
 using namespace fizzy::test;
 
 namespace
 {
-ExecutionResult execute_unary_operation(Instr instr, uint64_t arg)
+ExecutionResult execute_unary_operation(Instr instr, TypedValue arg)
 {
     const auto& instr_type = get_instruction_type_table()[static_cast<uint8_t>(instr)];
     EXPECT_EQ(instr_type.inputs.size(), 1);
     EXPECT_EQ(instr_type.outputs.size(), 1);
+    EXPECT_EQ(instr_type.inputs[0], arg.type);
 
     auto module{std::make_unique<Module>()};
     module->typesec.emplace_back(FuncType{{instr_type.inputs[0]}, {instr_type.outputs[0]}});
@@ -152,11 +154,11 @@ TEST(execute_numeric, i32_ge_u)
 
 TEST(execute_numeric, i64_eqz)
 {
-    EXPECT_THAT(execute_unary_operation(Instr::i64_eqz, 0), Result(1));
-    EXPECT_THAT(execute_unary_operation(Instr::i64_eqz, 1), Result(0));
+    EXPECT_THAT(execute_unary_operation(Instr::i64_eqz, 0_u64), Result(1));
+    EXPECT_THAT(execute_unary_operation(Instr::i64_eqz, 1_u64), Result(0));
     // 64-bit value on the stack
-    EXPECT_THAT(execute_unary_operation(fizzy::Instr::i64_eqz, 0xff00000000), Result(0));
-    EXPECT_THAT(execute_unary_operation(fizzy::Instr::i64_eqz, 0xff00000001), Result(0));
+    EXPECT_THAT(execute_unary_operation(fizzy::Instr::i64_eqz, 0xff00000000_u64), Result(0));
+    EXPECT_THAT(execute_unary_operation(fizzy::Instr::i64_eqz, 0xff00000001_u64), Result(0));
 }
 
 TEST(execute_numeric, i64_eq)
@@ -444,10 +446,10 @@ TEST(execute_numeric, i32_rotr)
 TEST(execute_numeric, i32_wrap_i64)
 {
     // <=32-bits set
-    EXPECT_THAT(execute_unary_operation(Instr::i32_wrap_i64, 0xffffffff), Result(0xffffffff));
+    EXPECT_THAT(execute_unary_operation(Instr::i32_wrap_i64, 0xffffffff_u64), Result(0xffffffff));
     // >32-bits set
     EXPECT_THAT(
-        execute_unary_operation(Instr::i32_wrap_i64, 0xffffffffffffffff), Result(0xffffffff));
+        execute_unary_operation(Instr::i32_wrap_i64, 0xffffffffffffffff_u64), Result(0xffffffff));
 }
 
 TEST(execute_numeric, i64_extend_i32_s_all_bits_set)
@@ -498,27 +500,27 @@ TEST(execute_numeric, i64_extend_i32_u_2)
 
 TEST(execute_numeric, i64_clz)
 {
-    EXPECT_THAT(execute_unary_operation(Instr::i64_clz, 0x7f), Result(64 - 7));
+    EXPECT_THAT(execute_unary_operation(Instr::i64_clz, 0x7f_u64), Result(64 - 7));
 }
 
 TEST(execute_numeric, i64_clz0)
 {
-    EXPECT_THAT(execute_unary_operation(Instr::i64_clz, 0), Result(64));
+    EXPECT_THAT(execute_unary_operation(Instr::i64_clz, 0_u64), Result(64));
 }
 
 TEST(execute_numeric, i64_ctz)
 {
-    EXPECT_THAT(execute_unary_operation(Instr::i64_ctz, 0x80), Result(7));
+    EXPECT_THAT(execute_unary_operation(Instr::i64_ctz, 0x80_u64), Result(7));
 }
 
 TEST(execute_numeric, i64_ctz0)
 {
-    EXPECT_THAT(execute_unary_operation(Instr::i64_ctz, 0), Result(64));
+    EXPECT_THAT(execute_unary_operation(Instr::i64_ctz, 0_u64), Result(64));
 }
 
 TEST(execute_numeric, i64_popcnt)
 {
-    EXPECT_THAT(execute_unary_operation(Instr::i64_popcnt, 0x7fff00), Result(7 + 8));
+    EXPECT_THAT(execute_unary_operation(Instr::i64_popcnt, 0x7fff00_u64), Result(7 + 8));
 }
 
 TEST(execute_numeric, i64_add)

--- a/test/unittests/execute_numeric_test.cpp
+++ b/test/unittests/execute_numeric_test.cpp
@@ -179,8 +179,8 @@ TEST(execute_numeric, i64_lt_s)
 {
     EXPECT_THAT(execute_binary_operation(Instr::i64_lt_s, 22_u64, 20_u64), Result(0));
     EXPECT_THAT(execute_binary_operation(Instr::i64_lt_s, 20_u64, 22_u64), Result(1));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_lt_s, uint64_t(-41), uint64_t(-42)), Result(0));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_lt_s, uint64_t(-42), uint64_t(-41)), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_lt_s, -41_u64, -42_u64), Result(0));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_lt_s, -42_u64, -41_u64), Result(1));
 }
 
 TEST(execute_numeric, i64_lt_u)
@@ -193,8 +193,8 @@ TEST(execute_numeric, i64_gt_s)
 {
     EXPECT_THAT(execute_binary_operation(Instr::i64_gt_s, 22_u64, 20_u64), Result(1));
     EXPECT_THAT(execute_binary_operation(Instr::i64_gt_s, 20_u64, 22_u64), Result(0));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_gt_s, uint64_t(-41), uint64_t(-42)), Result(1));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_gt_s, uint64_t(-42), uint64_t(-41)), Result(0));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_gt_s, -41_u64, -42_u64), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_gt_s, -42_u64, -41_u64), Result(0));
 }
 
 TEST(execute_numeric, i64_gt_u)
@@ -208,9 +208,9 @@ TEST(execute_numeric, i64_le_s)
     EXPECT_THAT(execute_binary_operation(Instr::i64_le_s, 22_u64, 20_u64), Result(0));
     EXPECT_THAT(execute_binary_operation(Instr::i64_le_s, 20_u64, 22_u64), Result(1));
     EXPECT_THAT(execute_binary_operation(Instr::i64_le_s, 20_u64, 20_u64), Result(1));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_le_s, uint64_t(-41), uint64_t(-42)), Result(0));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_le_s, uint64_t(-42), uint64_t(-41)), Result(1));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_le_s, uint64_t(-42), uint64_t(-42)), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_le_s, -41_u64, -42_u64), Result(0));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_le_s, -42_u64, -41_u64), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_le_s, -42_u64, -42_u64), Result(1));
 }
 
 TEST(execute_numeric, i64_le_u)
@@ -225,9 +225,9 @@ TEST(execute_numeric, i64_ge_s)
     EXPECT_THAT(execute_binary_operation(Instr::i64_ge_s, 22_u64, 20_u64), Result(1));
     EXPECT_THAT(execute_binary_operation(Instr::i64_ge_s, 20_u64, 22_u64), Result(0));
     EXPECT_THAT(execute_binary_operation(Instr::i64_ge_s, 20_u64, 20_u64), Result(1));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_ge_s, uint64_t(-41), uint64_t(-42)), Result(1));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_ge_s, uint64_t(-42), uint64_t(-41)), Result(0));
-    EXPECT_THAT(execute_binary_operation(Instr::i64_ge_s, uint64_t(-42), uint64_t(-42)), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_ge_s, -41_u64, -42_u64), Result(1));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_ge_s, -42_u64, -41_u64), Result(0));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_ge_s, -42_u64, -42_u64), Result(1));
 }
 
 TEST(execute_numeric, i64_ge_u)
@@ -542,8 +542,7 @@ TEST(execute_numeric, i64_mul)
 
 TEST(execute_numeric, i64_div_s)
 {
-    EXPECT_THAT(
-        execute_binary_operation(Instr::i64_div_s, uint64_t(-84), 2_u64), Result(uint64_t(-42)));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_div_s, -84_u64, 2_u64), Result(-42_u64));
 }
 
 TEST(execute_numeric, i64_div_s_by_zero)
@@ -554,7 +553,7 @@ TEST(execute_numeric, i64_div_s_by_zero)
 TEST(execute_numeric, i64_div_s_overflow)
 {
     EXPECT_THAT(execute_binary_operation(
-                    Instr::i64_div_s, uint64_t(std::numeric_limits<int64_t>::min()), uint64_t(-1)),
+                    Instr::i64_div_s, uint64_t(std::numeric_limits<int64_t>::min()), -1_u64),
         Traps());
 }
 
@@ -570,16 +569,14 @@ TEST(execute_numeric, i64_div_u_by_zero)
 
 TEST(execute_numeric, i64_rem_s)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_rem_s, uint64_t(-4242), 4200_u64),
-        Result(uint64_t(-42)));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_rem_s, -4242_u64, 4200_u64), Result(-42_u64));
     constexpr auto i64_min = std::numeric_limits<int64_t>::min();
-    EXPECT_THAT(
-        execute_binary_operation(Instr::i64_rem_s, uint64_t(i64_min), uint64_t(-1)), Result(0));
+    EXPECT_THAT(execute_binary_operation(Instr::i64_rem_s, uint64_t(i64_min), -1_u64), Result(0));
 }
 
 TEST(execute_numeric, i64_rem_s_by_zero)
 {
-    EXPECT_THAT(execute_binary_operation(Instr::i64_rem_s, uint64_t(-4242), 0_u64), Traps());
+    EXPECT_THAT(execute_binary_operation(Instr::i64_rem_s, -4242_u64, 0_u64), Traps());
 }
 
 TEST(execute_numeric, i64_rem_u)
@@ -625,7 +622,7 @@ TEST(execute_numeric, i64_shl)
 TEST(execute_numeric, i64_shr_s)
 {
     constexpr auto ebo = execute_binary_operation;
-    EXPECT_THAT(ebo(Instr::i64_shr_s, uint64_t(-84), 1_u64), Result(uint64_t(-42)));
+    EXPECT_THAT(ebo(Instr::i64_shr_s, -84_u64, 1_u64), Result(-42_u64));
     EXPECT_THAT(ebo(Instr::i64_shr_s, 0xffffffffffffffff_u64, 0_u64), Result(0xffffffffffffffff));
     EXPECT_THAT(ebo(Instr::i64_shr_s, 0xffffffffffffffff_u64, 1_u64), Result(0xffffffffffffffff));
     EXPECT_THAT(ebo(Instr::i64_shr_s, 0xffffffffffffffff_u64, 63_u64), Result(0xffffffffffffffff));
@@ -640,7 +637,7 @@ TEST(execute_numeric, i64_shr_s)
     EXPECT_THAT(ebo(Instr::i64_shr_s, 0x7fffffffffffffff_u64, 65_u64), Result(0x3fffffffffffffff));
     EXPECT_THAT(ebo(Instr::i64_shr_s, 0x7fffffffffffffff_u64, 126_u64), Result(1));
     EXPECT_THAT(ebo(Instr::i64_shr_s, 0x7fffffffffffffff_u64, 127_u64), Result(0));
-    EXPECT_THAT(ebo(Instr::i64_shr_s, 1_u64, uint64_t(-1)), Result(0));
+    EXPECT_THAT(ebo(Instr::i64_shr_s, 1_u64, -1_u64), Result(0));
 }
 
 TEST(execute_numeric, i64_shr_u)

--- a/test/unittests/execute_numeric_test.cpp
+++ b/test/unittests/execute_numeric_test.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "execute.hpp"
+#include "instructions.hpp"
 #include "parser.hpp"
 #include <gtest/gtest.h>
 #include <test/utils/asserts.hpp>
@@ -16,9 +17,12 @@ namespace
 {
 ExecutionResult execute_unary_operation(Instr instr, uint64_t arg)
 {
+    const auto& instr_type = get_instruction_type_table()[static_cast<uint8_t>(instr)];
+    EXPECT_EQ(instr_type.inputs.size(), 1);
+    EXPECT_EQ(instr_type.outputs.size(), 1);
+
     auto module{std::make_unique<Module>()};
-    // type is currently needed only to get arity of function, so exact value types don't matter
-    module->typesec.emplace_back(FuncType{{ValType::i32}, {ValType::i32}});
+    module->typesec.emplace_back(FuncType{{instr_type.inputs[0]}, {instr_type.outputs[0]}});
     module->funcsec.emplace_back(TypeIdx{0});
     module->codesec.emplace_back(Code{1, 0,
         {static_cast<uint8_t>(Instr::local_get), 0, 0, 0, 0, static_cast<uint8_t>(instr),
@@ -29,9 +33,13 @@ ExecutionResult execute_unary_operation(Instr instr, uint64_t arg)
 
 ExecutionResult execute_binary_operation(Instr instr, uint64_t lhs, uint64_t rhs)
 {
+    const auto& instr_type = get_instruction_type_table()[static_cast<uint8_t>(instr)];
+    EXPECT_EQ(instr_type.inputs.size(), 2);
+    EXPECT_EQ(instr_type.outputs.size(), 1);
+
     auto module{std::make_unique<Module>()};
-    // type is currently needed only to get arity of function, so exact value types don't matter
-    module->typesec.emplace_back(FuncType{{ValType::i32, ValType::i32}, {ValType::i32}});
+    module->typesec.emplace_back(
+        FuncType{{instr_type.inputs[0], instr_type.inputs[1]}, {instr_type.outputs[0]}});
     module->funcsec.emplace_back(TypeIdx{0});
     module->codesec.emplace_back(Code{2, 0,
         {static_cast<uint8_t>(Instr::local_get), 0, 0, 0, 0, static_cast<uint8_t>(Instr::local_get),

--- a/test/unittests/execute_test.cpp
+++ b/test/unittests/execute_test.cpp
@@ -49,9 +49,9 @@ TEST(execute, select)
         from_hex("0061736d0100000001080160037e7e7f017e030201000a0b0109002000200120021b0b");
 
     const auto module = parse(wasm);
-    EXPECT_THAT(execute(module, 0, {3, 6, 0}), Result(6));
-    EXPECT_THAT(execute(module, 0, {3, 6, 1}), Result(3));
-    EXPECT_THAT(execute(module, 0, {3, 6, 42}), Result(3));
+    EXPECT_THAT(execute(module, 0, {3_u64, 6_u64, 0_u32}), Result(6));
+    EXPECT_THAT(execute(module, 0, {3_u64, 6_u64, 1_u32}), Result(3));
+    EXPECT_THAT(execute(module, 0, {3_u64, 6_u64, 42_u32}), Result(3));
 }
 
 TEST(execute, local_get)
@@ -62,7 +62,7 @@ TEST(execute, local_get)
     )
     */
     const auto wasm = from_hex("0061736d0100000001060160017e017e030201000a0601040020000b");
-    EXPECT_THAT(execute(parse(wasm), 0, {42}), Result(42));
+    EXPECT_THAT(execute(parse(wasm), 0, {42_u64}), Result(42));
 }
 
 TEST(execute, local_init)
@@ -113,7 +113,7 @@ TEST(execute, local_set)
     */
     const auto wasm =
         from_hex("0061736d0100000001060160017e017e030201000a0c010a01017e2000210120010b");
-    EXPECT_THAT(execute(parse(wasm), 0, {42}), Result(42));
+    EXPECT_THAT(execute(parse(wasm), 0, {42_u64}), Result(42));
 }
 
 TEST(execute, local_tee)
@@ -126,7 +126,7 @@ TEST(execute, local_tee)
     )
     */
     const auto wasm = from_hex("0061736d0100000001060160017e017e030201000a0a010801017e200022010b");
-    EXPECT_THAT(execute(parse(wasm), 0, {42}), Result(42));
+    EXPECT_THAT(execute(parse(wasm), 0, {42_u64}), Result(42));
 }
 
 TEST(execute, global_get)
@@ -617,10 +617,10 @@ TEST(execute, i64_store_all_variants)
         *store_instr = static_cast<uint8_t>(instr);
         auto instance = instantiate(*module);
         std::fill_n(instance->memory->begin(), 10, uint8_t{0xcc});
-        EXPECT_THAT(execute(*instance, 0, {0xb7b6b5b4b3b2b1b0, 1}), Result());
+        EXPECT_THAT(execute(*instance, 0, {0xb7b6b5b4b3b2b1b0_u64, 1_u32}), Result());
         EXPECT_EQ(instance->memory->substr(0, 10), expected);
 
-        EXPECT_THAT(execute(*instance, 0, {0xb7b6b5b4b3b2b1b0, 65537}), Traps());
+        EXPECT_THAT(execute(*instance, 0, {0xb7b6b5b4b3b2b1b0_u64, 65537_u32}), Traps());
     }
 }
 
@@ -899,9 +899,9 @@ TEST(execute, imported_two_functions_different_type)
     auto instance =
         instantiate(*module, {{host_foo1, module->typesec[0]}, {host_foo2, module->typesec[1]}});
 
-    EXPECT_THAT(execute(*instance, 0, {20, 22}), Result(42));
-    EXPECT_THAT(execute(*instance, 1, {0x3000'0000}), Result(0x900'0000'0000'0000));
-    EXPECT_THAT(execute(*instance, 2, {20}), Result(0x2a002a));
+    EXPECT_THAT(execute(*instance, 0, {20_u32, 22_u32}), Result(42));
+    EXPECT_THAT(execute(*instance, 1, {0x3000'0000_u64}), Result(0x900'0000'0000'0000));
+    EXPECT_THAT(execute(*instance, 2, {20_u64}), Result(0x2a002a));
 }
 
 TEST(execute, imported_function_traps)

--- a/test/unittests/execute_test.cpp
+++ b/test/unittests/execute_test.cpp
@@ -374,7 +374,7 @@ TEST(execute, i32_load_overflow)
     auto instance = instantiate(parse(wasm));
 
     // Offset is 0x7fffffff + 0 => 0x7fffffff
-    EXPECT_THAT(execute(*instance, 0, {Value{0}}), Traps());
+    EXPECT_THAT(execute(*instance, 0, {0_u32}), Traps());
     // Offset is 0x7fffffff + 0x80000000 => 0xffffffff
     EXPECT_THAT(execute(*instance, 0, {0x80000000}), Traps());
     // Offset is 0x7fffffff + 0x80000001 => 0x100000000
@@ -396,7 +396,7 @@ TEST(execute, i64_load_overflow)
     auto instance = instantiate(parse(wasm));
 
     // Offset is 0x7fffffff + 0 => 0x7fffffff
-    EXPECT_THAT(execute(*instance, 0, {Value{0}}), Traps());
+    EXPECT_THAT(execute(*instance, 0, {0_u32}), Traps());
     // Offset is 0x7fffffff + 0x80000000 => 0xffffffff
     EXPECT_THAT(execute(*instance, 0, {0x80000000}), Traps());
     // Offset is 0x7fffffff + 0x80000001 => 0x100000000
@@ -520,7 +520,7 @@ TEST(execute, i32_store_overflow)
     auto instance = instantiate(parse(wasm));
 
     // Offset is 0x7fffffff + 0 => 0x7fffffff
-    EXPECT_THAT(execute(*instance, 0, {Value{0}}), Traps());
+    EXPECT_THAT(execute(*instance, 0, {0_u32}), Traps());
     // Offset is 0x7fffffff + 0x80000000 => 0xffffffff
     EXPECT_THAT(execute(*instance, 0, {0x80000000}), Traps());
     // Offset is 0x7fffffff + 0x80000001 => 0x100000000
@@ -544,7 +544,7 @@ TEST(execute, i64_store_overflow)
     auto instance = instantiate(parse(wasm));
 
     // Offset is 0x7fffffff + 0 => 0x7fffffff
-    EXPECT_THAT(execute(*instance, 0, {Value{0}}), Traps());
+    EXPECT_THAT(execute(*instance, 0, {0_u32}), Traps());
     // Offset is 0x7fffffff + 0x80000000 => 0xffffffff
     EXPECT_THAT(execute(*instance, 0, {0x80000000}), Traps());
     // Offset is 0x7fffffff + 0x80000001 => 0x100000000

--- a/test/unittests/typed_value_test.cpp
+++ b/test/unittests/typed_value_test.cpp
@@ -73,3 +73,23 @@ TEST(typed_value, construct)
     EXPECT_EQ(f64.type, ValType::f64);
     EXPECT_EQ(f64.value.f64, -2.2250738585072014e-308);
 }
+
+TEST(typed_value, u32_literal)
+{
+    static_assert(std::is_same_v<decltype(0_u32), uint32_t>);
+    EXPECT_EQ(0_u32, uint32_t{0});
+    EXPECT_EQ(1_u32, uint32_t{1});
+    EXPECT_EQ(0xffffffff_u32, uint32_t{0xffffffff});
+
+    EXPECT_THROW(operator""_u32(0x100000000), const char*);
+}
+
+TEST(typed_value, u64_literal)
+{
+    static_assert(std::is_same_v<decltype(0_u64), uint64_t>);
+    EXPECT_EQ(0_u64, uint64_t{0});
+    EXPECT_EQ(1_u64, uint64_t{1});
+    EXPECT_EQ(0xffffffff_u64, uint64_t{0xffffffff});
+    EXPECT_EQ(0x100000000_u64, uint64_t{0x100000000});
+    EXPECT_EQ(0xffffffffffffffff_u64, uint64_t{0xffffffffffffffff});
+}

--- a/test/utils/execute_helpers.hpp
+++ b/test/utils/execute_helpers.hpp
@@ -6,21 +6,38 @@
 
 #include "execute.hpp"
 #include <test/utils/instantiate_helpers.hpp>
+#include <test/utils/typed_value.hpp>
+#include <algorithm>
 #include <initializer_list>
 
 namespace fizzy::test
 {
 inline ExecutionResult execute(
-    Instance& instance, FuncIdx func_idx, std::initializer_list<Value> args)
+    Instance& instance, FuncIdx func_idx, std::initializer_list<TypedValue> typed_args)
 {
-    assert(args.size() == instance.module->get_function_type(func_idx).inputs.size());
-    return fizzy::execute(instance, func_idx, args.begin());
+    const auto& func_type = instance.module->get_function_type(func_idx);
+    const auto [typed_arg_it, type_it] = std::mismatch(std::cbegin(typed_args),
+        std::cend(typed_args), std::cbegin(func_type.inputs), std::cend(func_type.inputs),
+        [](const auto& typed_arg, auto type) { return typed_arg.type == type; });
+    if (typed_arg_it != std::cend(typed_args) && type_it != std::cend(func_type.inputs))
+        throw std::invalid_argument{"invalid type of the argument " +
+                                    std::to_string(typed_arg_it - std::cbegin(typed_args))};
+    else if (typed_arg_it != std::cend(typed_args))
+        throw std::invalid_argument{"too many arguments"};
+    else if (type_it != std::cend(func_type.inputs))
+        throw std::invalid_argument{"too few arguments"};
+
+    std::vector<fizzy::Value> args(typed_args.size());
+    std::transform(std::cbegin(typed_args), std::cend(typed_args), std::begin(args),
+        [](const auto& typed_arg) { return typed_arg.value; });
+
+    return fizzy::execute(instance, func_idx, args.data());
 }
 
 inline ExecutionResult execute(const std::unique_ptr<const Module>& module, FuncIdx func_idx,
-    std::initializer_list<Value> args)
+    std::initializer_list<TypedValue> typed_args)
 {
     auto instance = instantiate(*module);
-    return test::execute(*instance, func_idx, args);
+    return test::execute(*instance, func_idx, typed_args);
 }
 }  // namespace fizzy::test

--- a/test/utils/typed_value.hpp
+++ b/test/utils/typed_value.hpp
@@ -8,6 +8,21 @@
 
 namespace fizzy::test
 {
+/// Creates uint64_t value with intention to map it to i64 WebAssembly type.
+inline constexpr uint64_t operator"" _u64(unsigned long long x)
+{
+    return uint64_t{x};  // Guarantees lossless conversion if needed.
+}
+
+/// Creates uint32_t value with intention to map it to i32 WebAssembly type.
+inline constexpr uint32_t operator"" _u32(unsigned long long x)
+{
+    const auto v = static_cast<uint32_t>(x);
+    if (v != x)
+        throw "integer literal is too large to be represented in the u32 type";
+    return v;
+}
+
 struct TypedValue
 {
     Value value;


### PR DESCRIPTION
After previously introducing `TypedValue` in #658, this PR adds type checking for execution arguments in unit tests. The type checking is done in `fizzy::test::execute()` so can be bypassed by using `fizzy::execute()` directly. Still most of the tests uses the former.

Later we will add type checking to the execution result and the `Result()` matcher. We will be also able to see the type-checking bypassing cases and correct these if needed.

