### PR TITLE
test: Log error message for spectests expecting a failure

### DIFF
--- a/test/smoketests/spectests/CMakeLists.txt
+++ b/test/smoketests/spectests/CMakeLists.txt
@@ -43,6 +43,16 @@ set_tests_properties(
 )
 
 add_test(
+        NAME fizzy/smoketests/spectests/showpassed-error-message
+        COMMAND fizzy-spectests ${CMAKE_CURRENT_LIST_DIR}/default --show-passed
+)
+set_tests_properties(
+        fizzy/smoketests/spectests/showpassed-error-message
+        PROPERTIES
+        PASS_REGULAR_EXPRESSION "assert_malformed PASSED invalid wasm module prefix"
+)
+
+add_test(
         NAME fizzy/smoketests/spectests/showskipped
         COMMAND fizzy-spectests ${CMAKE_CURRENT_LIST_DIR}/default --show-skipped
 )

--- a/test/spectests/spectests.cpp
+++ b/test/spectests/spectests.cpp
@@ -293,7 +293,7 @@ public:
                 catch (fizzy::parser_error const& ex)
                 {
                     if (type == "assert_malformed")
-                        pass();
+                        pass(ex.what());
                     else
                         fail(std::string{"Unexpected parser error: "} + ex.what());
                     continue;
@@ -301,7 +301,7 @@ public:
                 catch (fizzy::validation_error const& ex)
                 {
                     if (type == "assert_invalid")
-                        pass();
+                        pass(ex.what());
                     else
                         fail(std::string{"Unexpected validation error: "} + ex.what());
                     continue;
@@ -332,7 +332,7 @@ public:
                     if (!error.empty())
                     {
                         if (type == "assert_unlinkable")
-                            pass();
+                            pass(error);
                         else
                             fail(error);
                         continue;
@@ -357,7 +357,7 @@ public:
                     if (ex.what() == std::string{"start function failed to execute"})
                     {
                         if (type == "assert_uninstantiable")
-                            pass();
+                            pass(ex.what());
                         else
                             fail(std::string{"Instantiation failed with error: "} + ex.what());
                     }
@@ -366,7 +366,7 @@ public:
                         if (type == "assert_uninstantiable")
                             fail(std::string{"Instantiation failed with error: "} + ex.what());
                         else
-                            pass();
+                            pass(ex.what());
                     }
                     continue;
                 }
@@ -622,11 +622,11 @@ private:
         return {result, ""};
     }
 
-    void pass()
+    void pass(std::string_view message = {})
     {
         ++m_results.passed;
         if (m_settings.show_passed)
-            add_to_result_details("PASSED");
+            add_to_result_details("PASSED " + std::string{message});
         log_no_newline(".");
     }
 


### PR DESCRIPTION
This can be helpful, when you'd like to check whether the invalid case fails for the right reason.
(It is displayed only with `--show-passed` option)