### PR TITLE
Fix overflows with memory of max size

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -145,17 +145,19 @@ inline uint32_t grow_memory(
     assert(memory_pages_limit <= MaxMemoryPagesLimit);
     assert(cur_pages <= memory_pages_limit);
 
-    const auto new_pages = uint64_t{cur_pages} + delta_pages;
-    if (new_pages > memory_pages_limit)
+    const auto new_pages_u64 = uint64_t{cur_pages} + delta_pages;
+    if (new_pages_u64 > memory_pages_limit)
         return static_cast<uint32_t>(-1);
+
+    const auto new_pages = static_cast<uint32_t>(new_pages_u64);
 
     try
     {
-        // new_pages <= memory_pages_limit <= MaxMemoryPagesLimit guarantees multiplication
+        // new_pages <= memory_pages_limit <= MaxMemoryPagesLimit guarantees memory_pages_to_bytes
         // will not overflow uint32_t.
-        assert(new_pages * PageSize <= std::numeric_limits<uint32_t>::max());
+        assert(memory_pages_to_bytes(new_pages) <= std::numeric_limits<uint32_t>::max());
         static_assert(sizeof(size_t) >= sizeof(uint32_t));
-        memory.resize(static_cast<size_t>(new_pages) * PageSize);
+        memory.resize(static_cast<size_t>(memory_pages_to_bytes(new_pages)));
         return static_cast<uint32_t>(cur_pages);
     }
     catch (...)

--- a/lib/fizzy/limits.hpp
+++ b/lib/fizzy/limits.hpp
@@ -4,12 +4,19 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 namespace fizzy
 {
 /// The page size as defined by the WebAssembly 1.0 specification.
 constexpr uint32_t PageSize = 65536;
+
+/// Convert memory size in pages to size in bytes.
+inline constexpr uint64_t memory_pages_to_bytes(uint32_t pages) noexcept
+{
+    return pages * PageSize;
+}
 
 /// The maximum memory page limit as defined by the specification.
 /// It is only possible to address 4 GB (32-bit) of memory.

--- a/lib/fizzy/limits.hpp
+++ b/lib/fizzy/limits.hpp
@@ -15,7 +15,7 @@ constexpr uint32_t PageSize = 65536;
 /// Convert memory size in pages to size in bytes.
 inline constexpr uint64_t memory_pages_to_bytes(uint32_t pages) noexcept
 {
-    return pages * PageSize;
+    return uint64_t{pages} * PageSize;
 }
 
 /// The maximum memory page limit as defined by the specification.

--- a/test/unittests/instantiate_test.cpp
+++ b/test/unittests/instantiate_test.cpp
@@ -579,6 +579,15 @@ TEST(instantiate, imported_memory_custom_hard_limit)
     EXPECT_NO_THROW(instantiate(*module_max_limit, {}, {}, {{&memory, {3, 6}}}, {}, 8));
 }
 
+TEST(instantiate, memory_pages_to_bytes)
+{
+    EXPECT_EQ(memory_pages_to_bytes(0), 0);
+    EXPECT_EQ(memory_pages_to_bytes(1), 65536);
+    EXPECT_EQ(memory_pages_to_bytes(2), 2 * 65536);
+    EXPECT_EQ(memory_pages_to_bytes(65536), uint64_t{65536} * 65536);
+    EXPECT_EQ(memory_pages_to_bytes(MaxMemoryPagesLimit), 4 * 1024 * 1024 * 1024ULL);
+}
+
 TEST(instantiate, element_section)
 {
     /* wat2wasm


### PR DESCRIPTION
The first part of max-memory-related fixes, fixing overflows happening on both 32-bit and 64-bit.