### PR TITLE
Correct max call depth

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -504,7 +504,7 @@ inline bool invoke_function(const FuncType& func_type, uint32_t func_idx, Instan
 ExecutionResult execute(Instance& instance, FuncIdx func_idx, const Value* args, int depth)
 {
     assert(depth >= 0);
-    if (depth > CallStackLimit)
+    if (depth >= CallStackLimit)
         return Trap;
 
     const auto& func_type = instance.module->get_function_type(func_idx);

--- a/lib/fizzy/limits.hpp
+++ b/lib/fizzy/limits.hpp
@@ -19,9 +19,9 @@ static_assert(MemoryPagesValidationLimit == 65536);
 /// The default hard limit of the memory size (256MB) as number of pages.
 constexpr uint32_t DefaultMemoryPagesLimit = (256 * 1024 * 1024ULL) / PageSize;
 
-/// Call depth limit is set to default limit in wabt.
-/// See
-/// https://github.com/WebAssembly/wabt/blob/ae2140ddc6969ef53599fe2fab81818de65db875/src/interp/interp.h#L1007
-// TODO: review this
+/// The limit of the size of the call stack, i.e. how many calls are allowed to be stacked up
+/// in a single execution thread. Allowed values for call depth levels are [0, CallStackLimit-1].
+/// The current value is the same as the default limit in WABT:
+/// https://github.com/WebAssembly/wabt/blob/1.0.20/src/interp/interp.h#L1027
 constexpr int CallStackLimit = 2048;
 }  // namespace fizzy


### PR DESCRIPTION
Previously there were 2049 number of recursive calls allowed (depth levels from 0 to 2048). With this change the number is reduced to 2048 (depth levels from 0 to 2047).