### PR TITLE
Indexing into a vector past its end is UB.

### DIFF
--- a/lib/fizzy/execute.cpp
+++ b/lib/fizzy/execute.cpp
@@ -593,7 +593,7 @@ ExecutionResult execute(
         case Instr::end:
         {
             // End execution if it's a final end instruction.
-            if (pc == &code.instructions[code.instructions.size()])
+            if (pc == code.instructions.data() + code.instructions.size())
                 goto end;
             break;
         }
@@ -1563,7 +1563,8 @@ ExecutionResult execute(
     }
 
 end:
-    assert(pc == &code.instructions[code.instructions.size()]);  // End of code must be reached.
+    // End of code must be reached.
+    assert(pc == code.instructions.data() + code.instructions.size());
     assert(stack.size() == instance.module->get_function_type(func_idx).outputs.size());
 
     return stack.size() != 0 ? ExecutionResult{stack.top()} : Void;


### PR DESCRIPTION
Even if all you're doing with the resulting reference is deriving a pointer to one-past-the-end.

Or it might be UB. Unclear.

At least: according to [cplusplus.com](https://www.cplusplus.com/reference/vector/vector/operator[]/) calling operator[] on a vector with an out-of-range argument is UB.

UBSan does not report anything, however. Or rather: it reports UB if you form a reference to `v[v.size()]` for an empty vector `v`, but not for a nonempty vector `v`. Go figure.

Building with `-stdlib=libc++` and `-D_LIBCPP_DEBUG=1` produces a runtime error `_LIBCPP_ASSERT '__n < size()' failed. vector[] index out of bounds` for empty or nonempty vectors.

In the C++ spec section 1.3.2 [dcl.ref] it says that "A reference shall be initialized to refer to a valid object". Furthermore table 88 defines `a[n]` as meaning `*(a.begin() + n)` on vector, and 26.3.11.4 [vector.data] says that only the range `[data(), data() + size())` is a valid range. But none of this explicitly says it's UB to initialize a reference to the one-past-the-end position. Just that it's not included in the ways that a reference "shall" be initialized.

So .. it is not clear to me by reading the spec whether it is UB merely to have called the operator (and thereby formed a reference to an element one-past-the-end) in order to then derive a pointer to that referenced element, but not dereferenced it. However, one can form the pointer in question without having to answer this question using the `data() + size()` idiom used elsewhere in this code, so that's what this PR does.