### PR TITLE
refactor: Use span instead of vectors in ExternalFunction

### DIFF
--- a/lib/fizzy/cxx20/span.hpp
+++ b/lib/fizzy/cxx20/span.hpp
@@ -59,6 +59,8 @@ public:
     constexpr T* data() const noexcept { return m_begin; }
     constexpr std::size_t size() const noexcept { return m_size; }
 
+    constexpr bool empty() const noexcept { return m_size == 0; }
+
     constexpr iterator begin() const noexcept { return m_begin; }
     constexpr iterator end() const noexcept { return m_begin + m_size; }
 

--- a/lib/fizzy/instantiate.cpp
+++ b/lib/fizzy/instantiate.cpp
@@ -12,6 +12,11 @@ namespace fizzy
 {
 namespace
 {
+bool equal_types(span<const ValType> valtypes1, span<const ValType> valtypes2) noexcept
+{
+    return std::equal(valtypes1.begin(), valtypes1.end(), valtypes2.begin(), valtypes2.end());
+}
+
 void match_imported_functions(const std::vector<FuncType>& module_imported_types,
     const std::vector<ExternalFunction>& imported_functions)
 {
@@ -24,7 +29,8 @@ void match_imported_functions(const std::vector<FuncType>& module_imported_types
 
     for (size_t i = 0; i < imported_functions.size(); ++i)
     {
-        if (module_imported_types[i] != imported_functions[i].type)
+        if (!equal_types(module_imported_types[i].inputs, imported_functions[i].input_types) ||
+            !equal_types(module_imported_types[i].outputs, imported_functions[i].output_types))
         {
             throw instantiate_error{"function " + std::to_string(i) +
                                     " type doesn't match module's imported function type"};

--- a/lib/fizzy/instantiate.hpp
+++ b/lib/fizzy/instantiate.hpp
@@ -21,9 +21,14 @@ namespace fizzy
 struct ExecutionResult;
 struct Instance;
 
+/// Function representing WebAssembly or host function execution.
+using execute_function = std::function<ExecutionResult(Instance&, const Value*, int depth)>;
+
+/// Function with associated input/output types,
+/// used to represent both imported and exported functions.
 struct ExternalFunction
 {
-    std::function<ExecutionResult(Instance&, const Value*, int depth)> function;
+    execute_function function;
     FuncType type;
 };
 
@@ -113,7 +118,7 @@ struct ImportedFunction
     std::string name;
     std::vector<ValType> inputs;
     std::optional<ValType> output;
-    std::function<ExecutionResult(Instance&, const Value*, int depth)> function;
+    execute_function function;
 };
 
 /// Create vector of ExternalFunctions ready to be passed to instantiate.

--- a/lib/fizzy/instantiate.hpp
+++ b/lib/fizzy/instantiate.hpp
@@ -29,7 +29,17 @@ using execute_function = std::function<ExecutionResult(Instance&, const Value*, 
 struct ExternalFunction
 {
     execute_function function;
-    FuncType type;
+    span<const ValType> input_types;
+    span<const ValType> output_types;
+
+    ExternalFunction(execute_function _function, span<const ValType> _input_types,
+        span<const ValType> _output_types)
+      : function(std::move(_function)), input_types(_input_types), output_types(_output_types)
+    {}
+
+    ExternalFunction(execute_function _function, const FuncType& type)
+      : function(std::move(_function)), input_types(type.inputs), output_types(type.outputs)
+    {}
 };
 
 /// Table element, which references a function in any instance.

--- a/test/unittests/api_test.cpp
+++ b/test/unittests/api_test.cpp
@@ -270,9 +270,9 @@ TEST(api, find_exported_function)
     auto opt_function = find_exported_function(*instance, "foo");
     ASSERT_TRUE(opt_function);
     EXPECT_THAT(opt_function->function(*instance, {}, 0), Result(42));
-    EXPECT_TRUE(opt_function->type.inputs.empty());
-    ASSERT_EQ(opt_function->type.outputs.size(), 1);
-    EXPECT_EQ(opt_function->type.outputs[0], ValType::i32);
+    EXPECT_TRUE(opt_function->input_types.empty());
+    ASSERT_EQ(opt_function->output_types.size(), 1);
+    EXPECT_EQ(opt_function->output_types[0], ValType::i32);
 
     EXPECT_FALSE(find_exported_function(*instance, "bar").has_value());
 
@@ -292,14 +292,14 @@ TEST(api, find_exported_function)
     const auto bar_type = FuncType{{}, {ValType::i32}};
 
     auto instance_reexported_function =
-        instantiate(parse(wasm_reexported_function), {{bar, bar_type}});
+        instantiate(parse(wasm_reexported_function), {{bar, bar_type.inputs, bar_type.outputs}});
 
-    opt_function = find_exported_function(*instance_reexported_function, "foo");
-    ASSERT_TRUE(opt_function);
-    EXPECT_THAT(opt_function->function(*instance, {}, 0), Result(42));
-    EXPECT_TRUE(opt_function->type.inputs.empty());
-    ASSERT_EQ(opt_function->type.outputs.size(), 1);
-    EXPECT_EQ(opt_function->type.outputs[0], ValType::i32);
+    auto opt_reexported_function = find_exported_function(*instance_reexported_function, "foo");
+    ASSERT_TRUE(opt_reexported_function);
+    EXPECT_THAT(opt_reexported_function->function(*instance, {}, 0), Result(42));
+    EXPECT_TRUE(opt_reexported_function->input_types.empty());
+    ASSERT_EQ(opt_reexported_function->output_types.size(), 1);
+    EXPECT_EQ(opt_reexported_function->output_types[0], ValType::i32);
 
     EXPECT_FALSE(find_exported_function(*instance, "bar").has_value());
 

--- a/test/unittests/cxx20_span_test.cpp
+++ b/test/unittests/cxx20_span_test.cpp
@@ -13,8 +13,14 @@ using namespace testing;
 
 TEST(cxx20_span, vector)
 {
+    std::vector<uint64_t> vec_empty;
+    span<const uint64_t> s_empty(vec_empty);
+    EXPECT_TRUE(s_empty.empty());
+    EXPECT_EQ(s_empty.size(), 0);
+
     std::vector<uint64_t> vec{1, 2, 3, 4, 5, 6};
     span<const uint64_t> s(&vec[1], 3);
+    EXPECT_FALSE(s.empty());
     EXPECT_EQ(s.size(), 3);
     EXPECT_EQ(s[0], 2);
     EXPECT_EQ(s[1], 3);
@@ -27,6 +33,7 @@ TEST(cxx20_span, vector)
     EXPECT_EQ(s[0], 100);
 
     const span<const uint64_t> s2 = vec;  // Implicit conversion from vector.
+    EXPECT_FALSE(s2.empty());
     for (size_t i = 0; i < vec.size(); ++i)
         EXPECT_EQ(s2[i], vec[i]);
 }
@@ -34,14 +41,26 @@ TEST(cxx20_span, vector)
 TEST(cxx20_span, array)
 {
     float a1[] = {1, 2, 3};
+
+    span<const float> s1_empty(&a1[0], size_t{0});
+    EXPECT_TRUE(s1_empty.empty());
+    EXPECT_EQ(s1_empty.size(), 0);
+
     span<const float> s1 = a1;
+    EXPECT_FALSE(s1.empty());
     EXPECT_EQ(s1.size(), 3);
     EXPECT_EQ(s1[0], 1.0f);
     EXPECT_EQ(s1[1], 2.0f);
     EXPECT_EQ(s1[2], 3.0f);
 
+    const std::array<float, 0> a2_empty = {};
+    span<const float> s2_empty(a2_empty);
+    EXPECT_TRUE(s2_empty.empty());
+    EXPECT_EQ(s2_empty.size(), 0);
+
     const std::array a2 = {0.1f, 0.2f, 0.3f};
     span<const float> s2 = a2;
+    EXPECT_FALSE(s2.empty());
     EXPECT_EQ(s2.size(), 3);
     EXPECT_EQ(s2[0], 0.1f);
     EXPECT_EQ(s2[1], 0.2f);
@@ -51,6 +70,11 @@ TEST(cxx20_span, array)
 TEST(cxx20_span, stack)
 {
     OperandStack stack(nullptr, 0, 0, 4);
+
+    span<const Value> s_empty(stack.rend(), size_t{0});
+    EXPECT_TRUE(s_empty.empty());
+    EXPECT_EQ(s_empty.size(), 0);
+
     stack.push(10);
     stack.push(11);
     stack.push(12);
@@ -58,6 +82,7 @@ TEST(cxx20_span, stack)
 
     constexpr auto num_items = 2;
     span<const Value> s(stack.rend() - num_items, num_items);
+    EXPECT_FALSE(s.empty());
     EXPECT_EQ(s.size(), 2);
     EXPECT_EQ(s[0].i64, 12);
     EXPECT_EQ(s[1].i64, 13);
@@ -71,8 +96,14 @@ TEST(cxx20_span, initializer_list)
     // This only works for lvalue initializer_lists, but not as `span{1, 2, 3}`.
     // Dangerous usage because user need to keep the initializer_list alive
     // as long as span is being used.
+    const std::initializer_list<uint64_t> empty = {};
+    span<const uint64_t> s_empty(empty);
+    EXPECT_TRUE(s_empty.empty());
+    EXPECT_EQ(s_empty.size(), 0);
+
     const std::initializer_list<uint64_t> init = {1, 2, 3};
     const auto s = span<const uint64_t>(init);
+    EXPECT_FALSE(s.empty());
     EXPECT_EQ(s.size(), 3);
     EXPECT_EQ(s[0], 1);
     EXPECT_EQ(s[1], 2);

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -53,10 +53,10 @@ TEST(instantiate, imported_functions)
 
     ASSERT_EQ(instance->imported_functions.size(), 1);
     EXPECT_EQ(*instance->imported_functions[0].function.target<decltype(&host_fn_1)>(), &host_fn_1);
-    ASSERT_EQ(instance->imported_functions[0].type.inputs.size(), 1);
-    EXPECT_EQ(instance->imported_functions[0].type.inputs[0], ValType::i32);
-    ASSERT_EQ(instance->imported_functions[0].type.outputs.size(), 1);
-    EXPECT_EQ(instance->imported_functions[0].type.outputs[0], ValType::i32);
+    ASSERT_EQ(instance->imported_functions[0].input_types.size(), 1);
+    EXPECT_EQ(instance->imported_functions[0].input_types[0], ValType::i32);
+    ASSERT_EQ(instance->imported_functions[0].output_types.size(), 1);
+    EXPECT_EQ(instance->imported_functions[0].output_types[0], ValType::i32);
 }
 
 TEST(instantiate, imported_functions_multiple)
@@ -74,13 +74,13 @@ TEST(instantiate, imported_functions_multiple)
 
     ASSERT_EQ(instance->imported_functions.size(), 2);
     EXPECT_EQ(*instance->imported_functions[0].function.target<decltype(&host_fn_1)>(), &host_fn_1);
-    ASSERT_EQ(instance->imported_functions[0].type.inputs.size(), 1);
-    EXPECT_EQ(instance->imported_functions[0].type.inputs[0], ValType::i32);
-    ASSERT_EQ(instance->imported_functions[0].type.outputs.size(), 1);
-    EXPECT_EQ(instance->imported_functions[0].type.outputs[0], ValType::i32);
+    ASSERT_EQ(instance->imported_functions[0].input_types.size(), 1);
+    EXPECT_EQ(instance->imported_functions[0].input_types[0], ValType::i32);
+    ASSERT_EQ(instance->imported_functions[0].output_types.size(), 1);
+    EXPECT_EQ(instance->imported_functions[0].output_types[0], ValType::i32);
     EXPECT_EQ(*instance->imported_functions[1].function.target<decltype(&host_fn_2)>(), &host_fn_2);
-    EXPECT_TRUE(instance->imported_functions[1].type.inputs.empty());
-    EXPECT_TRUE(instance->imported_functions[1].type.outputs.empty());
+    EXPECT_TRUE(instance->imported_functions[1].input_types.empty());
+    EXPECT_TRUE(instance->imported_functions[1].output_types.empty());
 }
 
 TEST(instantiate, imported_functions_not_enough)


### PR DESCRIPTION
This allows to avoid extra vector allocation when going from C `FizzyExternalFunction` to C++ `fizzy::ExternalFunction` and also when C++ API returns from `find_exported_function()`.

Also I it helps with `std::function` refactoring in #643 

The downside is that user has to ensure that arrays pointed to by spans live long enough (usually these arrays are in `Instance`, and you need this `Instance` to run `ExternalFunction` anyway).

This leaves `ImportedFunction` still using `vector<ValType>` for input types, I think it's convenient to leave it like this, otherwise it wouldn't be possible to pass input types as inline initializer list like this:
```cpp
        auto imports = fizzy::resolve_imported_functions(
            *module, {
                         {"env", "adler32", {fizzy::ValType::i32, fizzy::ValType::i32},
                             fizzy::ValType::i32, env_adler32},
                     });
```
neither like this
```cpp
    std::vector<ImportedFunction> imported_functions = {
        {"mod1", "foo1", {}, ValType::i32, function_returning_value(0)},
        {"mod1", "foo2", {ValType::i32}, ValType::i32, function_returning_value(1)},
        {"mod2", "foo1", {ValType::i32}, ValType::i32, function_returning_value(2)},
        {"mod2", "foo2", {ValType::i64, ValType::i32}, std::nullopt, function_returning_void},
    };
```
(Spans have to point to some container, so explicit vector declarations would be required on the user side) 

Also note that to make above use cases work, `resolve_imported_functions()` produces `ExternalFunction`s with type `span`s pointing to the type vector inside `Module`, not to the passed vector. Not sure whether it's confusing from the API standpoint, but it works.