### PR TITLE
ci: Don't run doxygen installation in background

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -270,12 +270,6 @@ jobs:
   lint:
     executor: linux-clang-latest
     steps:
-      - run:
-          name: "Install doxygen"
-          background: true
-          command: |
-            sudo apt-get -q update
-            sudo apt-get -qy install doxygen graphviz
       - checkout
       - run:
           name: "Run shellcheck"
@@ -325,6 +319,11 @@ jobs:
           cmake_options: -DCMAKE_TOOLCHAIN_FILE=~/project/cmake/toolchains/libc++.cmake -DCMAKE_CXX_STANDARD=20
       - install_testfloat
       - test
+      - run:
+          name: "Install doxygen"
+          command: |
+            sudo apt-get -q update
+            sudo apt-get -qy install doxygen graphviz
       - run:
           name: "Doxygen"
           command: doxygen


### PR DESCRIPTION
Trying to fix random lint job failures.