### PR TITLE
Depth improvements v1: bump depth for host functions

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -24,7 +24,6 @@
 //!         .execute(
 //!             "sum",
 //!             &[fizzy::TypedValue::U32(42), fizzy::TypedValue::U32(24)],
-//!             0,
 //!         )
 //!         .expect("execution failed");
 //!     let result = result
@@ -159,6 +158,7 @@ impl From<u64> for Value {
         Value { i64: v }
     }
 }
+
 impl From<f32> for Value {
     fn from(v: f32) -> Self {
         Value { f32: v }
@@ -383,18 +383,11 @@ impl Instance {
     ///
     /// An invalid index, invalid inputs, or invalid depth can cause undefined behaviour.
     ///
-    /// The `depth` argument sets the initial call depth. Should be set to `0`.
-    ///
     /// # Safety
-    /// This function expects a valid `func_idx`, appropriate number of `args`, and valid `depth`.
-    pub unsafe fn unsafe_execute(
-        &mut self,
-        func_idx: u32,
-        args: &[Value],
-        depth: i32,
-    ) -> ExecutionResult {
+    /// This function expects a valid `func_idx` and appropriate number of `args`.
+    pub unsafe fn unsafe_execute(&mut self, func_idx: u32, args: &[Value]) -> ExecutionResult {
         ExecutionResult {
-            0: sys::fizzy_execute(self.0.as_ptr(), func_idx, args.as_ptr(), depth),
+            0: sys::fizzy_execute(self.0.as_ptr(), func_idx, args.as_ptr()),
         }
     }
 
@@ -408,14 +401,11 @@ impl Instance {
     ///
     /// An error is returned if the function can not be found, inappropriate number of arguments are passed,
     /// or the supplied types are mismatching.
-    ///
-    /// The `depth` argument sets the initial call depth. Should be set to `0`.
     // TODO: consider different approach: Result<TypedValue, Error> where Error::Trap is used for traps
     pub fn execute(
         &mut self,
         name: &str,
         args: &[TypedValue],
-        depth: i32,
     ) -> Result<TypedExecutionResult, String> {
         let func_idx = self.find_exported_function_index(&name);
         if func_idx.is_none() {
@@ -439,7 +429,7 @@ impl Instance {
         // Translate to untyped raw values.
         let args: Vec<Value> = args.iter().map(|v| v.into()).collect();
 
-        let ret = unsafe { self.unsafe_execute(func_idx, &args, depth) };
+        let ret = unsafe { self.unsafe_execute(func_idx, &args) };
         Ok(TypedExecutionResult {
             result: ret.0,
             value_type: func_type.output,
@@ -691,7 +681,7 @@ mod tests {
         )
         */
         let input = hex::decode(
-        "0061736d010000000105016000017f030201000404017000000504010101020606017f0041000b07180403666f6f00000267310300037461620100036d656d02000a06010400412a0b").unwrap();
+            "0061736d010000000105016000017f030201000404017000000504010101020606017f0041000b07180403666f6f00000267310300037461620100036d656d02000a06010400412a0b").unwrap();
 
         let module = parse(&input);
         assert!(module.is_ok());
@@ -726,29 +716,29 @@ mod tests {
         assert!(instance.is_ok());
         let mut instance = instance.unwrap();
 
-        let result = unsafe { instance.unsafe_execute(0, &[], 0) };
+        let result = unsafe { instance.unsafe_execute(0, &[]) };
         assert!(!result.trapped());
         assert!(!result.value().is_some());
 
-        let result = unsafe { instance.unsafe_execute(1, &[], 0) };
+        let result = unsafe { instance.unsafe_execute(1, &[]) };
         assert!(!result.trapped());
         assert!(result.value().is_some());
         assert_eq!(result.value().unwrap().as_i32(), 42);
 
         // Explicit type specification
         let result =
-            unsafe { instance.unsafe_execute(2, &[(42 as i32).into(), (2 as i32).into()], 0) };
+            unsafe { instance.unsafe_execute(2, &[(42 as i32).into(), (2 as i32).into()]) };
         assert!(!result.trapped());
         assert!(result.value().is_some());
         assert_eq!(result.value().unwrap().as_i32(), 21);
 
         // Implicit i64 types (even though the code expects i32)
-        let result = unsafe { instance.unsafe_execute(2, &[42.into(), 2.into()], 0) };
+        let result = unsafe { instance.unsafe_execute(2, &[42.into(), 2.into()]) };
         assert!(!result.trapped());
         assert!(result.value().is_some());
         assert_eq!(result.value().unwrap().as_i32(), 21);
 
-        let result = unsafe { instance.unsafe_execute(3, &[], 0) };
+        let result = unsafe { instance.unsafe_execute(3, &[]) };
         assert!(result.trapped());
         assert!(!result.value().is_some());
     }
@@ -767,7 +757,7 @@ mod tests {
         )
         */
         let input = hex::decode(
-        "0061736d010000000115046000017f60027f7e017f60017d017d60017c017c030504000102030404017000000504010101020606017f0041000b072c0703666f6f000003626172000104706933320002047069363400030267310300037461620100036d656d02000a29040400412a0b080020002001a76a0b0a00200043c3f54840950b0e002000441f85eb51b81e0940a30b").unwrap();
+            "0061736d010000000115046000017f60027f7e017f60017d017d60017c017c030504000102030404017000000504010101020606017f0041000b072c0703666f6f000003626172000104706933320002047069363400030267310300037461620100036d656d02000a29040400412a0b080020002001a76a0b0a00200043c3f54840950b0e002000441f85eb51b81e0940a30b").unwrap();
 
         let module = parse(&input);
         assert!(module.is_ok());
@@ -776,7 +766,7 @@ mod tests {
         let mut instance = instance.unwrap();
 
         // Successful execution.
-        let result = instance.execute("foo", &[], 0);
+        let result = instance.execute("foo", &[]);
         assert!(result.is_ok());
         let result = result.unwrap();
         assert!(!result.trapped());
@@ -784,7 +774,7 @@ mod tests {
         assert_eq!(result.value().unwrap().as_u32().unwrap(), 42);
 
         // Successful execution with arguments.
-        let result = instance.execute("bar", &[TypedValue::U32(42), TypedValue::U64(24)], 0);
+        let result = instance.execute("bar", &[TypedValue::U32(42), TypedValue::U64(24)]);
         assert!(result.is_ok());
         let result = result.unwrap();
         assert!(!result.trapped());
@@ -792,7 +782,7 @@ mod tests {
         assert_eq!(result.value().unwrap().as_u32().unwrap(), 66);
 
         // Successful execution with 32-bit float argument.
-        let result = instance.execute("pi32", &[TypedValue::F32(0.5)], 0);
+        let result = instance.execute("pi32", &[TypedValue::F32(0.5)]);
         assert!(result.is_ok());
         let result = result.unwrap();
         assert!(!result.trapped());
@@ -800,7 +790,7 @@ mod tests {
         assert_eq!(result.value().unwrap().as_f32().unwrap(), 0.15923566);
 
         // Successful execution with 64-bit float argument.
-        let result = instance.execute("pi64", &[TypedValue::F64(0.5)], 0);
+        let result = instance.execute("pi64", &[TypedValue::F64(0.5)]);
         assert!(result.is_ok());
         let result = result.unwrap();
         assert!(!result.trapped());
@@ -811,23 +801,23 @@ mod tests {
         );
 
         // Non-function export.
-        let result = instance.execute("g1", &[], 0);
+        let result = instance.execute("g1", &[]);
         assert_eq!(result.err().unwrap(), "function not found");
 
         // Export not found.
-        let result = instance.execute("baz", &[], 0);
+        let result = instance.execute("baz", &[]);
         assert_eq!(result.err().unwrap(), "function not found");
 
         // Passing more arguments than required.
-        let result = instance.execute("foo", &[TypedValue::U32(42)], 0);
+        let result = instance.execute("foo", &[TypedValue::U32(42)]);
         assert_eq!(result.err().unwrap(), "argument count mismatch");
 
         // Passing less arguments than required.
-        let result = instance.execute("bar", &[], 0);
+        let result = instance.execute("bar", &[]);
         assert_eq!(result.err().unwrap(), "argument count mismatch");
 
         // Passing mismatched types.
-        let result = instance.execute("bar", &[TypedValue::F32(1.0), TypedValue::F64(2.0)], 0);
+        let result = instance.execute("bar", &[TypedValue::F32(1.0), TypedValue::F64(2.0)]);
         assert_eq!(result.err().unwrap(), "argument type mismatch");
     }
 
@@ -1067,7 +1057,7 @@ mod tests {
 
         // Grow with a single page.
         let result = instance
-            .execute("grow", &[TypedValue::U32(1)], 0)
+            .execute("grow", &[TypedValue::U32(1)])
             .expect("successful execution");
         assert!(!result.trapped());
         assert_eq!(
@@ -1101,7 +1091,7 @@ mod tests {
             assert_eq!(mem[3], 0);
         }
         let result = instance
-            .execute("peek", &[TypedValue::U32(0)], 0)
+            .execute("peek", &[TypedValue::U32(0)])
             .expect("successful execution");
         assert!(!result.trapped());
         assert_eq!(
@@ -1164,7 +1154,7 @@ mod tests {
         );
 
         let result = instance
-            .execute("peek", &[TypedValue::U32(0)], 0)
+            .execute("peek", &[TypedValue::U32(0)])
             .expect("successful execution");
         assert!(!result.trapped());
         assert_eq!(
@@ -1178,11 +1168,7 @@ mod tests {
 
         // Change memory via wasm.
         let result = instance
-            .execute(
-                "poke",
-                &[TypedValue::U32(0), TypedValue::U32(0x88776655)],
-                0,
-            )
+            .execute("poke", &[TypedValue::U32(0), TypedValue::U32(0x88776655)])
             .expect("successful execution");
         assert!(!result.trapped());
 

--- a/include/fizzy/fizzy.h
+++ b/include/fizzy/fizzy.h
@@ -520,7 +520,6 @@ bool fizzy_find_exported_global(
 ///
 /// @param  instance    Pointer to module instance. Cannot be NULL.
 /// @param  args        Pointer to the argument array. Can be NULL if function has 0 inputs.
-/// @param  depth       Call stack depth.
 /// @return             Result of execution.
 ///
 /// @note
@@ -528,7 +527,7 @@ bool fizzy_find_exported_global(
 /// When number of passed arguments or their types are different from the ones defined by the
 /// function type, behaviour is undefined.
 FizzyExecutionResult fizzy_execute(
-    FizzyInstance* instance, uint32_t func_idx, const FizzyValue* args, int depth);
+    FizzyInstance* instance, uint32_t func_idx, const FizzyValue* args);
 
 #ifdef __cplusplus
 }

--- a/lib/fizzy/capi.cpp
+++ b/lib/fizzy/capi.cpp
@@ -588,9 +588,9 @@ size_t fizzy_get_instance_memory_size(FizzyInstance* instance)
 }
 
 FizzyExecutionResult fizzy_execute(
-    FizzyInstance* instance, uint32_t func_idx, const FizzyValue* args, int depth)
+    FizzyInstance* instance, uint32_t func_idx, const FizzyValue* args)
 {
-    const auto result = fizzy::execute(*unwrap(instance), func_idx, unwrap(args), depth);
+    const auto result = fizzy::execute(*unwrap(instance), func_idx, unwrap(args));
     return wrap(result);
 }
 }

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -537,7 +537,7 @@ inline bool invoke_function(const FuncType& func_type, uint32_t func_idx, Instan
     assert(stack.size() >= num_args);
     const auto call_args = stack.rend() - num_args;
 
-    const auto ret = execute(instance, func_idx, call_args, depth + 1);
+    const auto ret = execute(instance, func_idx, call_args, depth);
     // Bubble up traps
     if (ret.trapped)
         return false;
@@ -562,7 +562,10 @@ ExecutionResult execute_impl(
 
 ExecutionResult execute(Instance& instance, FuncIdx func_idx, const Value* args, int depth) noexcept
 {
-    assert(depth >= 0);
+    assert(depth >= -1);
+
+    // Clain new call depth level.
+    ++depth;
     if (depth >= CallStackLimit)
         return Trap;
 

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -557,18 +557,26 @@ inline bool invoke_function(const FuncType& func_type, uint32_t func_idx, Instan
 
 }  // namespace
 
+ExecutionResult execute_impl(
+    Instance& instance, FuncIdx func_idx, const Value* args, int depth) noexcept;
+
 ExecutionResult execute(Instance& instance, FuncIdx func_idx, const Value* args, int depth) noexcept
 {
     assert(depth >= 0);
     if (depth >= CallStackLimit)
         return Trap;
 
-    const auto& func_type = instance.module->get_function_type(func_idx);
-
     assert(instance.module->imported_function_types.size() == instance.imported_functions.size());
     if (func_idx < instance.imported_functions.size())
         return instance.imported_functions[func_idx].function(instance, args, depth);
 
+    return execute_impl(instance, func_idx, args, depth);
+}
+
+ExecutionResult execute_impl(
+    Instance& instance, FuncIdx func_idx, const Value* args, int depth) noexcept
+{
+    const auto& func_type = instance.module->get_function_type(func_idx);
     const auto& code = instance.module->get_code(func_idx);
     auto* const memory = instance.memory.get();
 

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -49,8 +49,15 @@ constexpr ExecutionResult Trap{false};
 /// @param  args        The pointer to the arguments. The number of items and their types must match
 ///                     the expected number of input parameters of the function, otherwise undefined
 ///                     behaviour (including crash) happens.
-/// @param  depth       The call depth (indexing starts at 0). Can be left at the default setting.
+/// @param  depth       The call depth (indexing starts at 0).
 /// @return             The result of the execution.
 ExecutionResult execute(
-    Instance& instance, FuncIdx func_idx, const Value* args, int depth = 0) noexcept;
+    Instance& instance, FuncIdx func_idx, const Value* args, int depth) noexcept;
+
+/// Execute a function from an instance starting at default depth of 0.
+inline ExecutionResult execute(Instance& instance, FuncIdx func_idx, const Value* args) noexcept
+{
+    const int depth = 0;
+    return execute(instance, func_idx, args, depth);
+}
 }  // namespace fizzy

--- a/lib/fizzy/execute.hpp
+++ b/lib/fizzy/execute.hpp
@@ -57,7 +57,7 @@ ExecutionResult execute(
 /// Execute a function from an instance starting at default depth of 0.
 inline ExecutionResult execute(Instance& instance, FuncIdx func_idx, const Value* args) noexcept
 {
-    const int depth = 0;
+    const int depth = -1;
     return execute(instance, func_idx, args, depth);
 }
 }  // namespace fizzy

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(
     cxx20_bit_test.cpp
     cxx20_span_test.cpp
     end_to_end_test.cpp
+    execute_call_depth_test.cpp
     execute_call_test.cpp
     execute_control_test.cpp
     execute_death_test.cpp

--- a/test/unittests/capi_test.cpp
+++ b/test/unittests/capi_test.cpp
@@ -586,10 +586,10 @@ TEST(capi, instantiate_imported_globals)
     auto instance = fizzy_instantiate(module, nullptr, 0, nullptr, nullptr, globals, 4);
     EXPECT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 0, nullptr, 0), CResult(42_u32));
-    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), CResult(43_u64));
-    EXPECT_THAT(fizzy_execute(instance, 2, nullptr, 0), CResult(44.4f));
-    EXPECT_THAT(fizzy_execute(instance, 3, nullptr, 0), CResult(45.5));
+    EXPECT_THAT(fizzy_execute(instance, 0, nullptr), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 1, nullptr), CResult(43_u64));
+    EXPECT_THAT(fizzy_execute(instance, 2, nullptr), CResult(44.4f));
+    EXPECT_THAT(fizzy_execute(instance, 3, nullptr), CResult(45.5));
 
     fizzy_free_instance(instance);
 
@@ -719,10 +719,10 @@ TEST(capi, resolve_instantiate_functions)
     ASSERT_NE(instance, nullptr);
 
     FizzyValue arg;
-    EXPECT_THAT(fizzy_execute(instance, 0, &arg, 0), CResult(42_u32));
-    EXPECT_THAT(fizzy_execute(instance, 1, &arg, 0), CResult(43_u64));
-    EXPECT_THAT(fizzy_execute(instance, 2, &arg, 0), CResult(44.44f));
-    EXPECT_THAT(fizzy_execute(instance, 3, &arg, 0), CResult(45.45));
+    EXPECT_THAT(fizzy_execute(instance, 0, &arg), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 1, &arg), CResult(43_u64));
+    EXPECT_THAT(fizzy_execute(instance, 2, &arg), CResult(44.44f));
+    EXPECT_THAT(fizzy_execute(instance, 3, &arg), CResult(45.45));
 
     fizzy_free_instance(instance);
 
@@ -774,8 +774,8 @@ TEST(capi, resolve_instantiate_function_duplicate)
     auto instance = fizzy_resolve_instantiate(module, host_funcs, 1, nullptr, nullptr, nullptr, 0);
     ASSERT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 0, nullptr, 0), CResult(42_u32));
-    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 0, nullptr), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 1, nullptr), CResult(42_u32));
 
     fizzy_free_instance(instance);
 }
@@ -827,10 +827,10 @@ TEST(capi, resolve_instantiate_globals)
         fizzy_resolve_instantiate(module, &mod1foo1, 1, nullptr, nullptr, host_globals, 4);
     ASSERT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), CResult(42_u32));
-    EXPECT_THAT(fizzy_execute(instance, 2, nullptr, 0), CResult(43_u32));
-    EXPECT_THAT(fizzy_execute(instance, 3, nullptr, 0), CResult(44_u64));
-    EXPECT_THAT(fizzy_execute(instance, 4, nullptr, 0), CResult(45_u64));
+    EXPECT_THAT(fizzy_execute(instance, 1, nullptr), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 2, nullptr), CResult(43_u32));
+    EXPECT_THAT(fizzy_execute(instance, 3, nullptr), CResult(44_u64));
+    EXPECT_THAT(fizzy_execute(instance, 4, nullptr), CResult(45_u64));
 
     fizzy_free_instance(instance);
 
@@ -843,10 +843,10 @@ TEST(capi, resolve_instantiate_globals)
         module, &mod1foo1, 1, nullptr, nullptr, host_globals_reordered, 4);
     EXPECT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), CResult(42_u32));
