### PR TITLE
capi: Remove dynamic allocation in find_exported_function

### DIFF
--- a/include/fizzy/fizzy.h
+++ b/include/fizzy/fizzy.h
@@ -130,6 +130,8 @@ typedef struct FizzyExternalFunction
 {
     /// Function type.
     FizzyFunctionType type;
+    FizzyInstance* instance;
+    uint32_t function_index;
     /// Pointer to function.
     FizzyExternalFn function;
     /// Opaque pointer to execution context, that will be passed to function.

--- a/lib/fizzy/instantiate.cpp
+++ b/lib/fizzy/instantiate.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "instantiate.hpp"
+#include "cxx20/bit.hpp"
 #include "execute.hpp"  // needed for implementation of ExecuteFunction for Wasm functions
 #include <algorithm>
 #include <cassert>
@@ -322,8 +323,21 @@ ExecutionResult ExecuteFunction::operator()(
 {
     if (m_instance)
         return execute(*m_instance, m_func_idx, args, ctx);
-    else
+    else if (m_host_function)
         return m_host_function(m_host_context, instance, args, ctx);
+    else
+    {
+        assert(m_c_host_function != nullptr);
+        const auto result = m_c_host_function(std::any_cast<void*&>(m_host_context),
+            reinterpret_cast<FizzyInstance*>(&instance), reinterpret_cast<const FizzyValue*>(args),
+            reinterpret_cast<FizzyExecutionContext*>(&ctx));
+        if (result.trapped)
+            return fizzy::Trap;
+        else if (!result.has_value)
+            return fizzy::Void;
+        else
+            return fizzy::bit_cast<fizzy::Value>(result.value);
+    }
 }
 
 std::unique_ptr<Instance> instantiate(std::unique_ptr<const Module> module,

--- a/lib/fizzy/instantiate.hpp
+++ b/lib/fizzy/instantiate.hpp
@@ -10,6 +10,7 @@
 #include "module.hpp"
 #include "types.hpp"
 #include "value.hpp"
+#include <fizzy/fizzy.h>
 #include <any>
 #include <cstdint>
 #include <functional>
@@ -42,6 +43,8 @@ class ExecuteFunction
     /// Equals nullptr in case this ExecuteFunction represents WebAssembly function.
     HostFunctionPtr m_host_function = nullptr;
 
+    FizzyExternalFn m_c_host_function = nullptr;
+
     /// Opaque context of host function execution, which is passed to it as host_context parameter.
     /// Doesn't have value in case this ExecuteFunction represents WebAssembly function.
     std::any m_host_context;
@@ -67,8 +70,20 @@ public:
     ExecutionResult operator()(
         Instance& instance, const Value* args, ExecutionContext& ctx) noexcept;
 
+    ExecuteFunction(FizzyExternalFn f, void* host_context) noexcept
+      : m_c_host_function{f}, m_host_context{host_context}
+    {}
+
+    Instance* get_instance() const noexcept { return m_instance; }
+
     /// Function pointer stored inside this object.
     HostFunctionPtr get_host_function() const noexcept { return m_host_function; }
+
+    FizzyExternalFn get_c_host_function() const noexcept { return m_c_host_function; }
+
+    FuncIdx get_function_index() const noexcept { return m_func_idx; }
+
+    std::any& get_host_context() noexcept { return m_host_context; }
 };
 
 /// Function with associated input/output types,

--- a/test/unittests/capi_test.cpp
+++ b/test/unittests/capi_test.cpp
@@ -479,10 +479,14 @@ TEST(capi, find_exported_function)
     ASSERT_TRUE(fizzy_find_exported_function(instance, "foo", &function));
     EXPECT_EQ(function.type.inputs_size, 0);
     EXPECT_EQ(function.type.output, FizzyValueTypeI32);
-    EXPECT_NE(function.context, nullptr);
-    ASSERT_NE(function.function, nullptr);
+    EXPECT_EQ(function.context, nullptr);
+    ASSERT_EQ(function.function, nullptr);
+    EXPECT_EQ(function.instance, instance);
+    EXPECT_EQ(function.function_index, 0);
 
-    EXPECT_THAT(function.function(function.context, instance, nullptr, nullptr), CResult(42_u32));
+
+    // EXPECT_THAT(function.function(function.context, instance, nullptr, nullptr),
+    // CResult(42_u32));
 
     fizzy_free_exported_function(&function);
 
@@ -731,7 +735,8 @@ TEST(capi, instantiate_imported_function)
     module = fizzy_parse(wasm.data(), wasm.size(), nullptr);
     ASSERT_NE(module, nullptr);
 
-    FizzyExternalFunction host_funcs[] = {{{FizzyValueTypeI32, nullptr, 0}, NullFn, nullptr}};
+    FizzyExternalFunction host_funcs[] = {
+        {{FizzyValueTypeI32, nullptr, 0}, nullptr, 0, NullFn, nullptr}};
 
     auto instance = fizzy_instantiate(
         module, host_funcs, 1, nullptr, nullptr, nullptr, 0, FizzyMemoryPagesLimitDefault, nullptr);
@@ -921,7 +926,7 @@ TEST(capi, resolve_instantiate_no_imports)
 
     // providing unnecessary import
     FizzyImportedFunction host_funcs[] = {
-        {"mod", "foo", {{FizzyValueTypeVoid, nullptr, 0}, NullFn, nullptr}}};
+        {"mod", "foo", {{FizzyValueTypeVoid, nullptr, 0}, nullptr, 0, NullFn, nullptr}}};
 
     instance = fizzy_resolve_instantiate(
         module, host_funcs, 1, nullptr, nullptr, nullptr, 0, FizzyMemoryPagesLimitDefault, nullptr);
@@ -976,15 +981,19 @@ TEST(capi, resolve_instantiate_functions)
 
     const FizzyValueType input_type = FizzyValueTypeI32;
     FizzyValue result_int32{42};
-    FizzyExternalFunction mod1foo1 = {{FizzyValueTypeI32, &input_type, 1}, host_fn, &result_int32};
+    FizzyExternalFunction mod1foo1 = {
+        {FizzyValueTypeI32, &input_type, 1}, nullptr, 0, host_fn, &result_int32};
     FizzyValue result_int64{43};
-    FizzyExternalFunction mod1foo2 = {{FizzyValueTypeI64, &input_type, 1}, host_fn, &result_int64};
+    FizzyExternalFunction mod1foo2 = {
+        {FizzyValueTypeI64, &input_type, 1}, nullptr, 0, host_fn, &result_int64};
     FizzyValue result_f32;
     result_f32.f32 = 44.44f;
-    FizzyExternalFunction mod2foo1 = {{FizzyValueTypeF32, &input_type, 1}, host_fn, &result_f32};
+    FizzyExternalFunction mod2foo1 = {
+        {FizzyValueTypeF32, &input_type, 1}, nullptr, 0, host_fn, &result_f32};
     FizzyValue result_f64;
     result_f64.f64 = 45.45;
-    FizzyExternalFunction mod2foo2 = {{FizzyValueTypeF64, &input_type, 1}, host_fn, &result_f64};
+    FizzyExternalFunction mod2foo2 = {
+        {FizzyValueTypeF64, &input_type, 1}, nullptr, 0, host_fn, &result_f64};
 
     FizzyImportedFunction host_funcs[] = {{"mod1", "foo1", mod1foo1}, {"mod1", "foo2", mod1foo2},
         {"mod2", "foo1", mod2foo1}, {"mod2", "foo2", mod2foo2}};
@@ -1048,7 +1057,8 @@ TEST(capi, resolve_instantiate_function_duplicate)
         return FizzyExecutionResult{false, true, FizzyValue{42}};
     };
 
