### PR TITLE
Fix cable CMake error message when built as a subdirectory

### DIFF
--- a/cmake/CableBuildType.cmake
+++ b/cmake/CableBuildType.cmake
@@ -42,7 +42,7 @@ macro(cable_set_build_type)
             endif()
             message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
         endif()
-    elseif(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)  # After the main project().
+    elseif(PROJECT_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)  # After the main project().
         message(FATAL_ERROR "cable_set_build_type() must be used before project()")
     endif()  # Sub-project - silently ignore.
 endmacro()


### PR DESCRIPTION
As the title states. If Fizzy is included into a project via `add_subdirectory()` the following error message appears:

```
CMake Error at ext/fizzy/cmake/CableBuildType.cmake:46 (message):
  cable_set_build_type() must be used before project()
Call Stack (most recent call first):
  ext/fizzy/CMakeLists.txt:27 (cable_set_build_type)
```

In almost all cases, `CMAKE_CURRENT_{SOURCE|BINARY|LIST}_DIR` should be used over the non-`CURRENT` versions for this reason.