-    EXPECT_THAT(fizzy_execute(instance, 2, nullptr, 0), CResult(43_u32));
-    EXPECT_THAT(fizzy_execute(instance, 3, nullptr, 0), CResult(44_u64));
-    EXPECT_THAT(fizzy_execute(instance, 4, nullptr, 0), CResult(45_u64));
+    EXPECT_THAT(fizzy_execute(instance, 1, nullptr), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 2, nullptr), CResult(43_u32));
+    EXPECT_THAT(fizzy_execute(instance, 3, nullptr), CResult(44_u64));
+    EXPECT_THAT(fizzy_execute(instance, 4, nullptr), CResult(45_u64));
 
     fizzy_free_instance(instance);
 
@@ -859,10 +859,10 @@ TEST(capi, resolve_instantiate_globals)
         fizzy_resolve_instantiate(module, &mod1foo1, 1, nullptr, nullptr, host_globals_extra, 4);
     EXPECT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), CResult(42_u32));
-    EXPECT_THAT(fizzy_execute(instance, 2, nullptr, 0), CResult(43_u32));
-    EXPECT_THAT(fizzy_execute(instance, 3, nullptr, 0), CResult(44_u64));
-    EXPECT_THAT(fizzy_execute(instance, 4, nullptr, 0), CResult(45_u64));
+    EXPECT_THAT(fizzy_execute(instance, 1, nullptr), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 2, nullptr), CResult(43_u32));
+    EXPECT_THAT(fizzy_execute(instance, 3, nullptr), CResult(44_u64));
+    EXPECT_THAT(fizzy_execute(instance, 4, nullptr), CResult(45_u64));
 
     fizzy_free_instance(instance);
 
