### PR TITLE
hunter: Upgrade benchmark to 1.5.3

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,0 +1,8 @@
+# Hunter local configuration.
+
+hunter_config(
+    benchmark
+    VERSION 1.5.3
+    URL https://github.com/google/benchmark/archive/v1.5.3.tar.gz
+    SHA1 32655d8796e708439ac5d4de8aa31f00d9dbda3b
+)

--- a/cmake/Hunter/init.cmake
+++ b/cmake/Hunter/init.cmake
@@ -25,4 +25,5 @@ endif()
 HunterGate(
     URL https://github.com/cpp-pm/hunter/archive/v0.23.294.tar.gz
     SHA1 0dd1ee8723d54a15822519c17a877c1f281fce39
+    LOCAL
 )


### PR DESCRIPTION
Previous version of benchmark (1.5.0) does not build under GCC 11.
The 1.5.3 is the latest release.