### PR TITLE
test: Avoid dead host functions

### DIFF
--- a/test/unittests/execute_control_test.cpp
+++ b/test/unittests/execute_control_test.cpp
@@ -664,11 +664,8 @@ TEST(execute_control, br_1_out_of_function_and_imported_function)
         "0061736d010000000108026000006000017f02150108696d706f727465640866756e6374696f6e000003020101"
         "0a0d010b00034041010c010b41000b");
 
-    constexpr auto fake_imported_function = [](Instance&, const Value*,
-                                                int) noexcept -> ExecutionResult { return Void; };
-
     const auto module = parse(bin);
-    auto instance = instantiate(*module, {{fake_imported_function, module->typesec[0]}});
+    auto instance = instantiate(*module, {{nullptr, module->typesec[0]}});
     EXPECT_THAT(execute(*instance, 1, {}), Result(1));
 }
 


### PR DESCRIPTION
Replace host functions not being executed with null pointers or common functions. Code coverage is happy.