@@ -897,8 +897,8 @@ TEST(capi, resolve_instantiate_global_duplicate)
         fizzy_resolve_instantiate(module, nullptr, 0, nullptr, nullptr, host_globals, 1);
     ASSERT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 0, nullptr, 0), CResult(42_u32));
-    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 0, nullptr), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 1, nullptr), CResult(42_u32));
 
     fizzy_free_instance(instance);
 }
@@ -994,7 +994,7 @@ TEST(capi, memory_access)
     memory[0] = 0xaa;
     memory[1] = 0xbb;
 
-    EXPECT_THAT(fizzy_execute(instance, 0, nullptr, 0), CResult(0x22bbaa_u32));
+    EXPECT_THAT(fizzy_execute(instance, 0, nullptr), CResult(0x22bbaa_u32));
 
     fizzy_free_instance(instance);
 }
@@ -1036,7 +1036,7 @@ TEST(capi, imported_memory_access)
     auto* instance = fizzy_instantiate(module, nullptr, 0, nullptr, &memory, nullptr, 0);
     ASSERT_NE(instance, nullptr);
 
-    EXPECT_EQ(fizzy_execute(instance, 0, nullptr, 0).value.i32, 0x221100);
+    EXPECT_EQ(fizzy_execute(instance, 0, nullptr).value.i32, 0x221100);
 
     EXPECT_EQ(fizzy_get_instance_memory_size(instance), 65536);
 
