### PR TITLE
WASI testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,11 +12,11 @@ include(CableBuildType)
 include(CableCompilerSettings)
 include(CMakeDependentOption)
 
-option(FIZZY_WASI "Enable WASI support" OFF)
-
 option(FIZZY_TESTING "Enable Fizzy internal tests" OFF)
 cmake_dependent_option(HUNTER_ENABLED "Enable Hunter package manager" ON
     "FIZZY_TESTING" OFF)
+
+cmake_dependent_option(FIZZY_WASI "Enable WASI support" OFF "NOT FIZZY_TESTING" ON)
 
 cmake_dependent_option(FIZZY_FUZZING "Enable Fizzy fuzzing" OFF "FIZZY_TESTING" OFF)
 

--- a/circle.yml
+++ b/circle.yml
@@ -448,8 +448,9 @@ jobs:
     executor: linux-gcc-latest
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
-      # TODO: Enable detect_stack_use_after_return=1 when https://gcc.gnu.org/bugzilla/show_bug.cgi?id=97414 is fixed.
-      ASAN_OPTIONS: detect_invalid_pointer_pairs=2:check_initialization_order=1
+      # TODO: Enable detect_stack_use_after_return=1 with GCC11: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=97414.
+      # TODO: Enable detect_invalid_pointer_pairs=2 with GCC11: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=97415.
+      ASAN_OPTIONS: detect_invalid_pointer_pairs=1:check_initialization_order=1
       UBSAN_OPTIONS: halt_on_error=1
     steps:
       - checkout

