### PR TITLE
test: Enhance FP utils and tests

### DIFF
--- a/test/spectests/spectests.cpp
+++ b/test/spectests/spectests.cpp
@@ -431,12 +431,12 @@ private:
         {
             assert(static_cast<uint32_t>(raw_value) == raw_value && "overflow in f32 test value");
             assert(!is_canonical_nan(v) && !is_arithmetic_nan(v));
-            return fizzy::test::FP{static_cast<uint32_t>(raw_value)}.value;
+            return fizzy::test::FP{static_cast<uint32_t>(raw_value)}.as_float();
         }
         else if (type == "f64")
         {
             assert(!is_canonical_nan(v) && !is_arithmetic_nan(v));
-            return fizzy::test::FP{raw_value}.value;
+            return fizzy::test::FP{raw_value}.as_float();
         }
         else
         {

--- a/test/unittests/execute_floating_point_conversion_test.cpp
+++ b/test/unittests/execute_floating_point_conversion_test.cpp
@@ -214,7 +214,11 @@ TYPED_TEST(execute_floating_point_types, reinterpret)
         const auto& ordered_values = TestValues<TypeParam>::ordered_and_nans();
         for (const auto float_value : ordered_values)
         {
-            const auto uint_value = FP<TypeParam>{float_value}.as_uint();
+#if !SNAN_SUPPORTED
+            if (!float_value.is_arithmetic_nan())
+                continue;
+#endif
+            const auto uint_value = float_value.as_uint();
             EXPECT_THAT(execute(*instance, func_float_to_int, {float_value}), Result(uint_value));
             EXPECT_THAT(execute(*instance, func_int_to_float, {uint_value}), Result(float_value));
         }

--- a/test/unittests/execute_floating_point_conversion_test.cpp
+++ b/test/unittests/execute_floating_point_conversion_test.cpp
@@ -51,7 +51,7 @@ TEST(execute_floating_point_conversion, f64_promote_f32)
 
         for (const auto& [arg, expected] : test_cases)
         {
-            EXPECT_THAT(execute(*instance, 0, {arg.as_float()}), Result(expected))
+            EXPECT_THAT(execute(*instance, 0, {arg}), Result(expected))
                 << arg << " -> " << expected;
         }
 
@@ -179,8 +179,7 @@ TEST(execute_floating_point_conversion, f32_demote_f64)
 
     for (const auto& [arg, expected] : test_cases)
     {
-        EXPECT_THAT(execute(*instance, 0, {arg.as_float()}), Result(expected))
-            << arg << " -> " << expected;
+        EXPECT_THAT(execute(*instance, 0, {arg}), Result(expected)) << arg << " -> " << expected;
     }
 
     // Any input NaN other than canonical must result in an arithmetic NaN.

--- a/test/unittests/execute_floating_point_conversion_test.cpp
+++ b/test/unittests/execute_floating_point_conversion_test.cpp
@@ -26,7 +26,7 @@ TEST(execute_floating_point_conversion, f64_promote_f32)
     const auto wasm = from_hex("0061736d0100000001060160017d017c030201000a070105002000bb0b");
     auto instance = instantiate(parse(wasm));
 
-    const std::pair<float, double> test_cases[] = {
+    const std::pair<FP32, FP64> test_cases[] = {
         {0.0f, 0.0},
         {-0.0f, -0.0},
         {1.0f, 1.0},
@@ -51,7 +51,7 @@ TEST(execute_floating_point_conversion, f64_promote_f32)
 
         for (const auto& [arg, expected] : test_cases)
         {
-            EXPECT_THAT(execute(*instance, 0, {arg}), Result(expected))
+            EXPECT_THAT(execute(*instance, 0, {arg.as_float()}), Result(expected))
                 << arg << " -> " << expected;
         }
 
@@ -114,7 +114,7 @@ TEST(execute_floating_point_conversion, f32_demote_f64)
     constexpr double lowest_to_inf = (f32_max + f32_limit) / 2;
     ASSERT_EQ(lowest_to_inf, 0x1.ffffffp127);
 
-    const std::pair<double, float> test_cases[] = {
+    const std::pair<FP64, FP32> test_cases[] = {
         // demote(+-0) = +-0
         {0.0, 0.0f},
         {-0.0, -0.0f},
@@ -179,7 +179,8 @@ TEST(execute_floating_point_conversion, f32_demote_f64)
 
     for (const auto& [arg, expected] : test_cases)
     {
-        EXPECT_THAT(execute(*instance, 0, {arg}), Result(expected)) << arg << " -> " << expected;
+        EXPECT_THAT(execute(*instance, 0, {arg.as_float()}), Result(expected))
+            << arg << " -> " << expected;
     }
 
     // Any input NaN other than canonical must result in an arithmetic NaN.

--- a/test/unittests/execute_floating_point_test.cpp
+++ b/test/unittests/execute_floating_point_test.cpp
@@ -1148,7 +1148,7 @@ TEST(execute_floating_point, f32_store)
         "0b06cccccccccccc");
     const auto module = parse(wasm);
 
-    const std::tuple<float, bytes> test_cases[]
+    const std::tuple<FP32, bytes> test_cases[]
     {
         // clang-format off
         {0.0f, "cc00000000cc"_bytes},
@@ -1229,7 +1229,7 @@ TEST(execute_floating_point, f64_store)
         "0b0ccccccccccccccccccccccccc");
     const auto module = parse(wasm);
 
-    const std::tuple<double, bytes> test_cases[]
+    const std::tuple<FP64, bytes> test_cases[]
     {
         // clang-format off
         {0.0, "cc0000000000000000cc"_bytes},

--- a/test/unittests/execute_floating_point_test.cpp
+++ b/test/unittests/execute_floating_point_test.cpp
@@ -51,25 +51,25 @@ TYPED_TEST(execute_floating_point_types, test_values_selftest)
     EXPECT_EQ(std::size(TV::positive_all()), TV::num_positive + TV::num_nans);
 
     for (const auto nan : TV::positive_nans())
-        EXPECT_TRUE(std::isnan(nan));
+        EXPECT_TRUE(nan.is_nan());
 
     EXPECT_TRUE(FP<TypeParam>{*TV::canonical_nan}.is_canonical_nan());
 
     for (const auto nan : TV::positive_noncanonical_nans())
     {
-        EXPECT_TRUE(std::isnan(nan));
+        EXPECT_TRUE(nan.is_nan());
         EXPECT_FALSE(FP<TypeParam>{nan}.is_canonical_nan());
     }
 
     for (const auto p : TV::positive_all())
-        EXPECT_EQ(std::signbit(p), 0);
+        EXPECT_EQ(p.sign_bit(), 0);
 
     const auto& ordered = TV::ordered();
     auto current = ordered[0];
     EXPECT_EQ(current, -FP<TypeParam>::Limits::infinity());
     for (size_t i = 1; i < ordered.size(); ++i)
     {
-        EXPECT_LT(current, ordered[i]);
+        EXPECT_LT(current.as_float(), ordered[i].as_float());
         current = ordered[i];
     }
 
@@ -79,19 +79,19 @@ TYPED_TEST(execute_floating_point_types, test_values_selftest)
     size_t nan_start_index = 0;
     for (size_t i = 1; i < ordered_and_nans.size(); ++i)
     {
-        if (std::isnan(ordered_and_nans[i]))
+        if (ordered_and_nans[i].is_nan())
         {
             nan_start_index = i;
             break;
         }
 
-        EXPECT_LT(current, ordered_and_nans[i]);
+        EXPECT_LT(current.as_float(), ordered_and_nans[i].as_float());
         current = ordered_and_nans[i];
     }
     ASSERT_NE(nan_start_index, 0);
     for (size_t i = nan_start_index; i < ordered_and_nans.size(); ++i)
     {
-        EXPECT_TRUE(std::isnan(ordered_and_nans[i]));
+        EXPECT_TRUE(ordered_and_nans[i].is_nan());
     }
 }
 
@@ -100,27 +100,32 @@ TYPED_TEST(execute_floating_point_types, nan_matchers)
     using testing::Not;
     using FP = FP<TypeParam>;
 
+    // Use TypedValue(FP).value as a way of creating Value out of FP objects.
+    static constexpr auto to_result = [](auto fp) noexcept {
+        return ExecutionResult{TypedValue{fp}.value};
+    };
+
     EXPECT_THAT(Void, Not(CanonicalNaN(TypeParam{})));
     EXPECT_THAT(Trap, Not(CanonicalNaN(TypeParam{})));
     EXPECT_THAT(ExecutionResult{Value{TypeParam{}}}, Not(CanonicalNaN(TypeParam{})));
-    EXPECT_THAT(ExecutionResult{Value{FP::nan(FP::canon)}}, CanonicalNaN(TypeParam{}));
-    EXPECT_THAT(ExecutionResult{Value{-FP::nan(FP::canon)}}, CanonicalNaN(TypeParam{}));
-    EXPECT_THAT(ExecutionResult{Value{FP::nan(FP::canon + 1)}}, Not(CanonicalNaN(TypeParam{})));
-    EXPECT_THAT(ExecutionResult{Value{-FP::nan(FP::canon + 1)}}, Not(CanonicalNaN(TypeParam{})));
-    EXPECT_THAT(ExecutionResult{Value{FP::nan(1)}}, Not(CanonicalNaN(TypeParam{})));
-    EXPECT_THAT(ExecutionResult{Value{-FP::nan(1)}}, Not(CanonicalNaN(TypeParam{})));
+    EXPECT_THAT(to_result(FP::nan(FP::canon)), CanonicalNaN(TypeParam{}));
+    EXPECT_THAT(to_result(-FP::nan(FP::canon)), CanonicalNaN(TypeParam{}));
+    EXPECT_THAT(to_result(FP::nan(FP::canon + 1)), Not(CanonicalNaN(TypeParam{})));
+    EXPECT_THAT(to_result(-FP::nan(FP::canon + 1)), Not(CanonicalNaN(TypeParam{})));
+    EXPECT_THAT(to_result(FP::nan(1)), Not(CanonicalNaN(TypeParam{})));
+    EXPECT_THAT(to_result(-FP::nan(1)), Not(CanonicalNaN(TypeParam{})));
 
     EXPECT_THAT(Void, Not(ArithmeticNaN(TypeParam{})));
     EXPECT_THAT(Trap, Not(ArithmeticNaN(TypeParam{})));
     EXPECT_THAT(ExecutionResult{Value{TypeParam{}}}, Not(ArithmeticNaN(TypeParam{})));
-    EXPECT_THAT(ExecutionResult{Value{FP::nan(FP::canon)}}, ArithmeticNaN(TypeParam{}));
-    EXPECT_THAT(ExecutionResult{Value{-FP::nan(FP::canon)}}, ArithmeticNaN(TypeParam{}));
-    EXPECT_THAT(ExecutionResult{Value{FP::nan(FP::canon + 1)}}, ArithmeticNaN(TypeParam{}));
-    EXPECT_THAT(ExecutionResult{Value{-FP::nan(FP::canon + 1)}}, ArithmeticNaN(TypeParam{}));
+    EXPECT_THAT(to_result(FP::nan(FP::canon)), ArithmeticNaN(TypeParam{}));
+    EXPECT_THAT(to_result(-FP::nan(FP::canon)), ArithmeticNaN(TypeParam{}));
+    EXPECT_THAT(to_result(FP::nan(FP::canon + 1)), ArithmeticNaN(TypeParam{}));
+    EXPECT_THAT(to_result(-FP::nan(FP::canon + 1)), ArithmeticNaN(TypeParam{}));
 
 #if SNAN_SUPPORTED
-    EXPECT_THAT(ExecutionResult{Value{FP::nan(1)}}, Not(ArithmeticNaN(TypeParam{})));
-    EXPECT_THAT(ExecutionResult{Value{-FP::nan(1)}}, Not(ArithmeticNaN(TypeParam{})));
+    EXPECT_THAT(to_result(FP::nan(1)), Not(ArithmeticNaN(TypeParam{})));
+    EXPECT_THAT(to_result(-FP::nan(1)), Not(ArithmeticNaN(TypeParam{})));
 #endif
 }
 
@@ -275,7 +280,7 @@ TYPED_TEST(execute_floating_point_types, compare)
             {
                 const auto a = ordered_values[i];
                 const auto b = ordered_values[j];
-                if (std::isnan(a) || std::isnan(b))
+                if (a.is_nan() || b.is_nan())
                 {
                     EXPECT_THAT(eq(a, b), Result(0)) << a << "==" << b;
                     EXPECT_THAT(ne(a, b), Result(1)) << a << "!=" << b;
@@ -321,6 +326,11 @@ TYPED_TEST(execute_floating_point_types, abs)
 
         for (const auto p : TestValues<TypeParam>::positive_all())
         {
+#if !SNAN_SUPPORTED
+            if (!p.is_arithmetic_nan())
+                continue;
+#endif
+
             // fabs(+-p) = +p
             EXPECT_THAT(exec(p), Result(p));
             EXPECT_THAT(exec(-p), Result(p));
@@ -341,6 +351,11 @@ TYPED_TEST(execute_floating_point_types, neg)
         SCOPED_TRACE(rounding_direction);
         for (const auto p : TestValues<TypeParam>::positive_all())
         {
+#if !SNAN_SUPPORTED
+            if (!p.is_arithmetic_nan())
+                continue;
+#endif
+
             // fneg(+-p) = -+p
             EXPECT_THAT(exec(p), Result(-p));
             EXPECT_THAT(exec(-p), Result(p));
@@ -708,7 +723,7 @@ TYPED_TEST(execute_floating_point_types, add_sub_neg_relation)
             const auto addneg_result = addneg(z1, z2);
             ASSERT_TRUE(addneg_result.has_value);
 
-            if (std::isnan(z1) || std::isnan(z2))
+            if (z1.is_nan() || z2.is_nan())
             {
                 if (FP{z1}.nan_payload() == FP::canon && FP{z2}.nan_payload() == FP::canon)
                 {
@@ -970,8 +985,18 @@ TYPED_TEST(execute_floating_point_types, copysign)
 
         for (const auto p1 : TestValues<TypeParam>::positive_all())
         {
+#if !SNAN_SUPPORTED
+            if (!p1.is_arithmetic_nan())
+                continue;
+#endif
             for (const auto p2 : TestValues<TypeParam>::positive_all())
             {
+#if !SNAN_SUPPORTED
+                if (!p2.is_arithmetic_nan())
+                    continue;
+#endif
+
+
                 // fcopysign(+-p1, +-p2) = +-p1
                 EXPECT_THAT(exec(p1, p2), Result(p1));
                 EXPECT_THAT(exec(-p1, -p2), Result(-p1));
@@ -999,7 +1024,9 @@ TEST(execute_floating_point, f32_load)
 
     auto instance = instantiate(parse(wasm));
 
-    const std::tuple<bytes, float> test_cases[]{
+    const std::tuple<bytes, FP32> test_cases[]
+    {
+        // clang-format off
         {"00000000"_bytes, 0.0f},
         {"00000080"_bytes, -0.0f},
         {"b6f39d3f"_bytes, 1.234f},
@@ -1020,8 +1047,11 @@ TEST(execute_floating_point, f32_load)
         {"0000c0ff"_bytes, -FP32::nan(FP32::canon)},
         {"0100c07f"_bytes, FP32::nan(FP32::canon + 1)},
         {"0100c0ff"_bytes, -FP32::nan(FP32::canon + 1)},
+#if SNAN_SUPPORTED
         {"0100807f"_bytes, FP32::nan(1)},
         {"010080ff"_bytes, -FP32::nan(1)},
+#endif
+        // clang-format on
     };
 
     uint32_t address = 0;
@@ -1072,7 +1102,9 @@ TEST(execute_floating_point, f64_load)
 
     auto instance = instantiate(parse(wasm));
 
-    const std::tuple<bytes, double> test_cases[]{
+    const std::tuple<bytes, FP64> test_cases[]
+    {
+        // clang-format off
         {"0000000000000000"_bytes, 0.0},
         {"0000000000000080"_bytes, -0.0},
         {"5839b4c876bef33f"_bytes, 1.234},
@@ -1093,8 +1125,11 @@ TEST(execute_floating_point, f64_load)
         {"000000000000f8ff"_bytes, -FP64::nan(FP64::canon)},
         {"010000000000f87f"_bytes, FP64::nan(FP64::canon + 1)},
         {"010000000000f8ff"_bytes, -FP64::nan(FP64::canon + 1)},
+#if SNAN_SUPPORTED
         {"010000000000f07f"_bytes, FP64::nan(1)},
         {"010000000000f0ff"_bytes, -FP64::nan(1)},
+#endif
+        // clang-format on
     };
 
     uint32_t address = 0;

--- a/test/unittests/execute_floating_point_test.hpp
+++ b/test/unittests/execute_floating_point_test.hpp
@@ -44,7 +44,7 @@ class TestValues
 {
     using Limits = typename FP<T>::Limits;
 
-    inline static const T m_values[]{
+    inline static const FP<T> m_values[]{
         T{0.0},
 
         Limits::denorm_min(),
@@ -75,7 +75,7 @@ class TestValues
     };
 
 public:
-    using Iterator = const T*;
+    using Iterator = const FP<T>*;
 
     static constexpr auto num_nans = 7;
     static constexpr auto num_positive = std::size(m_values) - num_nans;
@@ -138,12 +138,12 @@ public:
     {
         static const auto ordered_values = [] {
             constexpr auto ps = positive_nonzero_infinite();
-            std::array<T, ps.size() * 2 + 1> a;
+            std::array<FP<T>, ps.size() * 2 + 1> a;
 
             auto it = std::begin(a);
             it = std::transform(std::make_reverse_iterator(std::end(ps)),
-                std::make_reverse_iterator(std::begin(ps)), it, std::negate<T>{});
-            *it++ = T{0.0};
+                std::make_reverse_iterator(std::begin(ps)), it, std::negate<FP<T>>{});
+            *it++ = FP{T{0.0}};
             std::copy(std::begin(ps), std::end(ps), it);
             return a;
         }();
@@ -160,12 +160,12 @@ public:
         static const auto ordered_values = [] {
             const auto& without_nans = ordered();
             const auto nans = positive_nans();
-            std::array<T, positive_all().size() * 2 - 1> a;
+            std::array<FP<T>, positive_all().size() * 2 - 1> a;
 
             auto it = std::begin(a);
             it = std::copy(std::begin(without_nans), std::end(without_nans), it);
             it = std::copy(std::begin(nans), std::end(nans), it);
-            std::transform(std::begin(nans), std::end(nans), it, std::negate<T>{});
+            std::transform(std::begin(nans), std::end(nans), it, std::negate<FP<T>>{});
             return a;
         }();
 

--- a/test/unittests/execute_floating_point_test.hpp
+++ b/test/unittests/execute_floating_point_test.hpp
@@ -44,7 +44,7 @@ class TestValues
 {
     using Limits = typename FP<T>::Limits;
 
-    inline static const std::array m_values{
+    inline static const T m_values[]{
         T{0.0},
 
         Limits::denorm_min(),
@@ -75,10 +75,10 @@ class TestValues
     };
 
 public:
-    using Iterator = typename decltype(m_values)::const_iterator;
+    using Iterator = const T*;
 
     static constexpr auto num_nans = 7;
-    static constexpr auto num_positive = m_values.size() - num_nans;
+    static constexpr auto num_positive = std::size(m_values) - num_nans;
 
     static constexpr Iterator first_non_zero = &m_values[1];
     static constexpr Iterator canonical_nan = &m_values[num_positive];
@@ -116,16 +116,19 @@ public:
     }
 
     // The list of positive NaN values.
-    static constexpr Range positive_nans() noexcept { return {canonical_nan, m_values.end()}; }
+    static constexpr Range positive_nans() noexcept { return {canonical_nan, std::end(m_values)}; }
 
     // The list of positive non-canonical NaN values (including signaling NaNs).
     static constexpr Range positive_noncanonical_nans() noexcept
     {
-        return {first_noncanonical_nan, m_values.end()};
+        return {first_noncanonical_nan, std::end(m_values)};
     }
 
     // The list of positive floating-point values with zero, infinity and NaNs.
-    static constexpr Range positive_all() noexcept { return {m_values.begin(), m_values.end()}; }
+    static constexpr Range positive_all() noexcept
+    {
+        return {std::begin(m_values), std::end(m_values)};
+    }
 
     // The list of floating-point values, including infinities.
     // They are strictly ordered (ordered_values[i] < ordered_values[j] for i<j).

--- a/test/unittests/floating_point_utils_test.cpp
+++ b/test/unittests/floating_point_utils_test.cpp
@@ -7,6 +7,46 @@
 
 using namespace fizzy::test;
 
+TEST(floating_point_utils, fp_default)
+{
+    EXPECT_EQ(FP32{}.as_uint(), 0);
+    EXPECT_EQ(FP32{}.as_float(), 0.0f);
+    EXPECT_EQ(FP32{}.sign_bit(), 0);
+
+    EXPECT_EQ(FP64{}.as_uint(), 0);
+    EXPECT_EQ(FP64{}.as_float(), 0.0);
+    EXPECT_EQ(FP64{}.sign_bit(), 0);
+}
+
+TEST(floating_point_utils, fp_sign_bit)
+{
+    EXPECT_EQ(FP{0.0f}.sign_bit(), 0);
+    EXPECT_EQ(FP{-0.0f}.sign_bit(), 1);
+    EXPECT_EQ(FP(FP32::Limits::infinity()).sign_bit(), 0);
+    EXPECT_EQ(FP(-FP32::Limits::infinity()).sign_bit(), 1);
+    EXPECT_EQ(FP(FP32::Limits::max()).sign_bit(), 0);
+    EXPECT_EQ(FP(FP32::Limits::lowest()).sign_bit(), 1);
+    EXPECT_EQ(FP(FP32::nan(FP32::canon)).sign_bit(), 0);
+    EXPECT_EQ((-FP(FP32::nan(FP32::canon))).sign_bit(), 1);
+
+    EXPECT_EQ(FP{0.0}.sign_bit(), 0);
+    EXPECT_EQ(FP{-0.0}.sign_bit(), 1);
+    EXPECT_EQ(FP(FP64::Limits::infinity()).sign_bit(), 0);
+    EXPECT_EQ(FP(-FP64::Limits::infinity()).sign_bit(), 1);
+    EXPECT_EQ(FP(FP64::Limits::max()).sign_bit(), 0);
+    EXPECT_EQ(FP(FP64::Limits::lowest()).sign_bit(), 1);
+    EXPECT_EQ(FP(FP64::nan(FP64::canon)).sign_bit(), 0);
+    EXPECT_EQ((-FP(FP64::nan(FP64::canon))).sign_bit(), 1);
+}
+
+TEST(floating_point_utils, fp_negate)
+{
+    EXPECT_EQ((-FP{1.0f}).as_float(), -1.0f);
+    EXPECT_EQ((-FP{1.0}).as_float(), -1.0);
+    EXPECT_EQ((-FP{-1.0f}).as_float(), 1.0f);
+    EXPECT_EQ((-FP{-1.0}).as_float(), 1.0);
+}
+
 TEST(floating_point_utils, double_as_uint)
 {
     EXPECT_EQ(FP(0.0).as_uint(), 0x0000000000000000);

--- a/test/unittests/floating_point_utils_test.cpp
+++ b/test/unittests/floating_point_utils_test.cpp
@@ -64,22 +64,22 @@ TEST(floating_point_utils, float_as_uint)
 
 TEST(floating_point_utils, double_from_uint)
 {
-    EXPECT_EQ(FP(uint64_t{0x0000000000000000}).value, 0.0);
-    EXPECT_EQ(FP(uint64_t{0x8000000000000000}).value, -0.0);
-    EXPECT_EQ(FP(uint64_t{0x3FF'000000000DEAD}).value, 0x1.000000000DEADp0);
-    EXPECT_EQ(FP(uint64_t{0xBFF'000000000DEAD}).value, -0x1.000000000DEADp0);
-    EXPECT_EQ(FP(uint64_t{0x7FF'0000000000000}).value, FP64::Limits::infinity());
-    EXPECT_EQ(FP(uint64_t{0xFFF'0000000000000}).value, -FP64::Limits::infinity());
+    EXPECT_EQ(FP(uint64_t{0x0000000000000000}).as_float(), 0.0);
+    EXPECT_EQ(FP(uint64_t{0x8000000000000000}).as_float(), -0.0);
+    EXPECT_EQ(FP(uint64_t{0x3FF'000000000DEAD}).as_float(), 0x1.000000000DEADp0);
+    EXPECT_EQ(FP(uint64_t{0xBFF'000000000DEAD}).as_float(), -0x1.000000000DEADp0);
+    EXPECT_EQ(FP(uint64_t{0x7FF'0000000000000}).as_float(), FP64::Limits::infinity());
+    EXPECT_EQ(FP(uint64_t{0xFFF'0000000000000}).as_float(), -FP64::Limits::infinity());
 }
 
 TEST(floating_point_utils, float_from_uint)
 {
-    EXPECT_EQ(FP(uint32_t{0x00000000}).value, 0.0f);
-    EXPECT_EQ(FP(uint32_t{0x80000000}).value, -0.0f);
-    EXPECT_EQ(FP(uint32_t{0x3FEF5680}).value, 0x1.DEADp0f);
-    EXPECT_EQ(FP(uint32_t{0xBFEF5680}).value, -0x1.DEADp0f);
-    EXPECT_EQ(FP(uint32_t{0x7F800000}).value, FP32::Limits::infinity());
-    EXPECT_EQ(FP(uint32_t{0xFF800000}).value, -FP32::Limits::infinity());
+    EXPECT_EQ(FP(uint32_t{0x00000000}).as_float(), 0.0f);
+    EXPECT_EQ(FP(uint32_t{0x80000000}).as_float(), -0.0f);
+    EXPECT_EQ(FP(uint32_t{0x3FEF5680}).as_float(), 0x1.DEADp0f);
+    EXPECT_EQ(FP(uint32_t{0xBFEF5680}).as_float(), -0x1.DEADp0f);
+    EXPECT_EQ(FP(uint32_t{0x7F800000}).as_float(), FP32::Limits::infinity());
+    EXPECT_EQ(FP(uint32_t{0xFF800000}).as_float(), -FP32::Limits::infinity());
 }
 
 TEST(floating_point_utils, double_nan_payload)

--- a/test/unittests/floating_point_utils_test.cpp
+++ b/test/unittests/floating_point_utils_test.cpp
@@ -340,3 +340,29 @@ TEST(floating_point_utils, float_is_arithmetic_nan)
     EXPECT_FALSE(FP32{FP32::Limits::infinity()}.is_arithmetic_nan());
     EXPECT_FALSE(FP32{-FP32::Limits::infinity()}.is_arithmetic_nan());
 }
+
+TEST(floating_point_utils, fp32_ostream)
+{
+    std::ostringstream os;
+
+    os << FP32{-0.0f};
+    EXPECT_EQ(os.str(), "-0 [-0x0p+0]");
+    os.str({});
+
+    os << FP32{FP32::nan(FP32::canon)};
+    EXPECT_EQ(os.str(), "nan [400000]");
+    os.str({});
+}
+
+TEST(floating_point_utils, fp64_ostream)
+{
+    std::ostringstream os;
+
+    os << FP64{-8.125};
+    EXPECT_EQ(os.str(), "-8.125 [-0x1.04p+3]");
+    os.str({});
+
+    os << FP64{FP64::nan(FP64::canon + 1)};
+    EXPECT_EQ(os.str(), "nan [8000000000001]");
+    os.str({});
+}

--- a/test/unittests/floating_point_utils_test.cpp
+++ b/test/unittests/floating_point_utils_test.cpp
@@ -26,8 +26,8 @@ TEST(floating_point_utils, fp_sign_bit)
     EXPECT_EQ(FP(-FP32::Limits::infinity()).sign_bit(), 1);
     EXPECT_EQ(FP(FP32::Limits::max()).sign_bit(), 0);
     EXPECT_EQ(FP(FP32::Limits::lowest()).sign_bit(), 1);
-    EXPECT_EQ(FP(FP32::nan(FP32::canon)).sign_bit(), 0);
-    EXPECT_EQ((-FP(FP32::nan(FP32::canon))).sign_bit(), 1);
+    EXPECT_EQ(FP32::nan(FP32::canon).sign_bit(), 0);
+    EXPECT_EQ((-FP32::nan(FP32::canon)).sign_bit(), 1);
 
     EXPECT_EQ(FP{0.0}.sign_bit(), 0);
     EXPECT_EQ(FP{-0.0}.sign_bit(), 1);
@@ -35,8 +35,8 @@ TEST(floating_point_utils, fp_sign_bit)
     EXPECT_EQ(FP(-FP64::Limits::infinity()).sign_bit(), 1);
     EXPECT_EQ(FP(FP64::Limits::max()).sign_bit(), 0);
     EXPECT_EQ(FP(FP64::Limits::lowest()).sign_bit(), 1);
-    EXPECT_EQ(FP(FP64::nan(FP64::canon)).sign_bit(), 0);
-    EXPECT_EQ((-FP(FP64::nan(FP64::canon))).sign_bit(), 1);
+    EXPECT_EQ(FP64::nan(FP64::canon).sign_bit(), 0);
+    EXPECT_EQ((-FP64::nan(FP64::canon)).sign_bit(), 1);
 }
 
 TEST(floating_point_utils, fp_negate)
@@ -130,7 +130,7 @@ TEST(floating_point_utils, double_nan_payload)
     EXPECT_EQ(FP(0.0).nan_payload(), 0);
     EXPECT_EQ(FP(FP64::nan(FP64::canon + 1)).nan_payload(), FP64::canon + 1);
     EXPECT_EQ(FP(qnan).nan_payload(), FP64::canon);
-    EXPECT_EQ(FP(qnan + 1.0).nan_payload(), FP64::canon);
+    EXPECT_EQ(FP(qnan.as_float() + 1.0).nan_payload(), FP64::canon);
     EXPECT_EQ(FP(inf - inf).nan_payload(), FP64::canon);
     EXPECT_EQ(FP(inf * 0.0).nan_payload(), FP64::canon);
 
@@ -145,9 +145,10 @@ TEST(floating_point_utils, float_nan_payload)
     const auto qnan = FP32::nan(FP32::canon);
 
     EXPECT_EQ(FP(0.0f).nan_payload(), 0);
+    EXPECT_EQ(FP(FP32::nan(1)).nan_payload(), 1);
     EXPECT_EQ(FP(FP32::nan(FP32::canon + 1)).nan_payload(), FP32::canon + 1);
     EXPECT_EQ(FP(qnan).nan_payload(), FP32::canon);
-    EXPECT_EQ(FP(qnan + 1.0f).nan_payload(), FP32::canon);
+    EXPECT_EQ(FP(qnan.as_float() + 1.0f).nan_payload(), FP32::canon);
     EXPECT_EQ(FP(inf - inf).nan_payload(), FP32::canon);
     EXPECT_EQ(FP(inf * 0.0f).nan_payload(), FP32::canon);
 
@@ -158,29 +159,36 @@ TEST(floating_point_utils, float_nan_payload)
 
 TEST(floating_point_utils, double_nan)
 {
-    EXPECT_TRUE(std::isnan(FP64::nan(FP64::canon)));
-    EXPECT_TRUE(std::isnan(FP64::nan(0xDEADBEEF)));
-    EXPECT_TRUE(std::isnan(FP64::nan(0xDEADBEEFBEEEF)));
-    EXPECT_FALSE(std::isnan(FP64::nan(0)));
+    EXPECT_TRUE(FP64::nan(FP64::canon).is_nan());
+    EXPECT_TRUE(std::isnan(FP64::nan(FP64::canon).as_float()));
+    EXPECT_TRUE(FP64::nan(1).is_nan());
+    EXPECT_TRUE(std::isnan(FP64::nan(1).as_float()));
+    EXPECT_TRUE(FP64::nan(0xDEADBEEF).is_nan());
+    EXPECT_TRUE(std::isnan(FP64::nan(0xDEADBEEF).as_float()));
+    EXPECT_TRUE(FP64::nan(0xDEADBEEFBEEEF).is_nan());
+    EXPECT_TRUE(std::isnan(FP64::nan(0xDEADBEEFBEEEF).as_float()));
+    EXPECT_FALSE(FP64::nan(0).is_nan());
+    EXPECT_FALSE(std::isnan(FP64::nan(0).as_float()));
 
     EXPECT_EQ(FP{FP64::nan(FP64::canon)}.nan_payload(), FP64::canon);
 
     EXPECT_EQ(FP{FP64::nan(FP64::canon)}.as_uint(), 0x7FF'8000000000000);
-    EXPECT_EQ(FP{FP64::nan(0xDEADBEEFBEEEF)}.as_uint(), 0x7FF'DEADBEEFBEEEF);
-
-#if SNAN_SUPPORTED
-    EXPECT_TRUE(std::isnan(FP64::nan(1)));
     EXPECT_EQ(FP{FP64::nan(0xDEADBEEF)}.as_uint(), 0x7FF'00000DEADBEEF);
-#endif
+    EXPECT_EQ(FP{FP64::nan(0xDEADBEEFBEEEF)}.as_uint(), 0x7FF'DEADBEEFBEEEF);
 }
 
 TEST(floating_point_utils, float_nan)
 {
-    EXPECT_TRUE(std::isnan(FP32::nan(FP32::canon)));
-    EXPECT_TRUE(std::isnan(FP32::nan(1)));
-    EXPECT_TRUE(std::isnan(FP32::nan(0x7fffff)));
-    EXPECT_TRUE(std::isnan(FP32::nan(0x400001)));
-    EXPECT_FALSE(std::isnan(FP32::nan(0)));
+    EXPECT_TRUE(FP32::nan(FP32::canon).is_nan());
+    EXPECT_TRUE(std::isnan(FP32::nan(FP32::canon).as_float()));
+    EXPECT_TRUE(FP32::nan(1).is_nan());
+    EXPECT_TRUE(std::isnan(FP32::nan(1).as_float()));
+    EXPECT_TRUE(FP32::nan(0x7fffff).is_nan());
+    EXPECT_TRUE(std::isnan(FP32::nan(0x7fffff).as_float()));
+    EXPECT_TRUE(FP32::nan(0x400001).is_nan());
+    EXPECT_TRUE(std::isnan(FP32::nan(0x400001).as_float()));
+    EXPECT_FALSE(FP32::nan(0).is_nan());
+    EXPECT_FALSE(std::isnan(FP32::nan(0).as_float()));
 
     EXPECT_EQ(FP{FP32::nan(FP32::canon)}.nan_payload(), FP32::canon);
 
@@ -389,7 +397,7 @@ TEST(floating_point_utils, fp32_ostream)
     EXPECT_EQ(os.str(), "-0 [-0x0p+0]");
     os.str({});
 
-    os << FP32{FP32::nan(FP32::canon)};
+    os << FP32::nan(FP32::canon);
     EXPECT_EQ(os.str(), "nan [400000]");
     os.str({});
 }
@@ -402,7 +410,7 @@ TEST(floating_point_utils, fp64_ostream)
     EXPECT_EQ(os.str(), "-8.125 [-0x1.04p+3]");
     os.str({});
 
-    os << FP64{FP64::nan(FP64::canon + 1)};
+    os << FP64::nan(FP64::canon + 1);
     EXPECT_EQ(os.str(), "nan [8000000000001]");
     os.str({});
 }

--- a/test/unittests/test_utils_test.cpp
+++ b/test/unittests/test_utils_test.cpp
@@ -106,17 +106,17 @@ TEST(test_utils, print_typed_execution_result)
 
     std::stringstream str_value_f32;
     str_value_f32 << TypedExecutionResult{ExecutionResult{Value{1.125f}}, ValType::f32};
-    EXPECT_EQ(str_value_f32.str(), "result(1.125 (f32))");
+    EXPECT_EQ(str_value_f32.str(), "result(1.125 [0x1.2p+0] (f32))");
     str_value_f32.str({});
     str_value_f32 << TypedExecutionResult{ExecutionResult{Value{-1.125f}}, ValType::f32};
-    EXPECT_EQ(str_value_f32.str(), "result(-1.125 (f32))");
+    EXPECT_EQ(str_value_f32.str(), "result(-1.125 [-0x1.2p+0] (f32))");
 
     std::stringstream str_value_f64;
     str_value_f64 << TypedExecutionResult{ExecutionResult{Value{1.125}}, ValType::f64};
-    EXPECT_EQ(str_value_f64.str(), "result(1.125 (f64))");
+    EXPECT_EQ(str_value_f64.str(), "result(1.125 [0x1.2p+0] (f64))");
     str_value_f64.str({});
     str_value_f64 << TypedExecutionResult{ExecutionResult{Value{-1.125}}, ValType::f64};
-    EXPECT_EQ(str_value_f64.str(), "result(-1.125 (f64))");
+    EXPECT_EQ(str_value_f64.str(), "result(-1.125 [-0x1.2p+0] (f64))");
 }
 
 TEST(test_utils, result_value_matcher)

--- a/test/utils/asserts.cpp
+++ b/test/utils/asserts.cpp
@@ -59,10 +59,10 @@ std::ostream& operator<<(std::ostream& os, const TypedExecutionResult& result)
                << "] (i64)";
             break;
         case ValType::f32:
-            os << result.value.f32 << " (f32)";
+            os << FP{result.value.f32} << " (f32)";
             break;
         case ValType::f64:
-            os << result.value.f64 << " (f64)";
+            os << FP{result.value.f64} << " (f64)";
             break;
         }
         os << ")";

--- a/test/utils/asserts.hpp
+++ b/test/utils/asserts.hpp
@@ -42,14 +42,14 @@ MATCHER_P(Result, value, "")  // NOLINT(readability-redundant-string-init)
         if (arg.trapped || !arg.has_value)
             return false;
 
-        if constexpr (std::is_same_v<value_type, float>)
+        if constexpr (std::is_same_v<value_type, float> || std::is_same_v<value_type, test::FP32>)
         {
-            return arg.type == ValType::f32 && arg.value.f32 == test::FP{value};
+            return arg.type == ValType::f32 && test::FP32{arg.value.f32} == value;
         }
 
-        if constexpr (std::is_same_v<value_type, double>)
+        if constexpr (std::is_same_v<value_type, double> || std::is_same_v<value_type, test::FP64>)
         {
-            return arg.type == ValType::f64 && arg.value.f64 == test::FP{value};
+            return arg.type == ValType::f64 && test::FP64{arg.value.f64} == value;
         }
 
         if constexpr (std::is_integral_v<value_type> && sizeof(value_type) == sizeof(uint64_t))
@@ -95,11 +95,11 @@ MATCHER_P(CResult, value, "")  // NOLINT(readability-redundant-string-init)
     if constexpr (std::is_floating_point_v<value_type>)
     {
         if constexpr (std::is_same_v<float, value_type>)
-            return arg.value.f32 == fizzy::test::FP{value};
+            return fizzy::test::FP{arg.value.f32} == value;
         else
         {
             static_assert(std::is_same_v<double, value_type>);
-            return arg.value.f64 == fizzy::test::FP{value};
+            return fizzy::test::FP{arg.value.f64} == value;
         }
     }
     else if constexpr (std::is_same_v<value_type, uint32_t>)

--- a/test/utils/floating_point_utils.hpp
+++ b/test/utils/floating_point_utils.hpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstdint>
 #include <limits>
+#include <ostream>
 #include <type_traits>
 
 #ifdef __i386__
@@ -105,6 +106,19 @@ public:
     friend bool operator!=(FP a, FP b) noexcept { return !(a == b); }
     friend bool operator!=(FP a, FloatType b) noexcept { return a != FP{b}; }
     friend bool operator!=(FloatType a, FP b) noexcept { return FP{a} != b; }
+
+    friend std::ostream& operator<<(std::ostream& os, FP x)
+    {
+        const auto format_flags = os.flags();
+        os << x.as_float() << " [";
+        if (x.is_nan())
+            os << std::hex << x.nan_payload();
+        else
+            os << std::hexfloat << x.as_float();
+        os << "]";
+        os.flags(format_flags);
+        return os;
+    }
 };
 
 FP(uint32_t)->FP<float>;

--- a/test/utils/floating_point_utils.hpp
+++ b/test/utils/floating_point_utils.hpp
@@ -111,9 +111,9 @@ public:
     /// The IEEE 754 defines quiet NaN as having the top bit of the mantissa set to 1. Wasm calls
     /// this NaN _arithmetic_. The arithmetic NaN with the lowest mantissa (the top bit set, all
     /// other zeros) is the _canonical_ NaN.
-    static FloatType nan(UintType payload) noexcept
+    static FP nan(UintType payload) noexcept
     {
-        return FP{(nan_exponent << num_mantissa_bits) | (payload & mantissa_mask)}.as_float();
+        return FP{(nan_exponent << num_mantissa_bits) | (payload & mantissa_mask)};
     }
 
     /// Returns the value of the sign bit.

--- a/test/utils/floating_point_utils.hpp
+++ b/test/utils/floating_point_utils.hpp
@@ -57,7 +57,7 @@ private:
     UintType m_storage{};  ///< Bits storage.
 
 public:
-    explicit FP(FloatType v) noexcept : m_storage{bit_cast<UintType>(v)} {}
+    FP(FloatType v) noexcept : m_storage{bit_cast<UintType>(v)} {}
 
     explicit FP(UintType u) noexcept : m_storage{u} {}
 

--- a/test/utils/floating_point_utils.hpp
+++ b/test/utils/floating_point_utils.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "cxx20/bit.hpp"
+#include "typed_value.hpp"
 #include <cmath>
 #include <cstdint>
 #include <limits>
@@ -60,6 +61,14 @@ public:
     FP(FloatType v) noexcept : m_storage{bit_cast<UintType>(v)} {}
 
     explicit FP(UintType u) noexcept : m_storage{u} {}
+
+    operator TypedValue() const noexcept
+    {
+        if constexpr (std::is_same_v<FloatType, float>)
+            return {ValType::f32, Value{m_storage}};
+        else
+            return {ValType::f64, Value{m_storage}};
+    }
 
     /// Return unsigned integer with the binary representation of the value.
     UintType as_uint() const noexcept { return m_storage; }


### PR DESCRIPTION
This enhance the FP utility type to be used in test cases and expected results in place of raw floating-point types. This gives better control of the floating-point binary representation and avoid places where some inplicit conversion may happen.