@@ -1046,8 +1046,8 @@ TEST(capi, imported_memory_access)
     memory_data[0] = 0xaa;
     memory_data[1] = 0xbb;
 
-    EXPECT_EQ(fizzy_execute(instance_memory, 0, nullptr, 0).value.i32, 0x22bbaa);
-    EXPECT_EQ(fizzy_execute(instance, 0, nullptr, 0).value.i32, 0x22bbaa);
+    EXPECT_EQ(fizzy_execute(instance_memory, 0, nullptr).value.i32, 0x22bbaa);
+    EXPECT_EQ(fizzy_execute(instance, 0, nullptr).value.i32, 0x22bbaa);
 
     fizzy_free_instance(instance);
     fizzy_free_instance(instance_memory);
@@ -1073,11 +1073,11 @@ TEST(capi, execute)
     auto instance = fizzy_instantiate(module, nullptr, 0, nullptr, nullptr, nullptr, 0);
     ASSERT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 0, nullptr, 0), CResult());
-    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 0, nullptr), CResult());
+    EXPECT_THAT(fizzy_execute(instance, 1, nullptr), CResult(42_u32));
     FizzyValue args[] = {{42}, {2}};
-    EXPECT_THAT(fizzy_execute(instance, 2, args, 0), CResult(21_u32));
-    EXPECT_THAT(fizzy_execute(instance, 3, nullptr, 0), CTraps());
+    EXPECT_THAT(fizzy_execute(instance, 2, args), CResult(21_u32));
+    EXPECT_THAT(fizzy_execute(instance, 3, nullptr), CTraps());
 
     fizzy_free_instance(instance);
 }
