### PR TITLE
Call depth limit

### DIFF
--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -37,5 +37,6 @@ constexpr ExecutionResult Void{true};
 constexpr ExecutionResult Trap{false};
 
 // Execute a function on an instance.
-ExecutionResult execute(Instance& instance, FuncIdx func_idx, const Value* args, int depth = 0);
+ExecutionResult execute(
+    Instance& instance, FuncIdx func_idx, const Value* args, int call_depth_limit = CallStackLimit);
 }  // namespace fizzy

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -269,7 +269,7 @@ TEST(api, find_exported_function)
 
     auto opt_function = find_exported_function(*instance, "foo");
     ASSERT_TRUE(opt_function);
-    EXPECT_THAT(opt_function->function(*instance, {}, 0), Result(42));
+    EXPECT_THAT(opt_function->function(*instance, {}, 1), Result(42));
     EXPECT_TRUE(opt_function->type.inputs.empty());
     ASSERT_EQ(opt_function->type.outputs.size(), 1);
     EXPECT_EQ(opt_function->type.outputs[0], ValType::i32);
@@ -296,7 +296,7 @@ TEST(api, find_exported_function)
 
     opt_function = find_exported_function(*instance_reexported_function, "foo");
     ASSERT_TRUE(opt_function);
-    EXPECT_THAT(opt_function->function(*instance, {}, 0), Result(42));
+    EXPECT_THAT(opt_function->function(*instance, {}, 1), Result(42));
     EXPECT_TRUE(opt_function->type.inputs.empty());
     ASSERT_EQ(opt_function->type.outputs.size(), 1);
     EXPECT_EQ(opt_function->type.outputs[0], ValType::i32);

--- a/test/unittests/capi_test.cpp
+++ b/test/unittests/capi_test.cpp
@@ -124,7 +124,7 @@ TEST(capi, find_exported_function)
     EXPECT_EQ(function.type.output, FizzyValueTypeI32);
     EXPECT_NE(function.context, nullptr);
     ASSERT_NE(function.function, nullptr);
-    EXPECT_THAT(function.function(function.context, instance, nullptr, 0), CResult(42));
+    EXPECT_THAT(function.function(function.context, instance, nullptr, 1), CResult(42));
 
     fizzy_free_exported_function(&function);
 
@@ -358,10 +358,10 @@ TEST(capi, instantiate_imported_globals)
     auto instance = fizzy_instantiate(module, nullptr, 0, nullptr, nullptr, globals, 4);
     EXPECT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 0, nullptr, 0), CResult(42));
-    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), CResult(uint64_t{43}));
-    EXPECT_THAT(fizzy_execute(instance, 2, nullptr, 0), CResult(float(44.4)));
-    EXPECT_THAT(fizzy_execute(instance, 3, nullptr, 0), CResult(45.5));
+    EXPECT_THAT(fizzy_execute(instance, 0, nullptr, 1), CResult(42));
+    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 1), CResult(uint64_t{43}));
+    EXPECT_THAT(fizzy_execute(instance, 2, nullptr, 1), CResult(float(44.4)));
+    EXPECT_THAT(fizzy_execute(instance, 3, nullptr, 1), CResult(45.5));
 
     fizzy_free_instance(instance);
 
@@ -593,7 +593,7 @@ TEST(capi, memory_access)
     memory[0] = 0xaa;
     memory[1] = 0xbb;
 
-    EXPECT_EQ(fizzy_execute(instance, 0, nullptr, 0).value.i64, 0x22bbaa);
+    EXPECT_EQ(fizzy_execute(instance, 0, nullptr, 1).value.i64, 0x22bbaa);
 
     fizzy_free_instance(instance);
 }


### PR DESCRIPTION
Alternative to #568.

Here we start `execute()` with some call depth limit which is then decreased by each call. Traps if 0.

Fundamentally, this looks to have similar issues to #568 (e.g. magic -1 depth at start).

However, this has nice property that you don't have to define the call depth limit inside Fizzy. This can be provided by user.

I have not finished fixing tests as they require a lot of changes.