### PR TITLE
Upgrade Hunter to get newer nlohmann_json

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,7 +1,0 @@
-
-hunter_config(
-    benchmark
-    VERSION 1.5.0
-    URL https://github.com/google/benchmark/archive/v1.5.0.tar.gz
-    SHA1 f8743dc33b5cef47b1a04a58eac647856ef6a5ce
-)

--- a/cmake/Hunter/init.cmake
+++ b/cmake/Hunter/init.cmake
@@ -23,7 +23,6 @@ if(NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 HunterGate(
-    URL https://github.com/cpp-pm/hunter/archive/v0.23.239.tar.gz
-    SHA1 135567a8493ab3499187bce1f2a8df9b449febf3
-    LOCAL
+    URL https://github.com/cpp-pm/hunter/archive/v0.23.294.tar.gz
+    SHA1 0dd1ee8723d54a15822519c17a877c1f281fce39
 )


### PR DESCRIPTION
Required for #716 

Older version of nlohmann_json has some compilation errors when `<any>` is included, see https://github.com/wasmx/fizzy/pull/716#issuecomment-779365591 for links.