@@ -1112,10 +1112,10 @@ TEST(capi, execute_with_host_function)
     auto instance = fizzy_instantiate(module, host_funcs, 2, nullptr, nullptr, nullptr, 0);
     ASSERT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 0, nullptr, 0), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance, 0, nullptr), CResult(42_u32));
 
     FizzyValue args[] = {{42}, {2}};
-    EXPECT_THAT(fizzy_execute(instance, 1, args, 0), CResult(21_u32));
+    EXPECT_THAT(fizzy_execute(instance, 1, args), CResult(21_u32));
 
     fizzy_free_instance(instance);
 }
@@ -1142,7 +1142,7 @@ TEST(capi, imported_function_traps)
     auto instance = fizzy_instantiate(module, host_funcs, 1, nullptr, nullptr, nullptr, 0);
     ASSERT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), CTraps());
+    EXPECT_THAT(fizzy_execute(instance, 1, nullptr), CTraps());
 
     fizzy_free_instance(instance);
 }
@@ -1171,7 +1171,7 @@ TEST(capi, imported_function_void)
     auto instance = fizzy_instantiate(module, host_funcs, 1, nullptr, nullptr, nullptr, 0);
     ASSERT_NE(instance, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance, 1, nullptr, 0), CResult());
+    EXPECT_THAT(fizzy_execute(instance, 1, nullptr), CResult());
     EXPECT_TRUE(called);
 
     fizzy_free_instance(instance);
@@ -1219,7 +1219,7 @@ TEST(capi, imported_function_from_another_module)
     ASSERT_NE(instance2, nullptr);
 
     FizzyValue args[] = {{44}, {2}};
-    EXPECT_THAT(fizzy_execute(instance2, 1, args, 0), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance2, 1, args), CResult(42_u32));
 
     fizzy_free_exported_function(&func);
     fizzy_free_instance(instance2);
@@ -1259,7 +1259,7 @@ TEST(capi, imported_table_from_another_module)
     auto instance2 = fizzy_instantiate(module2, nullptr, 0, &table, nullptr, nullptr, 0);
     ASSERT_NE(instance2, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance2, 0, nullptr, 0), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance2, 0, nullptr), CResult(42_u32));
 
     fizzy_free_instance(instance2);
     fizzy_free_instance(instance1);
@@ -1295,7 +1295,7 @@ TEST(capi, imported_memory_from_another_module)
     auto instance2 = fizzy_instantiate(module2, nullptr, 0, nullptr, &memory, nullptr, 0);
     ASSERT_NE(instance2, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance2, 0, nullptr, 0), CResult(0x00ffaa00_u32));
+    EXPECT_THAT(fizzy_execute(instance2, 0, nullptr), CResult(0x00ffaa00_u32));
 
     fizzy_free_instance(instance2);
     fizzy_free_instance(instance1);
@@ -1331,7 +1331,7 @@ TEST(capi, imported_global_from_another_module)
     auto instance2 = fizzy_instantiate(module2, nullptr, 0, nullptr, nullptr, &global, 1);
     ASSERT_NE(instance2, nullptr);
 
-    EXPECT_THAT(fizzy_execute(instance2, 0, nullptr, 0), CResult(42_u32));
+    EXPECT_THAT(fizzy_execute(instance2, 0, nullptr), CResult(42_u32));
 
     fizzy_free_instance(instance2);
     fizzy_free_instance(instance1);

