### PR TITLE
Fix bumpversion.cfg

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -23,7 +23,9 @@ values =
 [bumpversion:file:Doxyfile]
 
 [bumpversion:file:bindings/rust/Cargo.toml]
-search = version = \"{current_version}\"
+search = version = "{current_version}"
+replace = version = "{new_version}"
 
 [bumpversion:file:bindings/rust/integration-test/Cargo.toml]
-search = version = \"{current_version}\"
+search = version = "{current_version}"
+replace = version = "{new_version}"


### PR DESCRIPTION
Remove quotes for Cargo.toml fields

It seems that
1) with quotes it won't detect it
2) needs a `replace` field too as, while without quotes it detects it, it won't replace it

Inspired by https://github.com/ethereum/evmc which uses this configuration.