--- a/test/smoketests/wasi/CMakeLists.txt
+++ b/test/smoketests/wasi/CMakeLists.txt
@@ -19,7 +19,7 @@ add_test(
 set_tests_properties(
     fizzy/smoketests/wasi/cli-invalid-file
     PROPERTIES
-    PASS_REGULAR_EXPRESSION "File does not exists or is irregular:"
+    PASS_REGULAR_EXPRESSION "Not a file:"
 )
 
 add_test(
@@ -29,7 +29,7 @@ add_test(
 set_tests_properties(
     fizzy/smoketests/wasi/cli-missing-file
     PROPERTIES
-    PASS_REGULAR_EXPRESSION "File does not exists or is irregular:"
+    PASS_REGULAR_EXPRESSION "File does not exist:"
 )
 
 add_test(

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -5,7 +5,7 @@
 include(GoogleTest)
 
 add_executable(fizzy-unittests)
-target_link_libraries(fizzy-unittests PRIVATE fizzy::fizzy-internal fizzy::test-utils GTest::gtest_main GTest::gmock)
+target_link_libraries(fizzy-unittests PRIVATE fizzy::fizzy-internal fizzy::wasi fizzy::test-utils GTest::gtest_main GTest::gmock)
 
 target_sources(
     fizzy-unittests PRIVATE
@@ -40,6 +40,7 @@ target_sources(
     validation_stack_type_test.cpp
     validation_test.cpp
     value_test.cpp
+    wasi_test.cpp
     wasm_engine_test.cpp
 )
 

--- a/test/unittests/wasi_test.cpp
+++ b/test/unittests/wasi_test.cpp
@@ -1,0 +1,20 @@
+// Fizzy: A fast WebAssembly interpreter
+// Copyright 2021 The Fizzy Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "wasi.hpp"
+#include <gtest/gtest.h>
+#include <test/utils/hex.hpp>
+#include <sstream>
+
+using namespace fizzy;
+using namespace fizzy::test;
+
+TEST(wasi, no_file)
+{
+    const char* args[]{"ABC"};
+
+    std::ostringstream err;
+    EXPECT_FALSE(wasi::run(std::size(args), args, err));
+    EXPECT_EQ(err.str(), "File does not exists or is irregular: ABC\n");
+}

--- a/test/unittests/wasi_test.cpp
+++ b/test/unittests/wasi_test.cpp
@@ -15,6 +15,6 @@ TEST(wasi, no_file)
     const char* args[]{"ABC"};
 
     std::ostringstream err;
-    EXPECT_FALSE(wasi::run(std::size(args), args, err));
+    EXPECT_FALSE(wasi::load_and_run(std::size(args), args, err));
     EXPECT_EQ(err.str(), "File does not exist: \"ABC\"\n");
 }

--- a/test/unittests/wasi_test.cpp
+++ b/test/unittests/wasi_test.cpp
@@ -16,5 +16,5 @@ TEST(wasi, no_file)
 
     std::ostringstream err;
     EXPECT_FALSE(wasi::run(std::size(args), args, err));
-    EXPECT_EQ(err.str(), "File does not exists or is irregular: ABC\n");
+    EXPECT_EQ(err.str(), "File does not exist: \"ABC\"\n");
 }

--- a/tools/wasi/CMakeLists.txt
+++ b/tools/wasi/CMakeLists.txt
@@ -6,9 +6,8 @@ include(ProjectUVWASI)
 
 add_library(wasi)
 add_library(fizzy::wasi ALIAS wasi)
-target_compile_features(wasi PUBLIC cxx_std_17)
 target_include_directories(wasi PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(wasi PRIVATE fizzy::fizzy-internal uvwasi::uvwasi)
+target_link_libraries(wasi PUBLIC fizzy::fizzy-internal PRIVATE uvwasi::uvwasi)
 target_sources(wasi PRIVATE wasi.cpp wasi.hpp)
 
 add_executable(fizzy-wasi)

--- a/tools/wasi/CMakeLists.txt
+++ b/tools/wasi/CMakeLists.txt
@@ -1,14 +1,12 @@
 # Fizzy: A fast WebAssembly interpreter
-# Copyright 2019-2020 The Fizzy Authors.
+# Copyright 2020 The Fizzy Authors.
 # SPDX-License-Identifier: Apache-2.0
 
 include(ProjectUVWASI)
 
-set(fizzy_include_dir ${PROJECT_SOURCE_DIR}/lib/fizzy)
-
-add_executable(fizzy-wasi wasi.cpp)
+add_executable(fizzy-wasi)
 target_link_libraries(fizzy-wasi PRIVATE fizzy::fizzy-internal uvwasi::uvwasi)
-target_include_directories(fizzy-wasi PRIVATE ${fizzy_include_dir})
+target_sources(fizzy-wasi PRIVATE main.cpp wasi.cpp wasi.hpp)
 
 if(UNIX AND NOT APPLE)
     # For libstdc++ up to version 8 (included) this is needed for proper <filesystem> support.

--- a/tools/wasi/CMakeLists.txt
+++ b/tools/wasi/CMakeLists.txt
@@ -4,9 +4,16 @@
 
 include(ProjectUVWASI)
 
+add_library(wasi)
+add_library(fizzy::wasi ALIAS wasi)
+target_compile_features(wasi PUBLIC cxx_std_17)
+target_include_directories(wasi PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(wasi PRIVATE fizzy::fizzy-internal uvwasi::uvwasi)
+target_sources(wasi PRIVATE wasi.cpp wasi.hpp)
+
 add_executable(fizzy-wasi)
-target_link_libraries(fizzy-wasi PRIVATE fizzy::fizzy-internal uvwasi::uvwasi)
-target_sources(fizzy-wasi PRIVATE main.cpp wasi.cpp wasi.hpp)
+target_link_libraries(fizzy-wasi PRIVATE fizzy::wasi)
+target_sources(fizzy-wasi PRIVATE main.cpp)
 
 if(UNIX AND NOT APPLE)
     # For libstdc++ up to version 8 (included) this is needed for proper <filesystem> support.

--- a/tools/wasi/main.cpp
+++ b/tools/wasi/main.cpp
@@ -16,7 +16,7 @@ int main(int argc, const char** argv)
         }
 
         // Drop "fizzy-wasi" from the argv, but keep the wasm file name in argv[1].
-        const bool res = fizzy::wasi::run(argc - 1, argv + 1);
+        const bool res = fizzy::wasi::run(argc - 1, argv + 1, std::cerr);
         return res ? 0 : 1;
     }
     catch (const std::exception& ex)

--- a/tools/wasi/main.cpp
+++ b/tools/wasi/main.cpp
@@ -1,0 +1,27 @@
+// Fizzy: A fast WebAssembly interpreter
+// Copyright 2021 The Fizzy Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "wasi.hpp"
+#include <iostream>
+
+int main(int argc, const char** argv)
+{
+    try
+    {
+        if (argc < 2)
+        {
+            std::cerr << "Missing executable argument\n";
+            return -1;
+        }
+
+        // Drop "fizzy-wasi" from the argv, but keep the wasm file name in argv[1].
+        const bool res = fizzy::wasi::run(argc - 1, argv + 1);
+        return res ? 0 : 1;
+    }
+    catch (const std::exception& ex)
+    {
+        std::cerr << "Exception: " << ex.what() << "\n";
+        return -2;
+    }
+}

--- a/tools/wasi/main.cpp
+++ b/tools/wasi/main.cpp
@@ -16,7 +16,7 @@ int main(int argc, const char** argv)
         }
 
         // Drop "fizzy-wasi" from the argv, but keep the wasm file name in argv[1].
-        const bool res = fizzy::wasi::run(argc - 1, argv + 1, std::cerr);
+        const bool res = fizzy::wasi::load_and_run(argc - 1, argv + 1, std::cerr);
         return res ? 0 : 1;
     }
     catch (const std::exception& ex)

--- a/tools/wasi/wasi.cpp
+++ b/tools/wasi/wasi.cpp
@@ -132,7 +132,7 @@ std::optional<bytes> load_file(std::string_view file, std::ostream& err) noexcep
     }
 }
 
