### PR TITLE
Drop default depth param from execute()

### DIFF
--- a/include/fizzy/fizzy.h
+++ b/include/fizzy/fizzy.h
@@ -524,7 +524,6 @@ bool fizzy_find_exported_global(
 ///
 /// @param  instance    Pointer to module instance. Cannot be NULL.
 /// @param  args        Pointer to the argument array. Can be NULL if function has 0 inputs.
-/// @param  depth       Call stack depth.
 /// @return             Result of execution.
 ///
 /// @note
@@ -532,7 +531,7 @@ bool fizzy_find_exported_global(
 /// When number of passed arguments or their types are different from the ones defined by the
 /// function type, behaviour is undefined.
 FizzyExecutionResult fizzy_execute(
-    FizzyInstance* instance, uint32_t func_idx, const FizzyValue* args, int depth);
+    FizzyInstance* instance, uint32_t func_idx, const FizzyValue* args);
 
 #ifdef __cplusplus
 }

--- a/lib/fizzy/capi.cpp
+++ b/lib/fizzy/capi.cpp
@@ -588,9 +588,9 @@ size_t fizzy_get_instance_memory_size(FizzyInstance* instance)
 }
 
 FizzyExecutionResult fizzy_execute(
-    FizzyInstance* instance, uint32_t func_idx, const FizzyValue* args, int depth)
+    FizzyInstance* instance, uint32_t func_idx, const FizzyValue* args)
 {
-    const auto result = fizzy::execute(*unwrap(instance), func_idx, unwrap(args), depth);
+    const auto result = fizzy::execute(*unwrap(instance), func_idx, unwrap(args));
     return wrap(result);
 }
 }

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -49,8 +49,16 @@ constexpr ExecutionResult Trap{false};
 /// @param  args        The pointer to the arguments. The number of items and their types must match
 ///                     the expected number of input parameters of the function, otherwise undefined
 ///                     behaviour (including crash) happens.
-/// @param  depth       The call depth (indexing starts at 0). Can be left at the default setting.
+/// @param  depth       The call depth (indexing starts at 0).
 /// @return             The result of the execution.
 ExecutionResult execute(
-    Instance& instance, FuncIdx func_idx, const Value* args, int depth = 0) noexcept;
+    Instance& instance, FuncIdx func_idx, const Value* args, int depth) noexcept;
+
+/// Execute a function from an instance starting at default depth of 0.
+/// Arguments and behavior is the same as in the other execute().
+inline ExecutionResult execute(Instance& instance, FuncIdx func_idx, const Value* args) noexcept
+{
+    constexpr int depth = 0;
+    return execute(instance, func_idx, args, depth);
+}
 }  // namespace fizzy

--- a/test/unittests/capi_test.cpp
+++ b/test/unittests/capi_test.cpp
@@ -586,10 +586,10 @@ TEST(capi, instantiate_imported_globals)
     auto instance = fizzy_instantiate(module, nullptr, 0, nullptr, nullptr, globals, 4);
     EXPECT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 0, nullptr, 0), CResult(42_u32));
-    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), CResult(43_u64));
-    EXPECT_THAT(fizzy_execute(instance, 2, nullptr, 0), CResult(44.4f));
-    EXPECT_THAT(fizzy_execute(instance, 3, nullptr, 0), CResult(45.5));
+    EXPECT_THAT(fizzy_execute(instance, 0, nullptr), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 1, nullptr), CResult(43_u64));
+    EXPECT_THAT(fizzy_execute(instance, 2, nullptr), CResult(44.4f));
+    EXPECT_THAT(fizzy_execute(instance, 3, nullptr), CResult(45.5));
 
     fizzy_free_instance(instance);
 
@@ -719,10 +719,10 @@ TEST(capi, resolve_instantiate_functions)
     ASSERT_NE(instance, nullptr);
 
     FizzyValue arg;
-    EXPECT_THAT(fizzy_execute(instance, 0, &arg, 0), CResult(42_u32));
-    EXPECT_THAT(fizzy_execute(instance, 1, &arg, 0), CResult(43_u64));
-    EXPECT_THAT(fizzy_execute(instance, 2, &arg, 0), CResult(44.44f));
-    EXPECT_THAT(fizzy_execute(instance, 3, &arg, 0), CResult(45.45));
+    EXPECT_THAT(fizzy_execute(instance, 0, &arg), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 1, &arg), CResult(43_u64));
+    EXPECT_THAT(fizzy_execute(instance, 2, &arg), CResult(44.44f));
+    EXPECT_THAT(fizzy_execute(instance, 3, &arg), CResult(45.45));
 
     fizzy_free_instance(instance);
 
@@ -774,8 +774,8 @@ TEST(capi, resolve_instantiate_function_duplicate)
     auto instance = fizzy_resolve_instantiate(module, host_funcs, 1, nullptr, nullptr, nullptr, 0);
     ASSERT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 0, nullptr, 0), CResult(42_u32));
-    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 0, nullptr), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 1, nullptr), CResult(42_u32));
 
     fizzy_free_instance(instance);
 }
