### PR TITLE
cmake: Remove redundant target_compile_features(... cxx_std_17)

### DIFF
--- a/test/bench/CMakeLists.txt
+++ b/test/bench/CMakeLists.txt
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_executable(fizzy-bench bench.cpp)
-target_compile_features(fizzy-bench PRIVATE cxx_std_17)
 target_link_libraries(fizzy-bench PRIVATE fizzy::fizzy-internal fizzy::test-utils benchmark::benchmark)
 
 if(UNIX AND NOT APPLE)

--- a/test/spectests/CMakeLists.txt
+++ b/test/spectests/CMakeLists.txt
@@ -8,7 +8,6 @@ endif()
 find_package(nlohmann_json REQUIRED)
 
 add_executable(fizzy-spectests spectests.cpp)
-target_compile_features(fizzy-spectests PRIVATE cxx_std_17)
 target_link_libraries(fizzy-spectests PRIVATE fizzy::fizzy-internal fizzy::test-utils nlohmann_json::nlohmann_json)
 
 if(UNIX AND NOT APPLE)

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -30,6 +30,5 @@ target_sources(
     wasm_engine.hpp
 )
 
-target_compile_features(test-utils PUBLIC cxx_std_17)
 target_include_directories(test-utils PUBLIC ${PROJECT_SOURCE_DIR})
 target_link_libraries(test-utils PUBLIC fizzy::fizzy-internal PRIVATE wabt::wabt wasm3::wasm3 GTest::gtest)

--- a/tools/wasi/CMakeLists.txt
+++ b/tools/wasi/CMakeLists.txt
@@ -7,7 +7,6 @@ include(ProjectUVWASI)
 set(fizzy_include_dir ${PROJECT_SOURCE_DIR}/lib/fizzy)
 
 add_executable(fizzy-wasi wasi.cpp)
-target_compile_features(fizzy-wasi PRIVATE cxx_std_17)
 target_link_libraries(fizzy-wasi PRIVATE fizzy::fizzy-internal uvwasi::uvwasi)
 target_include_directories(fizzy-wasi PRIVATE ${fizzy_include_dir})
 


### PR DESCRIPTION
These are not needed, because `fizzy` library includes it, as pointed out in https://github.com/wasmx/fizzy/pull/329#discussion_r461691537