--- a/test/unittests/execute_call_depth_test.cpp
+++ b/test/unittests/execute_call_depth_test.cpp
@@ -1,0 +1,327 @@
+// Fizzy: A fast WebAssembly interpreter
+// Copyright 2021 The Fizzy Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "execute.hpp"
+#include "limits.hpp"
+#include "parser.hpp"
+#include <gtest/gtest.h>
+#include <test/utils/asserts.hpp>
+#include <test/utils/execute_helpers.hpp>
+#include <test/utils/hex.hpp>
+
+/// @file
+/// A set of unit tests inspecting the behavior of call depth limiting.
+
+using namespace fizzy;
+using namespace fizzy::test;
+
+/// Executing at DepthLimit call stack depth immediately traps.
+/// E.g. to create "space" for n calls use `DepthLimit - n`.
+constexpr auto DepthLimit = 2048;
+static_assert(DepthLimit == CallStackLimit);
+
+TEST(execute_call_depth, execute_internal_function)
+{
+    /* wat2wasm
+    (func (result i32) (i32.const 1))
+    */
+    const auto wasm = from_hex("0061736d010000000105016000017f030201000a0601040041010b");
+
+    auto instance = instantiate(parse(wasm));
+    EXPECT_THAT(execute(*instance, 0, {}, DepthLimit - 1), Result(1_u32));
+    EXPECT_THAT(execute(*instance, 0, {}, DepthLimit), Traps());
+}
+
+TEST(execute_call_depth, execute_imported_wasm_function)
+{
+    /* wat2wasm
+    (func (export "f") (result i32) (i32.const 1))
+    */
+    const auto exported_wasm =
+        from_hex("0061736d010000000105016000017f03020100070501016600000a0601040041010b");
+
+    /* wat2wasm
+    (func (import "exporter" "f") (result i32))
+    */
+    const auto executor_wasm =
+        from_hex("0061736d010000000105016000017f020e01086578706f7274657201660000");
+
+    auto exporter = instantiate(parse(exported_wasm));
+    auto executor = instantiate(parse(executor_wasm), {*find_exported_function(*exporter, "f")});
+    EXPECT_THAT(execute(*executor, 0, {}, DepthLimit - 1), Result(1_u32));
+    EXPECT_THAT(execute(*executor, 0, {}, DepthLimit), Traps());
+}
+
+TEST(execute_call_depth, execute_imported_host_function)
+{
+    /* wat2wasm
+    (func (import "host" "f") (result i32))
+    */
+    const auto wasm = from_hex("0061736d010000000105016000017f020a0104686f737401660000");
+
+    static int recorded_depth;
+    constexpr auto host_f = [](std::any&, Instance&, const Value*, int depth) noexcept {
+        recorded_depth = depth;
+        return ExecutionResult{Value{1_u32}};
+    };
+
+    const auto module = parse(wasm);
+    auto instance = instantiate(*module, {{{host_f}, module->typesec[0]}});
+
+    recorded_depth = -1000;
+    EXPECT_THAT(execute(*instance, 0, {}), Result(1_u32));
+    EXPECT_EQ(recorded_depth, 0);
+
+    recorded_depth = -1000;
+    EXPECT_THAT(execute(*instance, 0, {}, DepthLimit - 1), Result(1_u32));
+    EXPECT_EQ(recorded_depth, DepthLimit - 1);
+
+    recorded_depth = -1000;
+    EXPECT_THAT(execute(*instance, 0, {}, DepthLimit), Traps());
+    EXPECT_EQ(recorded_depth, -1000);
+}
+
+TEST(execute_call_depth, execute_imported_host_function_calling_wasm_function)
+{
+    // The imported host function $host_f is executed first. It then calls $leaf internal wasm
+    // function. The host function is obligated to bump depth and pass it along.
+
+    /* wat2wasm
+    (func $host_f (import "host" "f") (result i32))
+    (func $leaf (result i32) (i32.const 1))
+    */
+    const auto wasm =
+        from_hex("0061736d010000000105016000017f020a0104686f737401660000030201000a0601040041010b");
+
+    static int recorded_depth;
+    constexpr auto host_f = [](std::any&, Instance& instance, const Value*, int depth) noexcept {
+        recorded_depth = depth;
+        return fizzy::execute(instance, 1, {}, depth + 1);
+    };
+
+    const auto module = parse(wasm);
+    auto instance = instantiate(*module, {{{host_f}, module->typesec[0]}});
+
+    recorded_depth = -1000;
+    EXPECT_THAT(execute(*instance, 0, {}), Result(1_u32));
+    EXPECT_EQ(recorded_depth, 0);
+
+    recorded_depth = -1000;
+    EXPECT_THAT(execute(*instance, 0, {}, DepthLimit - 2), Result(1_u32));
+    EXPECT_EQ(recorded_depth, DepthLimit - 2);
+
+    recorded_depth = -1000;
+    EXPECT_THAT(execute(*instance, 0, {}, DepthLimit - 1), Traps());
+    EXPECT_EQ(recorded_depth, DepthLimit - 1);
+
+    recorded_depth = -1000;
+    EXPECT_THAT(execute(*instance, 0, {}, DepthLimit), Traps());
+    EXPECT_EQ(recorded_depth, -1000);
+}
+
+
+TEST(execute_call_depth, call_internal_function)
+{
+    /* wat2wasm
+    (func $internal (result i32) (i32.const 1))
+    (func (result i32) (call $internal))
+    */
+    const auto wasm =
+        from_hex("0061736d010000000105016000017f03030200000a0b02040041010b040010000b");
+
+    auto instance = instantiate(parse(wasm));
+    EXPECT_THAT(execute(*instance, 1, {}, DepthLimit - 2), Result(1_u32));
+    EXPECT_THAT(execute(*instance, 1, {}, DepthLimit - 1), Traps());
+    EXPECT_THAT(execute(*instance, 1, {}, DepthLimit), Traps());
+}
+
+TEST(execute_call_depth, call_imported_wasm_function)
+{
+    /* wat2wasm
+    (func (export "f") (result i32) (i32.const 1))
+    */
+    const auto exported_wasm =
+        from_hex("0061736d010000000105016000017f03020100070501016600000a0601040041010b");
+
+    /* wat2wasm
+    (func $exporter_f (import "exporter" "f") (result i32))
+    (func (result i32) (call $exporter_f))
+    */
+    const auto executor_wasm = from_hex(
+        "0061736d010000000105016000017f020e01086578706f7274657201660000030201000a0601040010000b");
+
+    auto exporter = instantiate(parse(exported_wasm));
+    auto executor = instantiate(parse(executor_wasm), {*find_exported_function(*exporter, "f")});
+    EXPECT_THAT(execute(*executor, 1, {}, DepthLimit - 2), Result(1_u32));
+    EXPECT_THAT(execute(*executor, 1, {}, DepthLimit - 1), Traps());
+    EXPECT_THAT(execute(*executor, 1, {}, DepthLimit), Traps());
+}
+
+TEST(execute_call_depth, call_imported_host_function)
+{
+    /* wat2wasm
+    (func $host_f (import "host" "f") (result i32))
+    (func (result i32) (call $host_f))
+    */
+    const auto wasm =
+        from_hex("0061736d010000000105016000017f020a0104686f737401660000030201000a0601040010000b");
+
+    static int recorded_depth;
+    constexpr auto host_f = [](std::any&, Instance&, const Value*, int depth) noexcept {
+        recorded_depth = depth;
+        return ExecutionResult{Value{1_u32}};
+    };
+
+    const auto module = parse(wasm);
+    auto instance = instantiate(*module, {{{host_f}, module->typesec[0]}});
+
+    recorded_depth = -1000;
+    EXPECT_THAT(execute(*instance, 1, {}), Result(1_u32));
+    EXPECT_EQ(recorded_depth, 1);
+
+    recorded_depth = -1000;
+    EXPECT_THAT(execute(*instance, 1, {}, DepthLimit - 2), Result(1_u32));
+    EXPECT_EQ(recorded_depth, DepthLimit - 1);
+
+    recorded_depth = -1000;
+    EXPECT_THAT(execute(*instance, 1, {}, DepthLimit - 1), Traps());
+    EXPECT_EQ(recorded_depth, -1000);
+
+    recorded_depth = -1000;
+    EXPECT_THAT(execute(*instance, 1, {}, DepthLimit), Traps());
+    EXPECT_EQ(recorded_depth, -1000);
+}
+
+TEST(execute_call_depth, call_host_function_calling_wasm_function)
+{
+    // Test for "wasm-host-wasm" sandwich.
+    // The host function is obligated to bump depth and pass it along.
+
+    /* wat2wasm
+    (func $host_f (import "host" "f") (result i32))
+    (func (result i32) (call $host_f))
+    (func $leaf (result i32) (i32.const 1))
+    */
+    const auto wasm = from_hex(
+        "0061736d010000000105016000017f020a0104686f73740166000003030200000a0b02040010000b040041010"
+        "b");
+
+    static int recorded_depth;
+    constexpr auto host_f = [](std::any&, Instance& instance, const Value*, int depth) noexcept {
+        recorded_depth = depth;
+        return fizzy::execute(instance, 2, {}, depth + 1);
+    };
+
+    const auto module = parse(wasm);
+    auto instance = instantiate(*module, {{{host_f}, module->typesec[0]}});
+
+    recorded_depth = -1000;
+    EXPECT_THAT(execute(*instance, 1, {}), Result(1_u32));
+    EXPECT_EQ(recorded_depth, 1);
+
+    recorded_depth = -1000;
+    EXPECT_THAT(execute(*instance, 1, {}, DepthLimit - 3), Result(1_u32));
+    EXPECT_EQ(recorded_depth, DepthLimit - 2);
+
+    recorded_depth = -1000;
+    EXPECT_THAT(execute(*instance, 1, {}, DepthLimit - 2), Traps());
+    EXPECT_EQ(recorded_depth, DepthLimit - 1);
+
+    recorded_depth = -1000;
+    EXPECT_THAT(execute(*instance, 1, {}, DepthLimit - 1), Traps());
+    EXPECT_EQ(recorded_depth, -1000);
+
+    recorded_depth = -1000;
+    EXPECT_THAT(execute(*instance, 1, {}, DepthLimit), Traps());
+    EXPECT_EQ(recorded_depth, -1000);
+}
+
+
+/// Infinite recursion
+
+TEST(execute_call_depth, execute_internal_infinite_recursion_function)
+{
+    // This execution must always trap.
+    // Number of $f invocations is counted in the imported global $counter.
+
+    /* wat2wasm
+    (global $counter (import "host" "counter") (mut i64))
+    (func $f
+      (global.set $counter (i64.add (global.get $counter) (i64.const 1)))
+      (call $f)
+    )
+    */
+    const auto wasm = from_hex(
+        "0061736d0100000001040160000002110104686f737407636f756e746572037e01030201000a0d010b00230042"
+        "017c240010000b");
+
+    Value counter;
+    auto instance = instantiate(parse(wasm), {}, {}, {}, {{&counter, {ValType::i64, true}}});
+
+    // When starting from depth 0, the $f is expected to be called CallStackLimit times.
+    counter.i64 = 0;
+    EXPECT_THAT(execute(*instance, 0, {}), Traps());
+    EXPECT_EQ(counter.i64, DepthLimit);
+
+    // Here only single depth level is available, so $f is called once.
+    counter.i64 = 0;
+    EXPECT_THAT(execute(*instance, 0, {}, DepthLimit - 1), Traps());
+    EXPECT_EQ(counter.i64, 1);
+
+    // Here execution traps immediately, the $f is never called.
+    counter.i64 = 0;
+    EXPECT_THAT(execute(*instance, 0, {}, DepthLimit), Traps());
+    EXPECT_EQ(counter.i64, 0);
+}
+
+TEST(execute_call_depth, execute_imported_wasm_infinite_recursion_function)
+{
+    // This execution must always trap.
+    // Number of $f invocations is counted in the imported global $counter.
+
+    /* wat2wasm
+    (global $counter (import "host" "counter") (mut i64))
+    (func $f (export "f")
+      (global.set $counter (i64.add (global.get $counter) (i64.const 1)))
+      (call $f)
+    )
+    */
+    const auto exported_wasm = from_hex(
+        "0061736d0100000001040160000002110104686f737407636f756e746572037e0103020100070501016600000a"
+        "0d010b00230042017c240010000b");
+
+    /* wat2wasm
+    (func $exporter_f (import "exporter" "f"))
+    (func (call $exporter_f))
+    */
+    const auto executor_wasm = from_hex(
+        "0061736d01000000010401600000020e01086578706f7274657201660000030201000a0601040010000b");
+
+    Value counter;
+    auto exporter =
+        instantiate(parse(exported_wasm), {}, {}, {}, {{&counter, {ValType::i64, true}}});
+    auto executor = instantiate(parse(executor_wasm), {*find_exported_function(*exporter, "f")});
+
+    // When starting from depth 0, the $f is expected to be called CallStackLimit-1 times.
+    counter.i64 = 0;
+    EXPECT_THAT(execute(*executor, 1, {}), Traps());
+    EXPECT_EQ(counter.i64, DepthLimit - 1);
+
+    // Here two depth levels are available: one is used for executor's main function,
+    // second is used for $f (the $f is called once).
+    counter.i64 = 0;
+    EXPECT_THAT(execute(*executor, 1, {}, DepthLimit - 2), Traps());
+    EXPECT_EQ(counter.i64, 1);
+
+    // Here the only depth level available is used on the executor's main function
+    // and execution traps before $f is called.
+    counter.i64 = 0;
+    EXPECT_THAT(execute(*executor, 1, {}, DepthLimit - 1), Traps());
+    EXPECT_EQ(counter.i64, 0);
+
+    // Here execution traps immediately, the $f is never called.
+    counter.i64 = 0;
+    EXPECT_THAT(execute(*executor, 1, {}, DepthLimit), Traps());
+    EXPECT_EQ(counter.i64, 0);
+}