@@ -827,10 +827,10 @@ TEST(capi, resolve_instantiate_globals)
         fizzy_resolve_instantiate(module, &mod1foo1, 1, nullptr, nullptr, host_globals, 4);
     ASSERT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), CResult(42_u32));
-    EXPECT_THAT(fizzy_execute(instance, 2, nullptr, 0), CResult(43_u32));
-    EXPECT_THAT(fizzy_execute(instance, 3, nullptr, 0), CResult(44_u64));
-    EXPECT_THAT(fizzy_execute(instance, 4, nullptr, 0), CResult(45_u64));
+    EXPECT_THAT(fizzy_execute(instance, 1, nullptr), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 2, nullptr), CResult(43_u32));
+    EXPECT_THAT(fizzy_execute(instance, 3, nullptr), CResult(44_u64));
+    EXPECT_THAT(fizzy_execute(instance, 4, nullptr), CResult(45_u64));
 
     fizzy_free_instance(instance);
 
@@ -843,10 +843,10 @@ TEST(capi, resolve_instantiate_globals)
         module, &mod1foo1, 1, nullptr, nullptr, host_globals_reordered, 4);
     EXPECT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), CResult(42_u32));
-    EXPECT_THAT(fizzy_execute(instance, 2, nullptr, 0), CResult(43_u32));
-    EXPECT_THAT(fizzy_execute(instance, 3, nullptr, 0), CResult(44_u64));
-    EXPECT_THAT(fizzy_execute(instance, 4, nullptr, 0), CResult(45_u64));
+    EXPECT_THAT(fizzy_execute(instance, 1, nullptr), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 2, nullptr), CResult(43_u32));
+    EXPECT_THAT(fizzy_execute(instance, 3, nullptr), CResult(44_u64));
+    EXPECT_THAT(fizzy_execute(instance, 4, nullptr), CResult(45_u64));
 
     fizzy_free_instance(instance);
 
@@ -859,10 +859,10 @@ TEST(capi, resolve_instantiate_globals)
         fizzy_resolve_instantiate(module, &mod1foo1, 1, nullptr, nullptr, host_globals_extra, 4);
     EXPECT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), CResult(42_u32));
-    EXPECT_THAT(fizzy_execute(instance, 2, nullptr, 0), CResult(43_u32));
-    EXPECT_THAT(fizzy_execute(instance, 3, nullptr, 0), CResult(44_u64));
-    EXPECT_THAT(fizzy_execute(instance, 4, nullptr, 0), CResult(45_u64));
+    EXPECT_THAT(fizzy_execute(instance, 1, nullptr), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 2, nullptr), CResult(43_u32));
+    EXPECT_THAT(fizzy_execute(instance, 3, nullptr), CResult(44_u64));
+    EXPECT_THAT(fizzy_execute(instance, 4, nullptr), CResult(45_u64));
 
     fizzy_free_instance(instance);
 
@@ -897,8 +897,8 @@ TEST(capi, resolve_instantiate_global_duplicate)
         fizzy_resolve_instantiate(module, nullptr, 0, nullptr, nullptr, host_globals, 1);
     ASSERT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 0, nullptr, 0), CResult(42_u32));
-    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 0, nullptr), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 1, nullptr), CResult(42_u32));
 
     fizzy_free_instance(instance);
 }
@@ -994,7 +994,7 @@ TEST(capi, memory_access)
     memory[0] = 0xaa;
     memory[1] = 0xbb;
 
-    EXPECT_THAT(fizzy_execute(instance, 0, nullptr, 0), CResult(0x22bbaa_u32));
+    EXPECT_THAT(fizzy_execute(instance, 0, nullptr), CResult(0x22bbaa_u32));
 
     fizzy_free_instance(instance);
 }
@@ -1036,7 +1036,7 @@ TEST(capi, imported_memory_access)
     auto* instance = fizzy_instantiate(module, nullptr, 0, nullptr, &memory, nullptr, 0);
     ASSERT_NE(instance, nullptr);
 
-    EXPECT_EQ(fizzy_execute(instance, 0, nullptr, 0).value.i32, 0x221100);
+    EXPECT_EQ(fizzy_execute(instance, 0, nullptr).value.i32, 0x221100);
 
     EXPECT_EQ(fizzy_get_instance_memory_size(instance), 65536);
 
@@ -1046,8 +1046,8 @@ TEST(capi, imported_memory_access)
     memory_data[0] = 0xaa;
     memory_data[1] = 0xbb;
 
-    EXPECT_EQ(fizzy_execute(instance_memory, 0, nullptr, 0).value.i32, 0x22bbaa);
-    EXPECT_EQ(fizzy_execute(instance, 0, nullptr, 0).value.i32, 0x22bbaa);
+    EXPECT_EQ(fizzy_execute(instance_memory, 0, nullptr).value.i32, 0x22bbaa);
+    EXPECT_EQ(fizzy_execute(instance, 0, nullptr).value.i32, 0x22bbaa);
 
     fizzy_free_instance(instance);
     fizzy_free_instance(instance_memory);
