### PR TITLE
Upgrade uvwasi to 0.0.12

### DIFF
--- a/cmake/ProjectUVWASI.cmake
+++ b/cmake/ProjectUVWASI.cmake
@@ -23,21 +23,24 @@ endif()
 ExternalProject_Add(uvwasi
     EXCLUDE_FROM_ALL 1
     PREFIX ${prefix}
-    DOWNLOAD_NAME uvwasi-0.0.11.tar.gz
+    DOWNLOAD_NAME uvwasi-0.0.12.tar.gz
     DOWNLOAD_DIR ${prefix}/downloads
     SOURCE_DIR ${source_dir}
     BINARY_DIR ${binary_dir}
-    URL https://github.com/nodejs/uvwasi/archive/v0.0.11.tar.gz
-    URL_HASH SHA256=c170e2e92280dcb2b54e5b65a429b03a61710245747c3ca01ec23239a3d61e76
+    URL https://github.com/nodejs/uvwasi/archive/v0.0.12.tar.gz
+    URL_HASH SHA256=f310a628d2657b9ed523a19284f58e4a407466f2e17efb2250d2e58524d02c53
     CMAKE_ARGS
     ${toolchain_file}
     -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    -DBUILD_SHARED_LIBS=OFF
     -DUVWASI_DEBUG_LOG=OFF
     -DCODE_COVERAGE=OFF
     -DASAN=OFF
     -DUVWASI_BUILD_TESTS=OFF
+    # packaged libuv version depends on this
+    -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE
     BUILD_BYPRODUCTS ${uvwasi_library} ${uv_library}
 )
 

--- a/cmake/ProjectUVWASI.cmake
+++ b/cmake/ProjectUVWASI.cmake
@@ -23,12 +23,12 @@ endif()
 ExternalProject_Add(uvwasi
     EXCLUDE_FROM_ALL 1
     PREFIX ${prefix}
-    DOWNLOAD_NAME uvwasi-0.0.10.tar.gz
+    DOWNLOAD_NAME uvwasi-0.0.11.tar.gz
     DOWNLOAD_DIR ${prefix}/downloads
     SOURCE_DIR ${source_dir}
     BINARY_DIR ${binary_dir}
-    URL https://github.com/nodejs/uvwasi/archive/v0.0.10.tar.gz
-    URL_HASH SHA256=39135f4dd4a44013399ceed7166391ffc5c09655e4bfbf851da2be039e6985df
+    URL https://github.com/nodejs/uvwasi/archive/v0.0.11.tar.gz
+    URL_HASH SHA256=c170e2e92280dcb2b54e5b65a429b03a61710245747c3ca01ec23239a3d61e76
     CMAKE_ARGS
     ${toolchain_file}
     -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>

--- a/tools/wasi/uvwasi.cpp
+++ b/tools/wasi/uvwasi.cpp
@@ -28,8 +28,7 @@ public:
             uvwasi_destroy(&m_state);
 
         // Initialisation settings.
-        // TODO: Make const after https://github.com/nodejs/uvwasi/pull/155 is merged.
-        uvwasi_options_t options = {
+        const uvwasi_options_t options = {
             3,           // sizeof fd_table
             0, nullptr,  // NOTE: no remappings
             argc, argv,

--- a/tools/wasi/uvwasi.cpp
+++ b/tools/wasi/uvwasi.cpp
@@ -13,19 +13,13 @@ class UVWASIImpl final : public UVWASI
 {
     /// UVWASI state.
     uvwasi_t m_state{};
-    bool m_inited = false;
 
 public:
-    ~UVWASIImpl() final
-    {
-        if (m_inited)
-            uvwasi_destroy(&m_state);
-    }
+    ~UVWASIImpl() final { uvwasi_destroy(&m_state); }
 
     uvwasi_errno_t init(uvwasi_size_t argc, const char** argv) noexcept final
     {
-        if (m_inited)
-            uvwasi_destroy(&m_state);
+        uvwasi_destroy(&m_state);
 
         // Initialisation settings.
         const uvwasi_options_t options = {
@@ -36,9 +30,7 @@ public:
             0, 1, 2,
             nullptr,  // NOTE: no special allocator
         };
-        const auto ret = uvwasi_init(&m_state, &options);
-        m_inited = (ret == UVWASI_ESUCCESS);
-        return ret;
+        return uvwasi_init(&m_state, &options);
     }
 
     uvwasi_errno_t proc_exit(uvwasi_exitcode_t exit_code) noexcept final


### PR DESCRIPTION
This allows removing two workarounds needed for earlier uvwasi versions.