-bool run(int argc, const char** argv, std::ostream& err)
+bool run(bytes_view wasm_binary, int argc, const char* argv[], std::ostream& err)
 {
     constexpr auto ns = "wasi_snapshot_preview1";
     const std::vector<ImportedFunction> wasi_functions = {
@@ -166,10 +166,6 @@ bool run(int argc, const char** argv, std::ostream& err)
             << "\n";
         return false;
     }
-
-    const auto wasm_binary = load_wasm_binary(argv[0], err);
-    if (wasm_binary.empty())
-        return false;
 
     auto module = parse(wasm_binary);
     auto imports = resolve_imported_functions(*module, wasi_functions);
@@ -207,5 +203,14 @@ bool run(int argc, const char** argv, std::ostream& err)
     assert(!result.has_value);
 
     return true;
+}
+
+bool load_and_run(int argc, const char** argv, std::ostream& err)
+{
+    const auto wasm_binary = load_file(argv[0], err);
+    if (!wasm_binary)
+        return false;
+
+    return run(*wasm_binary, argc, argv, err);
 }
 }  // namespace fizzy::wasi

--- a/tools/wasi/wasi.cpp
+++ b/tools/wasi/wasi.cpp
@@ -1,7 +1,8 @@
 // Fizzy: A fast WebAssembly interpreter
-// Copyright 2019-2020 The Fizzy Authors.
+// Copyright 2020 The Fizzy Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "wasi.hpp"
 #include "execute.hpp"
 #include "limits.hpp"
 #include "parser.hpp"
@@ -96,6 +97,7 @@ ExecutionResult environ_sizes_get(Instance& instance, const Value* args, int)
     uvwasi_serdes_write_uint32_t(instance.memory->data(), environ_buf_size, 0);
     return Value{uint32_t{UVWASI_ESUCCESS}};
 }
+}  // namespace
 
 bool run(int argc, const char** argv)
 {
@@ -184,26 +186,4 @@ bool run(int argc, const char** argv)
 
     return true;
 }
-}  // namespace
 }  // namespace fizzy::wasi
-
-int main(int argc, const char** argv)
-{
-    try
-    {
-        if (argc < 2)
-        {
-            std::cerr << "Missing executable argument\n";
-            return -1;
-        }
-
-        // Drop "fizzy-wasi" from the argv, but keep the wasm file name in argv[1].
-        const bool res = fizzy::wasi::run(argc - 1, argv + 1);
-        return res ? 0 : 1;
-    }
-    catch (const std::exception& ex)
-    {
-        std::cerr << "Exception: " << ex.what() << "\n";
-        return -2;
-    }
-}