-    FizzyExternalFunction mod1foo1 = {{FizzyValueTypeI32, nullptr, 0}, host_fn, nullptr};
+    FizzyExternalFunction mod1foo1 = {
+        {FizzyValueTypeI32, nullptr, 0}, nullptr, 0, host_fn, nullptr};
     FizzyImportedFunction host_funcs[] = {{"mod1", "foo1", mod1foo1}};
 
     auto instance = fizzy_resolve_instantiate(
@@ -1096,7 +1106,7 @@ TEST(capi, resolve_instantiate_globals)
         return FizzyExecutionResult{true, false, {0}};
     };
     FizzyImportedFunction mod1foo1 = {
-        "mod1", "foo1", {{FizzyValueTypeVoid, nullptr, 0}, host_fn, nullptr}};
+        "mod1", "foo1", {{FizzyValueTypeVoid, nullptr, 0}, nullptr, 0, host_fn, nullptr}};
 
     FizzyValue mod1g1value{42};
     FizzyExternalGlobal mod1g1 = {&mod1g1value, {FizzyValueTypeI32, false}};
@@ -1428,12 +1438,12 @@ TEST(capi, execute_with_host_function)
     const FizzyValueType inputs[] = {FizzyValueTypeI32, FizzyValueTypeI32};
 
     FizzyExternalFunction host_funcs[] = {
-        {{FizzyValueTypeI32, nullptr, 0},
+        {{FizzyValueTypeI32, nullptr, 0}, nullptr, 0,
             [](void*, FizzyInstance*, const FizzyValue*, FizzyExecutionContext*) noexcept {
                 return FizzyExecutionResult{false, true, {42}};
             },
             nullptr},
-        {{FizzyValueTypeI32, &inputs[0], 2},
+        {{FizzyValueTypeI32, &inputs[0], 2}, nullptr, 0,
             [](void*, FizzyInstance*, const FizzyValue* args, FizzyExecutionContext*) noexcept {
                 FizzyValue v;
                 v.i32 = args[0].i32 / args[1].i32;
@@ -1466,7 +1476,7 @@ TEST(capi, imported_function_traps)
     auto module = fizzy_parse(wasm.data(), wasm.size(), nullptr);
     ASSERT_NE(module, nullptr);
 
-    FizzyExternalFunction host_funcs[] = {{{FizzyValueTypeI32, nullptr, 0},
+    FizzyExternalFunction host_funcs[] = {{{FizzyValueTypeI32, nullptr, 0}, nullptr, 0,
         [](void*, FizzyInstance*, const FizzyValue*, FizzyExecutionContext*) noexcept {
             return FizzyExecutionResult{true, false, {}};
         },
@@ -1495,7 +1505,7 @@ TEST(capi, imported_function_void)
     ASSERT_NE(module, nullptr);
 
     bool called = false;
-    FizzyExternalFunction host_funcs[] = {{{},
+    FizzyExternalFunction host_funcs[] = {{{}, nullptr, 0,
         [](void* context, FizzyInstance*, const FizzyValue*, FizzyExecutionContext*) noexcept {
             *static_cast<bool*>(context) = true;
             return FizzyExecutionResult{false, false, {}};
@@ -1936,7 +1946,8 @@ TEST(capi, import_name_after_instantiate)
     EXPECT_STREQ(import0.module, "m");
     EXPECT_STREQ(import0.name, "f1");
 
-    FizzyExternalFunction host_funcs[] = {{{FizzyValueTypeI32, nullptr, 0}, NullFn, nullptr}};
+    FizzyExternalFunction host_funcs[] = {
+        {{FizzyValueTypeI32, nullptr, 0}, nullptr, 0, NullFn, nullptr}};
 
     auto instance = fizzy_instantiate(
         module, host_funcs, 1, nullptr, nullptr, nullptr, 0, FizzyMemoryPagesLimitDefault, nullptr);

--- a/test/utils/fizzy_c_engine.cpp
+++ b/test/utils/fizzy_c_engine.cpp
@@ -71,7 +71,7 @@ bool FizzyCEngine::instantiate(bytes_view wasm_binary)
 
     FizzyValueType inputs[] = {FizzyValueTypeI32, FizzyValueTypeI32};
     FizzyImportedFunction imports[] = {
-        {"env", "adler32", {{FizzyValueTypeI32, inputs, 2}, env_adler32, nullptr}}};
+        {"env", "adler32", {{FizzyValueTypeI32, inputs, 2}, nullptr, 0, env_adler32, nullptr}}};
     m_instance.reset(fizzy_resolve_instantiate(
         module, imports, 1, nullptr, nullptr, nullptr, 0, FizzyMemoryPagesLimitDefault, nullptr));
 


### PR DESCRIPTION
This is a PoC to get rid of extra dynamic allocation in C API for imported/exported functions at the expense of some changes in API and some C API details leaking into C++ side.