### PR TITLE
Update uvwasi repository address

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Licensed under the [Apache License, Version 2.0].
 [C API]: ./include/fizzy/fizzy.h
 
 [WASI]: https://github.com/WebAssembly/WASI
-[uvwasi]: https://github.com/cjihrig/uvwasi
+[uvwasi]: https://github.com/nodejs/uvwasi
 [wasi_snapshot_preview1]: https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/witx/wasi_snapshot_preview1.witx
 
 [webassembly badge]: https://img.shields.io/badge/WebAssembly-Engine-informational.svg?logo=webassembly

--- a/cmake/ProjectUVWASI.cmake
+++ b/cmake/ProjectUVWASI.cmake
@@ -23,7 +23,7 @@ ExternalProject_Add(uvwasi
     DOWNLOAD_DIR ${prefix}/downloads
     SOURCE_DIR ${source_dir}
     BINARY_DIR ${binary_dir}
-    URL https://github.com/cjihrig/uvwasi/archive/v0.0.10.tar.gz
+    URL https://github.com/nodejs/uvwasi/archive/v0.0.10.tar.gz
     URL_HASH SHA256=39135f4dd4a44013399ceed7166391ffc5c09655e4bfbf851da2be039e6985df
     CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>

--- a/tools/wasi/wasi.cpp
+++ b/tools/wasi/wasi.cpp
@@ -119,7 +119,7 @@ bool run(int argc, const char** argv)
     };
 
     // Initialisation settings.
-    // TODO: Make const after https://github.com/cjihrig/uvwasi/pull/155 is merged.
+    // TODO: Make const after https://github.com/nodejs/uvwasi/pull/155 is merged.
     uvwasi_options_t options = {
         3,           // sizeof fd_table
         0, nullptr,  // NOTE: no remappings


### PR DESCRIPTION
uvwasi was transferred into the Node.js GitHub org.
This commit updates the repository's link.