### PR TITLE
Add explicit check for imported limits validity

### DIFF
--- a/lib/fizzy/instantiate.cpp
+++ b/lib/fizzy/instantiate.cpp
@@ -40,6 +40,9 @@ void match_imported_functions(const std::vector<FuncType>& module_imported_types
 
 void match_limits(const Limits& external_limits, const Limits& module_limits)
 {
+    if (external_limits.max.has_value() && external_limits.min > *external_limits.max)
+        throw instantiate_error{"provided import's min limit is above import's max limit"};
+
     if (external_limits.min < module_limits.min)
         throw instantiate_error{"provided import's min is below import's min defined in module"};
 

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -177,6 +177,10 @@ TEST(instantiate, imported_table_invalid)
     EXPECT_THROW_MESSAGE(instantiate(*module, {}, {{&table, {10, std::nullopt}}}),
         instantiate_error, "provided import's max is above import's max defined in module");
 
+    // Provided limits have max less than min
+    EXPECT_THROW_MESSAGE(instantiate(*module, {}, {{&table, {10, 0}}}), instantiate_error,
+        "provided imported table doesn't fit provided limits");
+
     // Null pointer
     EXPECT_THROW_MESSAGE(instantiate(*module, {}, {{nullptr, {10, 30}}}), instantiate_error,
         "provided imported table has a null pointer to data");
@@ -282,6 +286,10 @@ TEST(instantiate, imported_memory_invalid)
     // Provided max is unlimited
     EXPECT_THROW_MESSAGE(instantiate(*module, {}, {}, {{&memory, {1, std::nullopt}}}),
         instantiate_error, "provided import's max is above import's max defined in module");
+
+    // Provided limits have max less than min
+    EXPECT_THROW_MESSAGE(instantiate(*module, {}, {}, {{&memory, {1, 0}}}), instantiate_error,
+        "provided imported memory doesn't fit provided limits");
 
     // Null pointer
     EXPECT_THROW_MESSAGE(instantiate(*module, {}, {}, {{nullptr, {1, 3}}}), instantiate_error,

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -179,7 +179,7 @@ TEST(instantiate, imported_table_invalid)
 
     // Provided limits have max less than min
     EXPECT_THROW_MESSAGE(instantiate(*module, {}, {{&table, {10, 0}}}), instantiate_error,
-        "provided imported table doesn't fit provided limits");
+        "provided import's min limit is above import's max limit");
 
     // Null pointer
     EXPECT_THROW_MESSAGE(instantiate(*module, {}, {{nullptr, {10, 30}}}), instantiate_error,
@@ -289,7 +289,7 @@ TEST(instantiate, imported_memory_invalid)
 
     // Provided limits have max less than min
     EXPECT_THROW_MESSAGE(instantiate(*module, {}, {}, {{&memory, {1, 0}}}), instantiate_error,
-        "provided imported memory doesn't fit provided limits");
+        "provided import's min limit is above import's max limit");
 
     // Null pointer
     EXPECT_THROW_MESSAGE(instantiate(*module, {}, {}, {{nullptr, {1, 3}}}), instantiate_error,


### PR DESCRIPTION
- This improves error message for the case when import's max is below min: `provided imported table doesn't fit provided limits` => `provided import's min limit is above import's max limit`.
- Also it will allow to simplify imported memory size checks in #755 (to leave only the check `memory.size() == min.limit` in instantiate).