### PR TITLE
Fix handling memory of max size on 32-bit systems: change hard memory limit

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -145,17 +145,19 @@ inline uint32_t grow_memory(
     assert(memory_pages_limit <= MaxMemoryPagesLimit);
     assert(cur_pages <= memory_pages_limit);
 
-    const auto new_pages = uint64_t{cur_pages} + delta_pages;
-    if (new_pages > memory_pages_limit)
+    const auto new_pages_u64 = uint64_t{cur_pages} + delta_pages;
+    if (new_pages_u64 > memory_pages_limit)
         return static_cast<uint32_t>(-1);
+
+    const auto new_pages = static_cast<uint32_t>(new_pages_u64);
 
     try
     {
-        // new_pages <= memory_pages_limit <= MaxMemoryPagesLimit guarantees multiplication
+        // new_pages <= memory_pages_limit <= MaxMemoryPagesLimit guarantees memory_pages_to_bytes
         // will not overflow uint32_t.
-        assert(new_pages * PageSize <= std::numeric_limits<uint32_t>::max());
+        assert(memory_pages_to_bytes(new_pages) <= std::numeric_limits<uint32_t>::max());
         static_assert(sizeof(size_t) >= sizeof(uint32_t));
-        memory.resize(static_cast<size_t>(new_pages) * PageSize);
+        memory.resize(static_cast<size_t>(memory_pages_to_bytes(new_pages)));
         return static_cast<uint32_t>(cur_pages);
     }
     catch (...)

--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -154,9 +154,8 @@ inline uint32_t grow_memory(
     try
     {
         // new_pages <= memory_pages_limit <= MaxMemoryPagesLimit guarantees memory_pages_to_bytes
-        // will not overflow uint32_t.
-        assert(memory_pages_to_bytes(new_pages) <= std::numeric_limits<uint32_t>::max());
-        static_assert(sizeof(size_t) >= sizeof(uint32_t));
+        // will not overflow size_t.
+        assert(memory_pages_to_bytes(new_pages) <= std::numeric_limits<size_t>::max());
         memory.resize(static_cast<size_t>(memory_pages_to_bytes(new_pages)));
         return static_cast<uint32_t>(cur_pages);
     }

--- a/lib/fizzy/instantiate.cpp
+++ b/lib/fizzy/instantiate.cpp
@@ -204,6 +204,9 @@ std::tuple<bytes_ptr, Limits> allocate_memory(const std::vector<Memory>& module_
                                     " bytes"};
         }
 
+        // memory_min <= memory_pages_limit <= MaxMemoryPagesLimit guarantees memory_pages_to_bytes
+        // will not overflow size_t.
+        assert(memory_pages_to_bytes(memory_min) <= std::numeric_limits<size_t>::max());
         // NOTE: fill it with zeroes
         bytes_ptr memory{
             new bytes(static_cast<size_t>(memory_pages_to_bytes(memory_min)), 0), bytes_delete};

--- a/lib/fizzy/limits.hpp
+++ b/lib/fizzy/limits.hpp
@@ -4,12 +4,19 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 namespace fizzy
 {
 /// The page size as defined by the WebAssembly 1.0 specification.
 constexpr uint32_t PageSize = 65536;
+
+/// Convert memory size in pages to size in bytes.
+inline constexpr uint64_t memory_pages_to_bytes(uint32_t pages) noexcept
+{
+    return pages * PageSize;
+}
 
 /// The maximum memory page limit as defined by the specification.
 /// It is only possible to address 4 GB (32-bit) of memory.

--- a/lib/fizzy/limits.hpp
+++ b/lib/fizzy/limits.hpp
@@ -4,8 +4,10 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 
 namespace fizzy
 {
@@ -20,8 +22,13 @@ inline constexpr uint64_t memory_pages_to_bytes(uint32_t pages) noexcept
 
 /// The maximum memory page limit as defined by the specification.
 /// It is only possible to address 4 GB (32-bit) of memory.
-constexpr uint32_t MaxMemoryPagesLimit = (4 * 1024 * 1024 * 1024ULL) / PageSize;
-static_assert(MaxMemoryPagesLimit == 65536);
+/// For 32-bit build environment only max size_t value can be allocated (4 GB - 1 byte).
+constexpr auto MaxMemoryBytesLimit =
+    std::min<uint64_t>(4 * 1024 * 1024 * 1024ULL, std::numeric_limits<size_t>::max());
+constexpr uint32_t MaxMemoryPagesLimit = MaxMemoryBytesLimit / PageSize;
+static_assert((sizeof(size_t) > sizeof(uint32_t) && MaxMemoryPagesLimit == 65536) ||
+              MaxMemoryPagesLimit == 65535);
+static_assert(memory_pages_to_bytes(MaxMemoryPagesLimit) <= std::numeric_limits<size_t>::max());
 
 /// The default hard limit of the memory size (256MB) as number of pages.
 constexpr uint32_t DefaultMemoryPagesLimit = (256 * 1024 * 1024ULL) / PageSize;

--- a/lib/fizzy/limits.hpp
+++ b/lib/fizzy/limits.hpp
@@ -15,7 +15,7 @@ constexpr uint32_t PageSize = 65536;
 /// Convert memory size in pages to size in bytes.
 inline constexpr uint64_t memory_pages_to_bytes(uint32_t pages) noexcept
 {
-    return pages * PageSize;
+    return uint64_t{pages} * PageSize;
 }
 
 /// The maximum memory page limit as defined by the specification.

--- a/test/spectests/spectests.cpp
+++ b/test/spectests/spectests.cpp
@@ -22,7 +22,7 @@ namespace
 {
 constexpr auto JsonExtension = ".json";
 constexpr auto UnnamedModule = "_unnamed";
-constexpr unsigned TestMemoryPagesLimit = (4 * 1024 * 1024 * 1024ULL) / fizzy::PageSize;  // 4 Gb
+constexpr auto TestMemoryPagesLimit = fizzy::MaxMemoryPagesLimit;
 
 // spectest module definition:
 // https://github.com/WebAssembly/spec/blob/99564b7eaa3452c2633b623c92fc286db2823f39/interpreter/README.md#spectest-host-module

--- a/test/unittests/capi_test.cpp
+++ b/test/unittests/capi_test.cpp
@@ -884,7 +884,10 @@ TEST(capi, instantiate_custom_hard_memory_limit)
                   module, nullptr, 0, nullptr, nullptr, nullptr, 0, memory_pages_limit, &error),
         nullptr);
     EXPECT_EQ(error.code, FizzyErrorInstantiationFailed);
-    EXPECT_STREQ(error.message, "hard memory limit cannot exceed 4294967296 bytes");
+    if constexpr (sizeof(size_t) > sizeof(uint32_t))
+        EXPECT_STREQ(error.message, "hard memory limit cannot exceed 4294967296 bytes");
+    else
+        EXPECT_STREQ(error.message, "hard memory limit cannot exceed 4294901760 bytes");
 }
 
 TEST(capi, resolve_instantiate_no_imports)
@@ -1226,7 +1229,10 @@ TEST(capi, resolve_instantiate_custom_hard_memory_limit)
                   module, nullptr, 0, nullptr, nullptr, nullptr, 0, memory_pages_limit, &error),
         nullptr);
     EXPECT_EQ(error.code, FizzyErrorInstantiationFailed);