@@ -1073,11 +1073,11 @@ TEST(capi, execute)
     auto instance = fizzy_instantiate(module, nullptr, 0, nullptr, nullptr, nullptr, 0);
     ASSERT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 0, nullptr, 0), CResult());
-    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 0, nullptr), CResult());
+    EXPECT_THAT(fizzy_execute(instance, 1, nullptr), CResult(42_u32));
     FizzyValue args[] = {{42}, {2}};
-    EXPECT_THAT(fizzy_execute(instance, 2, args, 0), CResult(21_u32));
-    EXPECT_THAT(fizzy_execute(instance, 3, nullptr, 0), CTraps());
+    EXPECT_THAT(fizzy_execute(instance, 2, args), CResult(21_u32));
+    EXPECT_THAT(fizzy_execute(instance, 3, nullptr), CTraps());
 
     fizzy_free_instance(instance);
 }
@@ -1112,10 +1112,10 @@ TEST(capi, execute_with_host_function)
     auto instance = fizzy_instantiate(module, host_funcs, 2, nullptr, nullptr, nullptr, 0);
     ASSERT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 0, nullptr, 0), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 0, nullptr), CResult(42_u32));
 
     FizzyValue args[] = {{42}, {2}};
-    EXPECT_THAT(fizzy_execute(instance, 1, args, 0), CResult(21_u32));
+    EXPECT_THAT(fizzy_execute(instance, 1, args), CResult(21_u32));
 
     fizzy_free_instance(instance);
 }
@@ -1142,7 +1142,7 @@ TEST(capi, imported_function_traps)
     auto instance = fizzy_instantiate(module, host_funcs, 1, nullptr, nullptr, nullptr, 0);
     ASSERT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), CTraps());
+    EXPECT_THAT(fizzy_execute(instance, 1, nullptr), CTraps());
 
     fizzy_free_instance(instance);
 }
@@ -1171,7 +1171,7 @@ TEST(capi, imported_function_void)
     auto instance = fizzy_instantiate(module, host_funcs, 1, nullptr, nullptr, nullptr, 0);
     ASSERT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), CResult());
+    EXPECT_THAT(fizzy_execute(instance, 1, nullptr), CResult());
     EXPECT_TRUE(called);
 
     fizzy_free_instance(instance);
@@ -1219,7 +1219,7 @@ TEST(capi, imported_function_from_another_module)
     ASSERT_NE(instance2, nullptr);
 
     FizzyValue args[] = {{44}, {2}};
-    EXPECT_THAT(fizzy_execute(instance2, 1, args, 0), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance2, 1, args), CResult(42_u32));
 
     fizzy_free_exported_function(&func);
     fizzy_free_instance(instance2);
@@ -1259,7 +1259,7 @@ TEST(capi, imported_table_from_another_module)
     auto instance2 = fizzy_instantiate(module2, nullptr, 0, &table, nullptr, nullptr, 0);
     ASSERT_NE(instance2, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance2, 0, nullptr, 0), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance2, 0, nullptr), CResult(42_u32));
 
     fizzy_free_instance(instance2);
     fizzy_free_instance(instance1);
@@ -1295,7 +1295,7 @@ TEST(capi, imported_memory_from_another_module)
     auto instance2 = fizzy_instantiate(module2, nullptr, 0, nullptr, &memory, nullptr, 0);
     ASSERT_NE(instance2, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance2, 0, nullptr, 0), CResult(0x00ffaa00_u32));
+    EXPECT_THAT(fizzy_execute(instance2, 0, nullptr), CResult(0x00ffaa00_u32));
 
     fizzy_free_instance(instance2);
     fizzy_free_instance(instance1);
@@ -1331,7 +1331,7 @@ TEST(capi, imported_global_from_another_module)
     auto instance2 = fizzy_instantiate(module2, nullptr, 0, nullptr, nullptr, &global, 1);
     ASSERT_NE(instance2, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance2, 0, nullptr, 0), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance2, 0, nullptr), CResult(42_u32));
 
     fizzy_free_instance(instance2);
     fizzy_free_instance(instance1);

--- a/test/utils/fizzy_c_engine.cpp
+++ b/test/utils/fizzy_c_engine.cpp
@@ -115,7 +115,7 @@ WasmEngine::Result FizzyCEngine::execute(
     assert(func_type.output != FizzyValueTypeF32 && func_type.output != FizzyValueTypeF64 &&
            "floating point result types are not supported");
     const auto first_arg = reinterpret_cast<const FizzyValue*>(args.data());
-    const auto status = fizzy_execute(m_instance.get(), func_idx, first_arg, 0);
+    const auto status = fizzy_execute(m_instance.get(), func_idx, first_arg);
     if (status.trapped)
         return {true, std::nullopt};
     else if (status.has_value)


### PR DESCRIPTION
In preparation for landing `ExecutionContext`, the default value for depth param is dropped in C++ and the param is completely removed from C and Rust (therefore C and Rust are not able to legally call wasm functions from host functions temporarily).