### PR TITLE
Fix overflows with memory of max size

### DIFF
--- a/lib/fizzy/instantiate.cpp
+++ b/lib/fizzy/instantiate.cpp
@@ -203,7 +203,7 @@ std::tuple<bytes_ptr, Limits> allocate_memory(const std::vector<Memory>& module_
         }
 
         // NOTE: fill it with zeroes
-        bytes_ptr memory{new bytes(memory_min * PageSize, 0), bytes_delete};
+        bytes_ptr memory{new bytes(uint64_t{memory_min} * PageSize, 0), bytes_delete};
         return {std::move(memory), module_memories[0].limits};
     }
     else if (imported_memories.size() == 1)

--- a/lib/fizzy/instantiate.cpp
+++ b/lib/fizzy/instantiate.cpp
@@ -121,7 +121,8 @@ void match_imported_memories(const std::vector<Memory>& module_imported_memories
 
         const auto min = imported_memories[0].limits.min;
         const auto& max = imported_memories[0].limits.max;
-        if (size < min * PageSize || (max.has_value() && size > *max * PageSize))
+        if (size < uint64_t{min} * PageSize ||
+            (max.has_value() && size > uint64_t{*max} * PageSize))
             throw instantiate_error{"provided imported memory doesn't fit provided limits"};
     }
 }

--- a/lib/fizzy/instantiate.cpp
+++ b/lib/fizzy/instantiate.cpp
@@ -200,7 +200,8 @@ std::tuple<bytes_ptr, Limits> allocate_memory(const std::vector<Memory>& module_
             (memory_max.has_value() && *memory_max > memory_pages_limit))
         {
             throw instantiate_error{"cannot exceed hard memory limit of " +
-                                    std::to_string(memory_pages_limit * PageSize) + " bytes"};
+                                    std::to_string(uint64_t{memory_pages_limit} * PageSize) +
+                                    " bytes"};
         }
 
         // NOTE: fill it with zeroes
@@ -217,7 +218,8 @@ std::tuple<bytes_ptr, Limits> allocate_memory(const std::vector<Memory>& module_
             (memory_max.has_value() && *memory_max > memory_pages_limit))
         {
             throw instantiate_error{"imported memory limits cannot exceed hard memory limit of " +
-                                    std::to_string(memory_pages_limit * PageSize) + " bytes"};
+                                    std::to_string(uint64_t{memory_pages_limit} * PageSize) +
+                                    " bytes"};
         }
 
         bytes_ptr memory{imported_memories[0].data, null_delete};

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -7,6 +7,7 @@
 #include "parser.hpp"
 #include <gtest/gtest.h>
 #include <test/utils/asserts.hpp>
+#include <test/utils/execute_helpers.hpp>
 #include <test/utils/hex.hpp>
 #include <test/utils/instantiate_helpers.hpp>
 
@@ -533,6 +534,20 @@ TEST(instantiate, memory_single_custom_hard_limit)
         "hard memory limit cannot exceed 4294967296 bytes");
     EXPECT_THROW_MESSAGE(instantiate(*module, {}, {}, {}, {}, std::numeric_limits<uint32_t>::max()),
         instantiate_error, "hard memory limit cannot exceed 4294967296 bytes");
+}
+
+TEST(instantiate, memory_allocate_max_size)
+{
+    /* wat2wasm
+      (memory 65536)
+      (func (result i32) (memory.size))
+    */
+    const auto bin =
+        from_hex("0061736d010000000105016000017f03020100050501008080040a060104003f000b");
+    const auto module = parse(bin);
+    auto instance = instantiate(*module, {}, {}, {}, {}, 65536);
+    EXPECT_EQ(instance->memory->size(), 4 * 1024 * 1024 * 1024ULL);
+    EXPECT_THAT(execute(*instance, 0, {}), Result(65536));
 }
 
 TEST(instantiate, imported_memory_custom_hard_limit)

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -568,6 +568,9 @@ TEST(instantiate, imported_memory_custom_hard_limit)
     EXPECT_THROW_MESSAGE(instantiate(*module, {}, {}, {{&memory, {3, 4}}}, {}, 3),
         instantiate_error,
         "imported memory limits cannot exceed hard memory limit of 196608 bytes");
+    EXPECT_THROW_MESSAGE(instantiate(*module, {}, {}, {{&memory, {3, 65537}}}, {}, 65536),
+        instantiate_error,
+        "imported memory limits cannot exceed hard memory limit of 4294967296 bytes");
 
     EXPECT_NO_THROW(instantiate(*module, {}, {}, {{&memory, {3, std::nullopt}}}, {}, 3));
     EXPECT_NO_THROW(instantiate(*module, {}, {}, {{&memory, {3, std::nullopt}}}, {}, 4));


### PR DESCRIPTION
Calculating memory in bytes to be allocated as `memory_min * PageSize` overflows 32 bit when trying to allocate 4 Gb and 0 bytes is actually allocated.

Probably this should be a spec test instead of unit test, unit test crashes on CI anyway.

`memory.grow` looks to not have a problem, but a test would be nice, too.