-    EXPECT_STREQ(error.message, "hard memory limit cannot exceed 4294967296 bytes");
+    if constexpr (sizeof(size_t) > sizeof(uint32_t))
+        EXPECT_STREQ(error.message, "hard memory limit cannot exceed 4294967296 bytes");
+    else
+        EXPECT_STREQ(error.message, "hard memory limit cannot exceed 4294901760 bytes");
 }
 
 TEST(capi, free_instance_null)

--- a/test/unittests/execute_test.cpp
+++ b/test/unittests/execute_test.cpp
@@ -695,10 +695,15 @@ TEST(execute, memory_grow_custom_hard_limit)
     }
 
     {
-        const auto instance_huge_hard_limit = instantiate(*module, {}, {}, {}, {}, 65536);
+        const auto instance_huge_hard_limit =
+            instantiate(*module, {}, {}, {}, {}, MaxMemoryPagesLimit);
         // For huge hard limit we test only failure cases, because allocating 4GB of memory would
         // be too slow for unit tests.
         // EXPECT_THAT(execute(*instance_huge_hard_limit, 0, {65535}), Result(1));
+        if constexpr (sizeof(size_t) == sizeof(uint32_t))
+        {
+            EXPECT_THAT(execute(*instance_huge_hard_limit, 0, {65535}), Result(-1));
+        }
         EXPECT_THAT(execute(*instance_huge_hard_limit, 0, {65536}), Result(-1));
         EXPECT_THAT(execute(*instance_huge_hard_limit, 0, {0xffffffff}), Result(-1));
     }
@@ -746,8 +751,12 @@ TEST(execute, memory_grow_custom_hard_limit)
 
     {
         bytes memory(PageSize, 0);
-        const auto instance_huge_hard_limit =
-            instantiate(*module_imported, {}, {}, {{&memory, {1, std::nullopt}}}, {}, 65536);
+        const auto instance_huge_hard_limit = instantiate(
+            *module_imported, {}, {}, {{&memory, {1, std::nullopt}}}, {}, MaxMemoryPagesLimit);
+        if constexpr (sizeof(size_t) == sizeof(uint32_t))
+        {
+            EXPECT_THAT(execute(*instance_huge_hard_limit, 0, {65535}), Result(-1));
+        }
         EXPECT_THAT(execute(*instance_huge_hard_limit, 0, {65536}), Result(-1));
         EXPECT_THAT(execute(*instance_huge_hard_limit, 0, {0xffffffff}), Result(-1));
     }

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -579,6 +579,15 @@ TEST(instantiate, imported_memory_custom_hard_limit)
     EXPECT_NO_THROW(instantiate(*module_max_limit, {}, {}, {{&memory, {3, 6}}}, {}, 8));
 }
 
+TEST(instantiate, memory_pages_to_bytes)
+{
+    EXPECT_EQ(memory_pages_to_bytes(0), 0);
+    EXPECT_EQ(memory_pages_to_bytes(1), 65536);
+    EXPECT_EQ(memory_pages_to_bytes(2), 2 * 65536);
+    EXPECT_EQ(memory_pages_to_bytes(65536), uint64_t{65536} * 65536);
+    EXPECT_EQ(memory_pages_to_bytes(MaxMemoryPagesLimit), 4 * 1024 * 1024 * 1024ULL);
+}
+
 TEST(instantiate, element_section)
 {
     /* wat2wasm


### PR DESCRIPTION
To support 32-bit systems I think it's better not to add another check for `size_t` overflow, but instead rely on existing check against hard memory limit and cap this limit to below 4 Gb (e.g. to 65535 pages) for 32-bit systems.

This way the logic is simpler in `allocate_memory` and `grow_memory` (I leave onle assertions for `size_t` overflow in these places), there's no additional check to test, the only complication is that some unit tests have different expectations for 32-bit build.
(Also `(module (memory 0 65536))` spec test won't pass on 32-bit)

Hard memory limit could be thought of as maximum possible memory size that system supports, then for 32-bit it shoud be below 4 Gb.