--- a/tools/wasi/wasi.hpp
+++ b/tools/wasi/wasi.hpp
@@ -1,0 +1,10 @@
+// Fizzy: A fast WebAssembly interpreter
+// Copyright 2021 The Fizzy Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace fizzy::wasi
+{
+/// Executes WASI main function with given CLI arguments.
+// TODO: Make noexcept.
+bool run(int argc, const char** argv);
+}

--- a/tools/wasi/wasi.hpp
+++ b/tools/wasi/wasi.hpp
@@ -2,10 +2,19 @@
 // Copyright 2021 The Fizzy Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <bytes.hpp>
 #include <iosfwd>
+#include <optional>
 
 namespace fizzy::wasi
 {
+/// Loads a binary file at the given path.
+///
+/// @param  file    Path to the file.
+/// @param  err     Error output stream.
+/// @return         Content of the loaded file.
+std::optional<bytes> load_file(std::string_view file, std::ostream& err) noexcept;
+
 /// Executes WASI main function with given CLI arguments.
 ///
 /// @param  argc    Number of CLI arguments.
@@ -15,4 +24,4 @@ namespace fizzy::wasi
 ///
 /// @todo Make noexcept.
 bool run(int argc, const char** argv, std::ostream& err);
-}
+}  // namespace fizzy::wasi

--- a/tools/wasi/wasi.hpp
+++ b/tools/wasi/wasi.hpp
@@ -15,13 +15,23 @@ namespace fizzy::wasi
 /// @return         Content of the loaded file.
 std::optional<bytes> load_file(std::string_view file, std::ostream& err) noexcept;
 
-/// Executes WASI main function with given CLI arguments.
+/// Loads the wasm file (path in first CLI argument) and
+/// executes WASI main function with given CLI arguments.
 ///
-/// @param  argc    Number of CLI arguments.
-/// @param  argv    Array of CLI arguments.
+/// @param  argc    Number of CLI arguments. Must be >= 1.
+/// @param  argv    Array of CLI arguments. The first argument must be wasm file path.
 /// @param  err     Error output stream.
 /// @return         False in case of error.
 ///
 /// @todo Make noexcept.
-bool run(int argc, const char** argv, std::ostream& err);
+bool load_and_run(int argc, const char** argv, std::ostream& err);
+
+/// Executes WASI main function from the wasm binary with given CLI arguments.
+///
+/// @param  wasm_binary    Wasm binary.
+/// @param  argc           Number of CLI arguments.
+/// @param  argv           Array of CLI arguments. The first argument should be wasm file path.
+/// @param  err            Error output stream.
+/// @return                False in case of error.
+bool run(bytes_view wasm_binary, int argc, const char* argv[], std::ostream& err);
 }  // namespace fizzy::wasi

--- a/tools/wasi/wasi.hpp
+++ b/tools/wasi/wasi.hpp
@@ -2,9 +2,17 @@
 // Copyright 2021 The Fizzy Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <iosfwd>
+
 namespace fizzy::wasi
 {
 /// Executes WASI main function with given CLI arguments.
-// TODO: Make noexcept.
-bool run(int argc, const char** argv);
+///
+/// @param  argc    Number of CLI arguments.
+/// @param  argv    Array of CLI arguments.
+/// @param  err     Error output stream.
+/// @return         False in case of error.
+///
+/// @todo Make noexcept.
+bool run(int argc, const char** argv, std::ostream& err);
 }


### PR DESCRIPTION
Closes #708 

TODO
- [x] Separate wasm file loading from execution.
- [x] Consider separate unittest executable: `fizzy-wasi-unittests`. This relaxes `WASI` and `TESTING` CMake options dependencies. (resolution: It is fine for now; less CMake option combinations is good for development and nobody reported issues with compiling libuvwasi so far; the CMake option can always be added later).
- [x] Consider different location for `fizzy::wasi` library (resolution: it is fine where it is).
- [x] ~~Create interface for WASI implementation / uvwasi. This allows mocking the implementation.~~ (To be done in a separate PR later)