### PR TITLE
refactor: ExecuteFunction without std::function

### DIFF
--- a/lib/fizzy/instantiate.hpp
+++ b/lib/fizzy/instantiate.hpp
@@ -46,9 +46,6 @@ class ExecuteFunction
     std::any m_host_context;
 
 public:
-    /// Default function constructor.
-    ExecuteFunction() noexcept = default;
-
     // WebAssembly function constructor.
     ExecuteFunction(Instance& instance, FuncIdx func_idx) noexcept
       : m_instance{&instance}, m_func_idx{func_idx}

--- a/test/unittests/execute_control_test.cpp
+++ b/test/unittests/execute_control_test.cpp
@@ -665,7 +665,7 @@ TEST(execute_control, br_1_out_of_function_and_imported_function)
         "0a0d010b00034041010c010b41000b");
 
     const auto module = parse(bin);
-    auto instance = instantiate(*module, {{nullptr, module->typesec[0]}});
+    auto instance = instantiate(*module, {{{nullptr}, module->typesec[0]}});
     EXPECT_THAT(execute(*instance, 1, {}), Result(1));
 }
 

--- a/test/utils/fizzy_engine.cpp
+++ b/test/utils/fizzy_engine.cpp
@@ -28,7 +28,8 @@ public:
 
 namespace
 {
-fizzy::ExecutionResult env_adler32(fizzy::Instance& instance, const fizzy::Value* args, int)
+fizzy::ExecutionResult env_adler32(
+    std::any&, fizzy::Instance& instance, const fizzy::Value* args, int)
 {
     assert(instance.memory != nullptr);
     const auto ret = fizzy::test::adler32(

--- a/tools/wasi/wasi.cpp
+++ b/tools/wasi/wasi.cpp
@@ -21,19 +21,19 @@ namespace
 // and we are a single-run tool. This may change in the future and should reevaluate.
 uvwasi_t state;
 
-ExecutionResult return_enosys(Instance&, const Value*, int)
+ExecutionResult return_enosys(std::any&, Instance&, const Value*, int)
 {
     return Value{uint32_t{UVWASI_ENOSYS}};
 }
 
-ExecutionResult proc_exit(Instance&, const Value* args, int)
+ExecutionResult proc_exit(std::any&, Instance&, const Value* args, int)
 {
     uvwasi_proc_exit(&state, static_cast<uvwasi_exitcode_t>(args[0].as<uint32_t>()));
     // Should not reach this.
     return Trap;
 }
 
-ExecutionResult fd_write(Instance& instance, const Value* args, int)
+ExecutionResult fd_write(std::any&, Instance& instance, const Value* args, int)
 {
     const auto fd = args[0].as<uint32_t>();
     const auto iov_ptr = args[1].as<uint32_t>();
@@ -54,7 +54,7 @@ ExecutionResult fd_write(Instance& instance, const Value* args, int)
     return Value{uint32_t{ret}};
 }
 
-ExecutionResult fd_read(Instance& instance, const Value* args, int)
+ExecutionResult fd_read(std::any&, Instance& instance, const Value* args, int)
 {
     const auto fd = args[0].as<uint32_t>();
     const auto iov_ptr = args[1].as<uint32_t>();
@@ -75,7 +75,7 @@ ExecutionResult fd_read(Instance& instance, const Value* args, int)
     return Value{uint32_t{ret}};
 }
 
-ExecutionResult fd_prestat_get(Instance& instance, const Value* args, int)
+ExecutionResult fd_prestat_get(std::any&, Instance& instance, const Value* args, int)
 {
     const auto fd = args[0].as<uint32_t>();
     const auto prestat_ptr = args[1].as<uint32_t>();
@@ -88,7 +88,7 @@ ExecutionResult fd_prestat_get(Instance& instance, const Value* args, int)
     return Value{uint32_t{ret}};
 }
 
-ExecutionResult environ_sizes_get(Instance& instance, const Value* args, int)
+ExecutionResult environ_sizes_get(std::any&, Instance& instance, const Value* args, int)
 {
     const auto environc = args[0].as<uint32_t>();
     const auto environ_buf_size = args[1].as<uint32_t>();


### PR DESCRIPTION
Simpler alternative to #643.
