### PR TITLE
Construct Value only from uint32_t/uint64_t

### DIFF
--- a/lib/fizzy/value.hpp
+++ b/lib/fizzy/value.hpp
@@ -23,14 +23,13 @@ union Value
 
     /// Converting constructors from integer types
     ///
-    /// We need to support {signed,unsigned} x {32,64} integers. However, due to uint64_t being
-    /// defined differently in different implementations we need to avoid the alias and provide
-    /// constructors for unsigned long and unsigned long long independently.
-    constexpr Value(unsigned int v) noexcept : i32{v} {}
-    constexpr Value(unsigned long v) noexcept : i64{v} {}
-    constexpr Value(unsigned long long v) noexcept : i64{v} {}
-    constexpr Value(int64_t v) noexcept : i64{static_cast<uint64_t>(v)} {}
+    /// Only fixed-size integer types are supported: {signed,unsigned} x {32,64}.
+    /// On the platforms where uint64_t is not unsigned long, it is expected that
+    /// Value cannot be constructed out of unsigned long literals.
+    constexpr Value(uint32_t v) noexcept : i32{v} {}
+    constexpr Value(uint64_t v) noexcept : i64{v} {}
     constexpr Value(int32_t v) noexcept : i32{static_cast<uint32_t>(v)} {}
+    constexpr Value(int64_t v) noexcept : i64{static_cast<uint64_t>(v)} {}
 
     constexpr Value(float v) noexcept : f32{v} {}
     constexpr Value(double v) noexcept : f64{v} {}

--- a/test/unittests/value_test.cpp
+++ b/test/unittests/value_test.cpp
@@ -61,8 +61,6 @@ TEST(value, constructor_from_unsigned_ints)
 {
     EXPECT_EQ(Value{uint32_t{0xdededefe}}.i32, 0xdededefe);
     EXPECT_EQ(Value{uint64_t{0xdededededededefe}}.i64, 0xdededededededefe);
-    EXPECT_EQ(Value{static_cast<unsigned long>(0xdededededededefe)}.i64, 0xdededededededefe);
-    EXPECT_EQ(Value{static_cast<unsigned long long>(0xdededededededefe)}.i64, 0xdededededededefe);
 }
 
 TEST(value, constructor_from_signed_ints)
@@ -88,7 +86,7 @@ TEST(value, as_integer_32bit_value)
 
 TEST(value, as_integer_64bit_value)
 {
-    const Value v{0xfffffffffffffffe};
+    const Value v{uint64_t{0xfffffffffffffffe}};
     EXPECT_EQ(v.as<uint64_t>(), 0xfffffffffffffffe);
     EXPECT_EQ(v.as<int64_t>(), -2);
 }


### PR DESCRIPTION
This disables Value constructors for unsigned integers for types other
than uint32_t/uint64_t. This requires users to use these types.
This can cause portability issues on macOS/Linux if type like
unsigned long is used. This also helps in 32-bit port.