### PR TITLE
rust: Overhaul errors to use an enum

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -43,6 +43,28 @@ use std::ptr::NonNull;
 
 use crate::constnonnull::ConstNonNull;
 
+/// The various kinds of errors, which can be returned by any of the interfaces.
+#[derive(Eq, PartialEq, Debug, Clone)]
+pub enum Error {
+    MalformedModule(String),
+    InvalidModule(String),
+    InstantiationFailed(String),
+    MemoryAllocationFailed(String),
+    Other(String),
+}
+
+impl From<String> for Error {
+    fn from(error: String) -> Self {
+        Error::Other(error)
+    }
+}
+
+impl From<&str> for Error {
+    fn from(error: &str) -> Self {
+        Error::Other(error.to_string())
+    }
+}
+
 /// A safe container for handling the low-level FizzyError struct.
 struct FizzyErrorBox(Box<sys::FizzyError>);
 

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -124,12 +124,6 @@ impl FizzyErrorBox {
     }
 }
 
-impl std::fmt::Display for FizzyErrorBox {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{} [{}]", self.code(), self.message())
-    }
-}
-
 /// Parse and validate the input according to WebAssembly 1.0 rules. Returns true if the supplied input is valid.
 pub fn validate<T: AsRef<[u8]>>(input: T) -> Result<(), Error> {
     let mut err = FizzyErrorBox::new();
@@ -558,7 +552,6 @@ mod tests {
         assert_eq!(err.code(), 0);
         assert_eq!(err.message(), "");
         assert!(err.error().is_none());
-        assert_eq!(format!("{}", err), "0 []");
     }
 
     #[test]

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -402,14 +402,14 @@ impl Instance {
         memory_size: usize,
         offset: u32,
         size: usize,
-    ) -> Result<core::ops::Range<usize>, String> {
+    ) -> Result<core::ops::Range<usize>, Error> {
         // This is safe given usize::BITS >= u32::BITS, see https://doc.rust-lang.org/std/primitive.usize.html.
         let offset = offset as usize;
         if memory_data.is_null() {
-            return Err("no memory is available".to_string());
+            return Err("no memory is available".into());
         }
         if offset.checked_add(size).is_none() || (offset + size) > memory_size {
-            return Err("invalid offset or size".to_string());
+            return Err("invalid offset or size".into());
         }
         Ok(offset..offset + size)
     }
@@ -418,7 +418,7 @@ impl Instance {
     ///
     /// # Safety
     /// These slices turn invalid if the memory is resized (i.e. via the WebAssembly `memory.grow` instruction)
-    pub unsafe fn checked_memory_slice(&self, offset: u32, size: usize) -> Result<&[u8], String> {
+    pub unsafe fn checked_memory_slice(&self, offset: u32, size: usize) -> Result<&[u8], Error> {
         let memory_data = sys::fizzy_get_instance_memory_data(self.0.as_ptr());
         let memory_size = sys::fizzy_get_instance_memory_size(self.0.as_ptr());
         let range = Instance::checked_memory_range(memory_data, memory_size, offset, size)?;
@@ -436,7 +436,7 @@ impl Instance {
         &mut self,
         offset: u32,
         size: usize,
-    ) -> Result<&mut [u8], String> {
+    ) -> Result<&mut [u8], Error> {
         let memory_data = sys::fizzy_get_instance_memory_data(self.0.as_ptr());
         let memory_size = sys::fizzy_get_instance_memory_size(self.0.as_ptr());
         let range = Instance::checked_memory_range(memory_data, memory_size, offset, size)?;
@@ -452,14 +452,14 @@ impl Instance {
     }
 
     /// Copies memory from `offset` to `target`, for the length of `target.len()`.
-    pub fn memory_get(&self, offset: u32, target: &mut [u8]) -> Result<(), String> {
+    pub fn memory_get(&self, offset: u32, target: &mut [u8]) -> Result<(), Error> {
         let slice = unsafe { self.checked_memory_slice(offset, target.len())? };
         target.copy_from_slice(slice);
         Ok(())
     }
 
     /// Copies memory from `source` to `offset`, for the length of `source.len()`.
-    pub fn memory_set(&mut self, offset: u32, source: &[u8]) -> Result<(), String> {
+    pub fn memory_set(&mut self, offset: u32, source: &[u8]) -> Result<(), Error> {
         let slice = unsafe { self.checked_memory_slice_mut(offset, source.len())? };
         slice.copy_from_slice(source);
         Ok(())
@@ -963,62 +963,62 @@ mod tests {
         unsafe {
             assert_eq!(
                 instance.checked_memory_slice(0, 0).err().unwrap(),
-                "no memory is available"
+                Error::Other("no memory is available".into())
             );
             assert_eq!(
                 instance.checked_memory_slice_mut(0, 0).err().unwrap(),
-                "no memory is available"
+                Error::Other("no memory is available".into())
             );
             assert_eq!(
                 instance.checked_memory_slice(0, 65536).err().unwrap(),
-                "no memory is available"
+                Error::Other("no memory is available".into())
             );
             assert_eq!(
                 instance.checked_memory_slice_mut(0, 65536).err().unwrap(),
-                "no memory is available"
+                Error::Other("no memory is available".into())
             );
             assert_eq!(
                 instance.checked_memory_slice(65535, 1).err().unwrap(),
-                "no memory is available"
+                Error::Other("no memory is available".into())
             );
             assert_eq!(
                 instance.checked_memory_slice_mut(65535, 1).err().unwrap(),
-                "no memory is available"
+                Error::Other("no memory is available".into())
             );
             assert_eq!(
                 instance.checked_memory_slice(65535, 2).err().unwrap(),
-                "no memory is available"
+                Error::Other("no memory is available".into())
             );
             assert_eq!(
                 instance.checked_memory_slice_mut(65535, 2).err().unwrap(),
-                "no memory is available"
+                Error::Other("no memory is available".into())
             );
             assert_eq!(
                 instance.checked_memory_slice(65536, 0).err().unwrap(),
-                "no memory is available"
+                Error::Other("no memory is available".into())
             );
             assert_eq!(
                 instance.checked_memory_slice_mut(65536, 0).err().unwrap(),
-                "no memory is available"
+                Error::Other("no memory is available".into())
             );
             assert_eq!(
                 instance.checked_memory_slice(65536, 1).err().unwrap(),
-                "no memory is available"
+                Error::Other("no memory is available".into())
             );
             assert_eq!(
                 instance.checked_memory_slice_mut(65536, 1).err().unwrap(),
-                "no memory is available"
+                Error::Other("no memory is available".into())
             );
         }
 
         // Set memory via safe helper.
         assert_eq!(
             instance.memory_set(0, &[]).err().unwrap(),
-            "no memory is available"
+            Error::Other("no memory is available".into())
         );
         assert_eq!(
             instance.memory_set(0, &[0x11, 0x22]).err().unwrap(),
-            "no memory is available"
+            Error::Other("no memory is available".into())
         );
         // Get memory via safe helper.
         let mut dst: Vec<u8> = Vec::new();
@@ -1026,12 +1026,12 @@ mod tests {
         // Reading empty slice.
         assert_eq!(
             instance.memory_get(0, &mut dst[0..0]).err().unwrap(),
-            "no memory is available"
+            Error::Other("no memory is available".into())
         );
         // Reading 65536 bytes.
         assert_eq!(
             instance.memory_get(0, &mut dst).err().unwrap(),
-            "no memory is available"
+            Error::Other("no memory is available".into())
         );
     }
 
@@ -1059,43 +1059,43 @@ mod tests {
             assert!(instance.checked_memory_slice_mut(0, 0).is_ok());
             assert_eq!(
                 instance.checked_memory_slice(0, 65536).err().unwrap(),
-                "invalid offset or size"
+                Error::Other("invalid offset or size".into())
             );
             assert_eq!(
                 instance.checked_memory_slice_mut(0, 65536).err().unwrap(),
-                "invalid offset or size"
+                Error::Other("invalid offset or size".into())
             );
             assert_eq!(
                 instance.checked_memory_slice(65535, 1).err().unwrap(),
-                "invalid offset or size"
+                Error::Other("invalid offset or size".into())
             );
             assert_eq!(
                 instance.checked_memory_slice_mut(65535, 1).err().unwrap(),
-                "invalid offset or size"
+                Error::Other("invalid offset or size".into())
             );
             assert_eq!(
                 instance.checked_memory_slice(65535, 2).err().unwrap(),
-                "invalid offset or size"
+                Error::Other("invalid offset or size".into())
             );
             assert_eq!(
                 instance.checked_memory_slice_mut(65535, 2).err().unwrap(),
-                "invalid offset or size"
+                Error::Other("invalid offset or size".into())
             );
             assert_eq!(
                 instance.checked_memory_slice(65536, 0).err().unwrap(),
-                "invalid offset or size"
+                Error::Other("invalid offset or size".into())
             );
             assert_eq!(
                 instance.checked_memory_slice_mut(65536, 0).err().unwrap(),
-                "invalid offset or size"
+                Error::Other("invalid offset or size".into())
             );
             assert_eq!(
                 instance.checked_memory_slice(65536, 1).err().unwrap(),
-                "invalid offset or size"
+                Error::Other("invalid offset or size".into())
             );
             assert_eq!(
                 instance.checked_memory_slice_mut(65536, 1).err().unwrap(),
-                "invalid offset or size"
+                Error::Other("invalid offset or size".into())
             );
         }
 
@@ -1103,7 +1103,7 @@ mod tests {
         assert!(instance.memory_set(0, &[]).is_ok());
         assert_eq!(
             instance.memory_set(0, &[0x11, 0x22]).err().unwrap(),
-            "invalid offset or size"
+            Error::Other("invalid offset or size".into())
         );
         // Get memory via safe helper.
         let mut dst: Vec<u8> = Vec::new();
@@ -1113,7 +1113,7 @@ mod tests {
         // Reading 65536 bytes.
         assert_eq!(
             instance.memory_get(0, &mut dst).err().unwrap(),
-            "invalid offset or size"
+            Error::Other("invalid offset or size".into())
         );
     }
 
@@ -1153,28 +1153,28 @@ mod tests {
             // Reading over.
             assert_eq!(
                 instance.checked_memory_slice(65535, 2).err().unwrap(),
-                "invalid offset or size"
+                Error::Other("invalid offset or size".into())
             );
             assert_eq!(
                 instance.checked_memory_slice_mut(65535, 2).err().unwrap(),
-                "invalid offset or size"
+                Error::Other("invalid offset or size".into())
             );
             assert_eq!(
                 instance.checked_memory_slice(65536, 1).err().unwrap(),
-                "invalid offset or size"
+                Error::Other("invalid offset or size".into())
             );
             assert_eq!(
                 instance.checked_memory_slice_mut(65536, 1).err().unwrap(),
-                "invalid offset or size"
+                Error::Other("invalid offset or size".into())
             );
             // Offset overflow.
             assert_eq!(
                 instance.checked_memory_slice(65537, 0).err().unwrap(),
-                "invalid offset or size"
+                Error::Other("invalid offset or size".into())
             );
             assert_eq!(
                 instance.checked_memory_slice_mut(65537, 0).err().unwrap(),
-                "invalid offset or size"
+                Error::Other("invalid offset or size".into())
             );
         }
 
@@ -1234,7 +1234,7 @@ mod tests {
         assert!(instance.memory_set(65536 + 65536, &[]).is_ok());
         assert_eq!(
             instance.memory_set(65536 + 65537, &[]).err().unwrap(),
-            "invalid offset or size"
+            Error::Other("invalid offset or size".into())
         );
         assert!(instance.memory_set(0, &[0x11, 0x22, 0x33, 0x44]).is_ok());
         assert!(instance
@@ -1245,35 +1245,35 @@ mod tests {
                 .memory_set(65536 + 65533, &[0x11, 0x22, 0x33, 0x44])
                 .err()
                 .unwrap(),
-            "invalid offset or size"
+            Error::Other("invalid offset or size".into())
         );
         assert_eq!(
             instance
                 .memory_set(65536 + 65534, &[0x11, 0x22, 0x33, 0x44])
                 .err()
                 .unwrap(),
-            "invalid offset or size"
+            Error::Other("invalid offset or size".into())
         );
         assert_eq!(
             instance
                 .memory_set(65536 + 65535, &[0x11, 0x22, 0x33, 0x44])
                 .err()
                 .unwrap(),
-            "invalid offset or size"
+            Error::Other("invalid offset or size".into())
         );
         assert_eq!(
             instance
                 .memory_set(65536 + 65536, &[0x11, 0x22, 0x33, 0x44])
                 .err()
                 .unwrap(),
-            "invalid offset or size"
+            Error::Other("invalid offset or size".into())
         );
         assert_eq!(
             instance
                 .memory_set(65536 + 65537, &[0x11, 0x22, 0x33, 0x44])
                 .err()
                 .unwrap(),
-            "invalid offset or size"
+            Error::Other("invalid offset or size".into())
         );
 
         let result = instance
@@ -1312,7 +1312,7 @@ mod tests {
                 .memory_get(65536 + 65537, &mut dst[0..0])
                 .err()
                 .unwrap(),
-            "invalid offset or size"
+            Error::Other("invalid offset or size".into())
         );
 
         // Read into short slice.
@@ -1323,35 +1323,35 @@ mod tests {
                 .memory_get(65536 + 65533, &mut dst[0..4])
                 .err()
                 .unwrap(),
-            "invalid offset or size"
+            Error::Other("invalid offset or size".into())
         );
         assert_eq!(
             instance
                 .memory_get(65536 + 65534, &mut dst[0..4])
                 .err()
                 .unwrap(),
-            "invalid offset or size"
+            Error::Other("invalid offset or size".into())
         );
         assert_eq!(
             instance
                 .memory_get(65536 + 65535, &mut dst[0..4])
                 .err()
                 .unwrap(),
-            "invalid offset or size"
+            Error::Other("invalid offset or size".into())
         );
         assert_eq!(
             instance
                 .memory_get(65536 + 65536, &mut dst[0..4])
                 .err()
                 .unwrap(),
-            "invalid offset or size"
+            Error::Other("invalid offset or size".into())
         );
         assert_eq!(
             instance
                 .memory_get(65536 + 65537, &mut dst[0..4])
                 .err()
                 .unwrap(),
-            "invalid offset or size"
+            Error::Other("invalid offset or size".into())
         );
     }
 }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -168,7 +168,7 @@ impl Clone for Module {
 }
 
 /// Parse and validate the input according to WebAssembly 1.0 rules.
-pub fn parse<T: AsRef<[u8]>>(input: &T) -> Result<Module, String> {
+pub fn parse<T: AsRef<[u8]>>(input: &T) -> Result<Module, Error> {
     let mut err = FizzyErrorBox::new();
     let ptr = unsafe {
         sys::fizzy_parse(
@@ -179,7 +179,7 @@ pub fn parse<T: AsRef<[u8]>>(input: &T) -> Result<Module, String> {
     };
     if ptr.is_null() {
         debug_assert!(err.code() != 0);
-        Err(err.message())
+        Err(err.error().unwrap())
     } else {
         debug_assert!(err.code() == 0);
         Ok(Module(unsafe { ConstNonNull::new_unchecked(ptr) }))
@@ -757,7 +757,7 @@ mod tests {
             parse(&[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x01])
                 .err()
                 .unwrap(),
-            "invalid wasm module prefix"
+            Error::MalformedModule("invalid wasm module prefix".to_string())
         );
     }
 

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -198,7 +198,7 @@ impl Drop for Instance {
 impl Module {
     /// Create an instance of a module.
     // TODO: support imported functions
-    pub fn instantiate(self) -> Result<Instance, String> {
+    pub fn instantiate(self) -> Result<Instance, Error> {
         let mut err = FizzyErrorBox::new();
         let ptr = unsafe {
             sys::fizzy_instantiate(
@@ -217,7 +217,7 @@ impl Module {
         core::mem::forget(self);
         if ptr.is_null() {
             debug_assert!(err.code() != 0);
-            Err(err.message())
+            Err(err.error().unwrap())
         } else {
             debug_assert!(err.code() == 0);
             Ok(Instance(unsafe { NonNull::new_unchecked(ptr) }))
@@ -782,7 +782,9 @@ mod tests {
         let instance = module.unwrap().instantiate();
         assert_eq!(
             instance.err().unwrap(),
-            "module defines an imported memory but none was provided"
+            Error::InstantiationFailed(
+                "module defines an imported memory but none was provided".to_string()
+            )
         );
     }
 


### PR DESCRIPTION
Depends on #783.
Based on #677.