--- a/test/utils/execute_helpers.hpp
+++ b/test/utils/execute_helpers.hpp
@@ -13,7 +13,7 @@
 namespace fizzy::test
 {
 inline TypedExecutionResult execute(Instance& instance, FuncIdx func_idx,
-    std::initializer_list<TypedValue> typed_args, int depth = 0)
+    std::initializer_list<TypedValue> typed_args, int depth = -1)
 {
     const auto& func_type = instance.module->get_function_type(func_idx);
     const auto [typed_arg_it, type_it] = std::mismatch(std::cbegin(typed_args),

--- a/test/utils/fizzy_c_engine.cpp
+++ b/test/utils/fizzy_c_engine.cpp
@@ -115,7 +115,7 @@ WasmEngine::Result FizzyCEngine::execute(
     assert(func_type.output != FizzyValueTypeF32 && func_type.output != FizzyValueTypeF64 &&
            "floating point result types are not supported");
     const auto first_arg = reinterpret_cast<const FizzyValue*>(args.data());
-    const auto status = fizzy_execute(m_instance.get(), func_idx, first_arg, 0);
+    const auto status = fizzy_execute(m_instance.get(), func_idx, first_arg);
     if (status.trapped)
         return {true, std::nullopt};
     else if (status.has_value)


### PR DESCRIPTION
This is one of two variants of call depth limiting improvements.
This one keeps the current semantic where host functions are included in the call depth limit. The functional change here is that we now bump the depth for the host functions. This has two usability improvements:
- host functions are only required to pass the received depth value along; depth can be replaced with an opaque object,
- limit is more precisely enforced; e.g. now calling a host function outside of the limit will result in trap, previously it was up to the host function to check the limit.

The visible change is also that we start with depth `-1`. This can be interpreter as the current depth of the caller. If this is considered a problem, the code probably can be changed to a form where we start with depth `0`.